### PR TITLE
Sync, Async mappings and Middleware features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,24 +16,39 @@ keywords = ["volga", "server", "http", "web", "framework"]
 bytes = "1.8.0"
 futures-util = "0.3.31"
 http-body-util = "0.1.2"
-hyper = { version = "1.5.0", features = ["server"], optional = true }
+hyper = { version = "1.5.1", features = ["server"], optional = true }
 hyper-util = { version = "0.1.10", features = ["server", "server-auto", "server-graceful", "service", "tokio"], optional = true }
 mime = "0.3.17"
 tokio = { version = "1.41.1", features = ["full"] }
 tokio-util = "0.7.12"
 tokio-stream = "0.1.16"
-serde_json = "1.0.132"
-serde = { version = "1.0.214", features = ["derive"] }
+serde_json = "1.0.133"
+serde = { version = "1.0.215", features = ["derive"] }
 
 [dev-dependencies]
 reqwest = { version = "0.12.9", features = ["blocking", "json", "http2"] }
 
 [features]
-default = ["http1"]
-full = ["http1", "http2"]
+default = ["http1", "async"]
+full = ["http1", "http2", "async", "sync"]
 
 http1 = ["dep:hyper", "hyper?/http1", "dep:hyper-util", "hyper-util?/http1"]
 http2 = ["dep:hyper", "hyper?/http2", "dep:hyper-util", "hyper-util?/http2"]
+
+sync = []
+async = []
+
+[[test]]
+name = "app_sync_json_payload"
+required-features = ["sync"]
+
+[[test]]
+name = "app_sync_mapping_tests"
+required-features = ["sync"]
+
+[[test]]
+name = "app_sync_request_params"
+required-features = ["sync"]
 
 [[example]]
 name = "hello_world"
@@ -42,6 +57,7 @@ path = "examples/hello_world.rs"
 [[example]]
 name = "sync_api"
 path = "examples/sync_api.rs"
+required-features = ["sync"]
 
 [[example]]
 name = "middleware"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,14 +29,22 @@ serde = { version = "1.0.215", features = ["derive"] }
 reqwest = { version = "0.12.9", features = ["blocking", "json", "http2"] }
 
 [features]
-default = ["http1", "async"]
-full = ["http1", "http2", "async", "sync"]
+# Default HTTP/1 only server with async endpoints mapping
+default = ["http1", "async", "middleware"]
+# HTTP/1 and HTTP/2 server with sync and async endpoints mappings
+full = ["http1", "http2", "async", "sync", "middleware"]
+
+# Mimimal HTTP/1
+mini = ["http1", "async"]
+# Mimimal HTTP/2
+mini2 = ["http2", "async"]
 
 http1 = ["dep:hyper", "hyper?/http1", "dep:hyper-util", "hyper-util?/http1"]
 http2 = ["dep:hyper", "hyper?/http2", "dep:hyper-util", "hyper-util?/http2"]
 
 sync = []
 async = []
+middleware = []
 
 [[test]]
 name = "app_sync_json_payload"
@@ -50,6 +58,10 @@ required-features = ["sync"]
 name = "app_sync_request_params"
 required-features = ["sync"]
 
+[[test]]
+name = "app_async_middleware_mapping_tests"
+required-features = ["middleware"]
+
 [[example]]
 name = "hello_world"
 path = "examples/hello_world.rs"
@@ -62,6 +74,7 @@ required-features = ["sync"]
 [[example]]
 name = "middleware"
 path = "examples/middleware.rs"
+required-features = ["middleware"]
 
 [[example]]
 name = "query_params"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ tokio = "1.41.1"
 ```
 ### Simple asynchronous request handler:
 ```rust
-use volga::{App, ok, AsyncEndpointsMapping, Params};
+use volga::*;
 
 #[tokio::main]
 async fn main() -> std::io::Result<()> {

--- a/src/app.rs
+++ b/src/app.rs
@@ -57,7 +57,6 @@ struct Connection {
 
 pub(crate) type BoxedHttpResultFuture = Box<dyn Future<Output = HttpResult> + Send>;
 
-#[cfg(any(feature = "http1", feature = "http2"))]
 impl App {
     /// Initializes a new instance of the `App` on specified `socket`.
     /// 

--- a/src/app.rs
+++ b/src/app.rs
@@ -12,7 +12,6 @@ use tokio::io::ErrorKind::{
     InvalidData
 };
 use crate::app::{
-    middlewares::{Middlewares, mapping::asynchronous::AsyncMiddlewareMapping},
     pipeline::{Pipeline, PipelineBuilder},
     endpoints::Endpoints,
     results::HttpResult,
@@ -20,13 +19,22 @@ use crate::app::{
     server::Server
 };
 
+#[cfg(feature = "middleware")]
+use crate::app::middlewares::{
+    Middlewares, 
+    mapping::asynchronous::AsyncMiddlewareMapping
+};
+
+#[cfg(feature = "middleware")]
 pub mod middlewares;
+
 pub mod endpoints;
 pub mod body;
 pub mod request;
 pub mod results;
 pub mod mapping;
 pub(crate) mod scope;
+#[cfg(feature = "middleware")]
 pub(crate) mod http_context;
 pub(crate) mod pipeline;
 mod server;
@@ -99,8 +107,11 @@ impl App {
 
     /// Runs the Web Server
     pub async fn run(mut self) -> io::Result<()> {
-        // Register default middleware
-        self.use_endpoints();
+        #[cfg(feature = "middleware")]
+        {
+            // Register default middleware
+            self.use_endpoints();
+        }
 
         let connection = &mut self.connection;
         let pipeline = Arc::new(self.pipeline.build());
@@ -111,9 +122,7 @@ impl App {
                     let pipeline = pipeline.clone();
                     let io = TokioIo::new(stream);
                     
-                    tokio::spawn(async move {
-                        Self::handle_connection(io, pipeline).await;
-                    });
+                    tokio::spawn(Self::handle_connection(io, pipeline));
                 }
                 _ = connection.shutdown_signal.recv() => {
                     println!("Shutting down server...");
@@ -135,6 +144,7 @@ impl App {
         };
     }
 
+    #[cfg(feature = "middleware")]
     pub(crate) fn middlewares_mut(&mut self) -> &mut Middlewares {
         self.pipeline.middlewares_mut()
     }
@@ -158,11 +168,14 @@ impl App {
             }
         });
     }
-    
+
+    #[cfg(feature = "middleware")]
     fn use_endpoints(&mut self) {
-        self.use_middleware(|ctx, _| async move {
-            ctx.execute().await
-        });
+        if self.pipeline.has_middleware_pipeline() {
+            self.use_middleware(|ctx, _| async move {
+                ctx.execute().await
+            });
+        }
     }
     
     #[inline]

--- a/src/app/endpoints/handlers.rs
+++ b/src/app/endpoints/handlers.rs
@@ -8,8 +8,10 @@ pub(crate) trait Handler {
     fn call(&self, req: HttpRequest) -> Pin<BoxedHttpResultFuture>;
 }
 
+#[cfg(feature = "async")]
 pub(crate) struct AsyncHandler<F>(pub F);
 
+#[cfg(feature = "async")]
 impl<F, Fut> Handler for AsyncHandler<F>
 where
     F: Fn(HttpRequest) -> Fut + Send + Sync + 'static,
@@ -20,8 +22,10 @@ where
     }
 }
 
+#[cfg(feature = "sync")]
 pub(crate) struct SyncHandler<F>(pub F);
 
+#[cfg(feature = "sync")]
 impl<F> Handler for SyncHandler<F>
 where
     F: Fn(HttpRequest) -> HttpResult + Send + Sync + 'static,

--- a/src/app/endpoints/mapping.rs
+++ b/src/app/endpoints/mapping.rs
@@ -1,35 +1,35 @@
-﻿use std::{sync::Arc, future::Future};
-use hyper::Method;
+﻿use hyper::Method;
+use std::{sync::Arc, future::Future};
 use crate::{HttpResult, HttpRequest};
-use crate::app::endpoints::{
-    Endpoints,
-    mapping::{asynchronous::AsyncMapping, synchronous::SyncMapping},
-    handlers::{SyncHandler, AsyncHandler}
-};
+use crate::app::endpoints::Endpoints;
 use crate::app::endpoints::handlers::RouteHandler;
 
+#[cfg(feature = "async")]
 pub mod asynchronous;
+#[cfg(feature = "sync")]
 pub mod synchronous;
 
-impl AsyncMapping for Endpoints  {
+#[cfg(feature = "async")]
+impl asynchronous::AsyncMapping for Endpoints  {
     #[inline]
     fn map<F, Fut>(&mut self, method: Method, pattern: &str, handler: F)
     where
         F: Fn(HttpRequest) -> Fut + Send + Sync + 'static,
         Fut: Future<Output = HttpResult> + Send + 'static,
     {
-        let handler = Arc::new(AsyncHandler(handler)) as RouteHandler;
+        let handler = Arc::new(crate::app::endpoints::handlers::AsyncHandler(handler)) as RouteHandler;
         self.map_route(method, pattern, handler);
     }
 }
 
-impl SyncMapping for Endpoints {
+#[cfg(feature = "sync")]
+impl synchronous::SyncMapping for Endpoints {
     #[inline]
     fn map<F>(&mut self, method: Method, pattern: &str, handler: F)
     where
         F: Fn(HttpRequest) -> HttpResult + Send + Sync + 'static,
     {
-        let handler = Arc::new(SyncHandler(handler)) as RouteHandler;
+        let handler = Arc::new(crate::app::endpoints::handlers::SyncHandler(handler)) as RouteHandler;
         self.map_route(method, pattern, handler);
     }
 }

--- a/src/app/mapping.rs
+++ b/src/app/mapping.rs
@@ -1,2 +1,4 @@
-﻿pub mod asynchronous;
+﻿#[cfg(feature = "async")]
+pub mod asynchronous;
+#[cfg(feature = "sync")]
 pub mod synchronous;

--- a/src/app/mapping/asynchronous.rs
+++ b/src/app/mapping/asynchronous.rs
@@ -4,11 +4,11 @@ use crate::{
     App, 
     HttpResult, 
     HttpRequest, 
-    HttpContext, 
-    Next,
-    AsyncMiddlewareMapping, 
     AsyncEndpointsMapping
 };
+#[cfg(feature = "middleware")]
+use crate::{HttpContext, Next, AsyncMiddlewareMapping};
+
 
 impl AsyncEndpointsMapping for App {
     fn map_get<F, Fut>(&mut self, pattern: &str, handler: F)
@@ -67,6 +67,7 @@ impl AsyncEndpointsMapping for App {
     }
 }
 
+#[cfg(feature = "middleware")]
 impl AsyncMiddlewareMapping for App {
     fn use_middleware<F, Fut>(&mut self, handler: F)
     where

--- a/src/app/middlewares.rs
+++ b/src/app/middlewares.rs
@@ -20,11 +20,13 @@ impl Middlewares {
         Self { pipeline: Vec::new() }
     }
 
-    pub(crate) fn compose(&self) -> Next {
-        // Check if the pipeline is empty or not as a safeguard.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.pipeline.is_empty()
+    }
+
+    pub(crate) fn compose(&self) -> Option<Next> {
         if self.pipeline.is_empty() {
-            // Return a default handler if there is actually nothing in the pipeline.
-            return Arc::new(|_ctx| Box::pin(async { Results::not_found() }));
+            return None;
         }
 
         // Fetching the last middleware which is the request handler to be the initial `next`.
@@ -49,7 +51,7 @@ impl Middlewares {
                 })
             });
         }
-        next
+        Some(next)
     }
 }
 

--- a/src/app/pipeline.rs
+++ b/src/app/pipeline.rs
@@ -1,20 +1,35 @@
-﻿use crate::{
-    app::{middlewares::Middlewares,endpoints::Endpoints},
-    HttpContext, 
-    HttpResult, 
+﻿use crate:: app::endpoints::Endpoints;
+#[cfg(feature = "middleware")]
+use crate::{
+    app::middlewares::Middlewares,
+    HttpResult,
+    HttpContext,
     Next
 };
 
+#[cfg(feature = "middleware")]
 pub(crate) struct PipelineBuilder {
     middlewares: Middlewares,
     endpoints: Endpoints,
 }
 
-pub(crate) struct Pipeline {
+#[cfg(not(feature = "middleware"))]
+pub(crate) struct PipelineBuilder {
     endpoints: Endpoints,
-    start: Next,
 }
 
+#[cfg(feature = "middleware")]
+pub(crate) struct Pipeline {
+    endpoints: Endpoints,
+    start: Option<Next>,
+}
+
+#[cfg(not(feature = "middleware"))]
+pub(crate) struct Pipeline {
+    endpoints: Endpoints
+}
+
+#[cfg(feature = "middleware")]
 impl PipelineBuilder {
     pub(crate) fn new() -> Self {
         Self {
@@ -31,6 +46,10 @@ impl PipelineBuilder {
         }
     }
 
+    pub(crate) fn has_middleware_pipeline(&self) -> bool {
+        self.middlewares.is_empty()
+    }
+
     pub(crate) fn middlewares_mut(&mut self) -> &mut Middlewares {
         &mut self.middlewares
     }
@@ -40,15 +59,51 @@ impl PipelineBuilder {
     }
 }
 
+#[cfg(not(feature = "middleware"))]
+impl PipelineBuilder {
+    pub(crate) fn new() -> Self {
+        Self {
+            endpoints: Endpoints::new()
+        }
+    }
+
+    pub(crate) fn build(self) -> Pipeline {
+        Pipeline {
+            endpoints: self.endpoints
+        }
+    }
+
+    pub(crate) fn endpoints_mut(&mut self) -> &mut Endpoints {
+        &mut self.endpoints
+    }
+}
+
+#[cfg(feature = "middleware")]
 impl Pipeline {
+    pub(crate) fn has_middleware_pipeline(&self) -> bool {
+        self.start.is_some()
+    }
+
     #[inline]
     pub(crate) fn endpoints(&self) -> &Endpoints {
         &self.endpoints
     }
 
-    #[inline]
     pub(crate) async fn execute(&self, ctx: HttpContext) -> HttpResult {
-        let next = self.start.clone();
-        next(ctx).await
+        let next = &self.start;
+        if let Some(next) = next {
+            let next: Next = next.clone();
+            next(ctx).await
+        } else {
+            ctx.execute().await
+        }
+    }
+}
+
+#[cfg(not(feature = "middleware"))]
+impl Pipeline {
+    #[inline]
+    pub(crate) fn endpoints(&self) -> &Endpoints {
+        &self.endpoints
     }
 }

--- a/src/app/pipeline.rs
+++ b/src/app/pipeline.rs
@@ -7,37 +7,33 @@ use crate::{
     Next
 };
 
-#[cfg(feature = "middleware")]
 pub(crate) struct PipelineBuilder {
+    #[cfg(feature = "middleware")]
     middlewares: Middlewares,
-    endpoints: Endpoints,
-}
-
-#[cfg(not(feature = "middleware"))]
-pub(crate) struct PipelineBuilder {
-    endpoints: Endpoints,
-}
-
-#[cfg(feature = "middleware")]
-pub(crate) struct Pipeline {
-    endpoints: Endpoints,
-    start: Option<Next>,
-}
-
-#[cfg(not(feature = "middleware"))]
-pub(crate) struct Pipeline {
     endpoints: Endpoints
 }
 
-#[cfg(feature = "middleware")]
+pub(crate) struct Pipeline {
+    #[cfg(feature = "middleware")]
+    start: Option<Next>,
+    endpoints: Endpoints
+}
+
 impl PipelineBuilder {
+    #[cfg(feature = "middleware")]
     pub(crate) fn new() -> Self {
         Self {
             middlewares: Middlewares::new(),
             endpoints: Endpoints::new()
         }
     }
-    
+
+    #[cfg(not(feature = "middleware"))]
+    pub(crate) fn new() -> Self {
+        Self { endpoints: Endpoints::new() }
+    }
+
+    #[cfg(feature = "middleware")]
     pub(crate) fn build(self) -> Pipeline {
         let start = self.middlewares.compose();
         Pipeline {
@@ -46,10 +42,17 @@ impl PipelineBuilder {
         }
     }
 
+    #[cfg(not(feature = "middleware"))]
+    pub(crate) fn build(self) -> Pipeline {
+        Pipeline { endpoints: self.endpoints }
+    }
+
+    #[cfg(feature = "middleware")]
     pub(crate) fn has_middleware_pipeline(&self) -> bool {
         self.middlewares.is_empty()
     }
 
+    #[cfg(feature = "middleware")]
     pub(crate) fn middlewares_mut(&mut self) -> &mut Middlewares {
         &mut self.middlewares
     }
@@ -59,36 +62,18 @@ impl PipelineBuilder {
     }
 }
 
-#[cfg(not(feature = "middleware"))]
-impl PipelineBuilder {
-    pub(crate) fn new() -> Self {
-        Self {
-            endpoints: Endpoints::new()
-        }
-    }
-
-    pub(crate) fn build(self) -> Pipeline {
-        Pipeline {
-            endpoints: self.endpoints
-        }
-    }
-
-    pub(crate) fn endpoints_mut(&mut self) -> &mut Endpoints {
-        &mut self.endpoints
-    }
-}
-
-#[cfg(feature = "middleware")]
 impl Pipeline {
-    pub(crate) fn has_middleware_pipeline(&self) -> bool {
-        self.start.is_some()
-    }
-
     #[inline]
     pub(crate) fn endpoints(&self) -> &Endpoints {
         &self.endpoints
     }
+    
+    #[cfg(feature = "middleware")]
+    pub(crate) fn has_middleware_pipeline(&self) -> bool {
+        self.start.is_some()
+    }
 
+    #[cfg(feature = "middleware")]
     pub(crate) async fn execute(&self, ctx: HttpContext) -> HttpResult {
         let next = &self.start;
         if let Some(next) = next {
@@ -97,13 +82,5 @@ impl Pipeline {
         } else {
             ctx.execute().await
         }
-    }
-}
-
-#[cfg(not(feature = "middleware"))]
-impl Pipeline {
-    #[inline]
-    pub(crate) fn endpoints(&self) -> &Endpoints {
-        &self.endpoints
     }
 }

--- a/src/app/request/file.rs
+++ b/src/app/request/file.rs
@@ -1,9 +1,10 @@
 ﻿use std::{io::Error,future::Future,path::Path};
 
+#[cfg(feature = "async")]
 pub trait File {
     /// Reads the request body as frames stream and saves into file
     /// 
-    /// > This method is only available in async context
+    /// > This method is only available with async feature
     /// 
     /// # Example
     /// ```no_run
@@ -23,4 +24,30 @@ pub trait File {
     ///}
     /// ```
     fn to_file(self, file_name: impl AsRef<Path>) -> impl Future<Output = Result<(), Error>>;
+}
+
+#[cfg(feature = "sync")]
+pub trait SyncFile {
+    /// Reads the request body as frames stream and saves into file
+    /// 
+    /// > This method is only available with sync feature
+    /// 
+    /// # Example
+    /// ```no_run
+    ///use volga::{App, SyncEndpointsMapping, Results, SyncFile};
+    ///
+    ///#[tokio::main]
+    ///async fn main() -> std::io::Result<()> {
+    ///    let mut app = App::build("127.0.0.1:7878").await?;
+    ///
+    ///    app.map_post("/test", |req| move {
+    ///        req.to_file("file.dat")?;
+    ///
+    ///        Results::text("Pass!")
+    ///    });
+    ///
+    ///    app.run().await
+    ///}
+    /// ```
+    fn to_file(self, file_name: impl AsRef<Path>) -> Result<(), Error>;
 }

--- a/src/app/request/payload.rs
+++ b/src/app/request/payload.rs
@@ -1,10 +1,11 @@
 ﻿use std::future::Future;
 use serde::de::DeserializeOwned;
 
+#[cfg(feature = "async")]
 pub trait Payload {
     /// Returns a request body deserialized to type of `T`
     /// 
-    /// > This method is only available in async context
+    /// > This method is only available with async feature
     /// 
     /// # Example
     /// ```no_run
@@ -33,4 +34,39 @@ pub trait Payload {
     ///}
     /// ```
     fn payload<T: DeserializeOwned>(self) -> impl Future<Output = Result<T, std::io::Error>>;
+}
+
+#[cfg(feature = "sync")]
+pub trait SyncPayload {
+    /// Returns a request body deserialized to type of `T`
+    /// 
+    /// > This method is only available with sync feature
+    /// 
+    /// # Example
+    /// ```no_run
+    ///use volga::{App, SyncEndpointsMapping, Results, SyncPayload};
+    ///use serde::Deserialize;
+    /// 
+    ///#[derive(Deserialize)]
+    ///struct User {
+    ///    name: String,
+    ///    age: i32
+    ///}
+    ///
+    ///#[tokio::main]
+    ///async fn main() -> std::io::Result<()> {
+    ///    let mut app = App::build("127.0.0.1:7878").await?;
+    ///
+    ///    // POST /test
+    ///    // { name: "John", age: 35 }
+    ///    app.map_post("/test", |req| move {
+    ///        let params: User = req.payload()?;
+    ///
+    ///        Results::text("Pass!")
+    ///    });
+    ///
+    ///    app.run().await
+    ///}
+    /// ```
+    fn payload<T: DeserializeOwned>(self) -> Result<T, std::io::Error>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,12 @@ pub mod app;
 pub mod test_utils;
 
 pub use crate::app::{App, http_context::HttpContext};
-pub use crate::app::endpoints::mapping::{asynchronous::AsyncEndpointsMapping, synchronous::SyncEndpointsMapping};
+
+#[cfg(feature = "async")]
+pub use crate::app::endpoints::mapping::asynchronous::AsyncEndpointsMapping;
+#[cfg(feature = "sync")]
+pub use crate::app::endpoints::mapping::synchronous::SyncEndpointsMapping;
+
 pub use crate::app::middlewares::{Next, mapping::asynchronous::AsyncMiddlewareMapping};
 pub use crate::app::results::{HttpResponse, HttpResult, HttpHeaders, Results, ResponseContext};
 pub use crate::app::request::{HttpRequest, RequestParams, payload::Payload, params::Params, cancel::Cancel, file::File};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,16 +30,31 @@ pub mod app;
 #[cfg(test)]
 pub mod test_utils;
 
-pub use crate::app::{App, http_context::HttpContext};
+pub use crate::app::App;
+pub use crate::app::results::{HttpResponse, HttpResult, HttpHeaders, Results, ResponseContext};
+pub use crate::app::request::{HttpRequest, RequestParams, params::Params, cancel::Cancel};
+
+#[cfg(feature = "middleware")]
+pub use crate::app::http_context::HttpContext;
+
+#[cfg(feature = "middleware")]
+pub use crate::app::middlewares::{Next, mapping::asynchronous::AsyncMiddlewareMapping};
 
 #[cfg(feature = "async")]
 pub use crate::app::endpoints::mapping::asynchronous::AsyncEndpointsMapping;
 #[cfg(feature = "sync")]
 pub use crate::app::endpoints::mapping::synchronous::SyncEndpointsMapping;
 
-pub use crate::app::middlewares::{Next, mapping::asynchronous::AsyncMiddlewareMapping};
-pub use crate::app::results::{HttpResponse, HttpResult, HttpHeaders, Results, ResponseContext};
-pub use crate::app::request::{HttpRequest, RequestParams, payload::Payload, params::Params, cancel::Cancel, file::File};
+#[cfg(feature = "async")]
+pub use crate::app::request::payload::Payload;
+#[cfg(feature = "sync")]
+pub use crate::app::request::payload::SyncPayload;
+
+#[cfg(feature = "async")]
+pub use crate::app::request::file::File;
+#[cfg(feature = "sync")]
+pub use crate::app::request::file::SyncFile;
+
 pub use crate::app::body::BoxBody;
 
 // Exposing shortcut for CancellationToken for convenience

--- a/tests/app_async_middleware_mapping_tests.rs
+++ b/tests/app_async_middleware_mapping_tests.rs
@@ -1,4 +1,4 @@
-﻿use volga::{App, AsyncMiddlewareMapping, Results, SyncEndpointsMapping};
+﻿use volga::{App, AsyncEndpointsMapping, AsyncMiddlewareMapping, Results};
 
 #[tokio::test]
 async fn it_adds_middleware_request() {
@@ -12,7 +12,7 @@ async fn it_adds_middleware_request() {
             Results::text("Pass!")
         });
 
-        app.map_get("/test", |_req| {
+        app.map_get("/test", |_req| async {
             Results::text("Unreachable!")
         });
 

--- a/tests/app_sync_json_payload.rs
+++ b/tests/app_sync_json_payload.rs
@@ -1,5 +1,6 @@
 ﻿use serde::{Deserialize, Serialize};
-use volga::{App, Results, SyncEndpointsMapping, ok};
+use volga::{App, Results, ok};
+use volga::SyncEndpointsMapping;
 
 #[derive(Deserialize, Serialize)]
 struct User {

--- a/tests/app_sync_json_payload.rs
+++ b/tests/app_sync_json_payload.rs
@@ -1,5 +1,5 @@
 ﻿use serde::{Deserialize, Serialize};
-use volga::{App, Results, ok};
+use volga::{App, Results, ok, SyncPayload};
 use volga::SyncEndpointsMapping;
 
 #[derive(Deserialize, Serialize)]
@@ -8,30 +8,30 @@ struct User {
     age: u32
 }
 
-//#[tokio::test]
-//async fn it_reads_json_payload() {
-//    tokio::spawn(async {
-//        let mut app = App::build("127.0.0.1:7891").await?;
-//
-//        app.map_post("/test", |req| {
-//            let user: User = tokio::runtime::Runtime::new().unwrap().block_on(req.payload())?;
-//            let response = format!("My name is: {}, I'm {} years old", user.name, user.age);
-//
-//            Results::text(&response)
-//        });
-//
-//        app.run().await
-//    });
-//
-//    let response = tokio::spawn(async {
-//        let user = User { name: String::from("John"), age: 35 };
-//        let client = reqwest::Client::new();
-//        client.post("http://127.0.0.1:7891/test").json(&user).send().await
-//    }).await.unwrap().unwrap();
-//
-//    assert!(response.status().is_success());
-//    assert_eq!(response.text().await.unwrap(), "My name is: John, I'm 35 years old");
-//}
+#[tokio::test]
+async fn it_reads_json_payload() {
+    tokio::spawn(async {
+        let mut app = App::build("127.0.0.1:7891").await?;
+
+        app.map_post("/test", |req| {
+            let user: User = req.payload()?;
+            let response = format!("My name is: {}, I'm {} years old", user.name, user.age);
+
+            Results::text(&response)
+        });
+
+        app.run().await
+    });
+
+    let response = tokio::spawn(async {
+        let user = User { name: String::from("John"), age: 35 };
+        let client = reqwest::Client::new();
+        client.post("http://127.0.0.1:7891/test").json(&user).send().await
+    }).await.unwrap().unwrap();
+
+    assert!(response.status().is_success());
+    assert_eq!(response.text().await.unwrap(), "My name is: John, I'm 35 years old");
+}
 
 #[tokio::test]
 async fn it_writes_json_response() {

--- a/tests/app_sync_mapping_tests.rs
+++ b/tests/app_sync_mapping_tests.rs
@@ -1,4 +1,5 @@
-﻿use volga::{App, Results, SyncEndpointsMapping};
+﻿use volga::{App, Results};
+use volga::SyncEndpointsMapping;
 
 #[tokio::test]
 async fn it_maps_to_get_request() {

--- a/tests/app_sync_request_params.rs
+++ b/tests/app_sync_request_params.rs
@@ -1,4 +1,5 @@
-﻿use volga::{App, Results, SyncEndpointsMapping, Params};
+﻿use volga::{App, Results, Params};
+use volga::SyncEndpointsMapping;
 
 #[tokio::test]
 async fn it_reads_route_params() {


### PR DESCRIPTION
Introduced new features:
* async
* sync
* middleware

The default and full are now include:
```toml
# Default HTTP/1 only server with async endpoints mapping
default = ["http1", "async", "middleware"]
# HTTP/1 and HTTP/2 server with sync and async endpoints mappings
full = ["http1", "http2", "async", "sync", "middleware"]
```

Introduced new minimal API features:
* mini
* mini2

```toml
# Mimimal HTTP/1
mini = ["http1", "async"]
# Mimimal HTTP/2
mini2 = ["http2", "async"]
```