### PR TITLE
File response with custom headers and several performance improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volga"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 authors = ["Roman Emreis <roman.emreis@outlook.com>"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Volga
 Fast & Easy Web Framework for Rust based on [Tokio](https://tokio.rs/) runtime for fun and painless microservices crafting.
 
-[![latest](https://img.shields.io/badge/latest-0.2.3-blue)](https://crates.io/crates/volga)
+[![latest](https://img.shields.io/badge/latest-0.2.4-blue)](https://crates.io/crates/volga)
 [![latest](https://img.shields.io/badge/rustc-1.80+-964B00)](https://crates.io/crates/volga)
 [![License: MIT](https://img.shields.io/badge/License-MIT-violet.svg)](https://github.com/RomanEmreis/volga/blob/main/LICENSE)
 [![Build](https://github.com/RomanEmreis/volga/actions/workflows/rust.yml/badge.svg)](https://github.com/RomanEmreis/volga/actions/workflows/rust.yml)
+[![Release](https://github.com/RomanEmreis/volga/actions/workflows/release.yml/badge.svg)](https://github.com/RomanEmreis/volga/actions/workflows/release.yml)
 
 [Tutorial](https://romanemreis.github.io/volga-docs/) | [API Docs](https://docs.rs/volga/latest/volga/)
 
@@ -18,7 +19,7 @@ Fast & Easy Web Framework for Rust based on [Tokio](https://tokio.rs/) runtime f
 ### Dependencies
 ```toml
 [dependencies]
-volga = "0.2.3"
+volga = "0.2.4"
 tokio = "1.41.0"
 ```
 ### Asynchronous handler (Recommended):
@@ -204,10 +205,9 @@ async fn main() -> std::io::Result<()> {
     app.run().await
 }
 ```
-### Custom headers
+### Custom headers and Content Type
 ```rust
 use volga::{App, ok, AsyncEndpointsMapping};
-use std::collections::HashMap;
 
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
@@ -215,7 +215,8 @@ async fn main() -> std::io::Result<()> {
 
    app.map_get("/hello", |req| async move {
        ok!("Hello World!", [
-           ("x-api-key", "some api key")
+           ("x-api-key", "some api key"),
+           ("Content-Type", "text/plain")
        ])
    });
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -2,6 +2,7 @@
 use httparse::EMPTY_HEADER;
 use std::sync::Arc;
 use std::time::Duration;
+use bytes::BytesMut;
 use tokio_util::sync::CancellationToken;
 use tokio::{
     net::{TcpListener, TcpStream},
@@ -270,8 +271,8 @@ impl App {
     }
 
     async fn write_response(socket: &mut TcpStream, response: &HttpResponse) -> io::Result<()> {
-        let mut response_bytes = vec![];
-
+        let mut response_bytes = BytesMut::new();
+        
         // Start with the HTTP status line
         let status_line = format!(
             "HTTP/1.1 {} {}\r\n",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! volga = "0.2.3"
+//! volga = "0.2.4"
 //! tokio = "1.41.0"
 //! ```
 //! ```no_run


### PR DESCRIPTION
* Response writing logic to use `BytesMut` instead of `Vec<u8>`
* Refactored `ResponseContext<T>` to have status code and explicitly have headers.