### PR TITLE
Route and Query params improvements

### DIFF
--- a/examples/json.rs
+++ b/examples/json.rs
@@ -22,9 +22,9 @@ async fn main() -> std::io::Result<()> {
     // Return strongly typed JSON
     // GET /user/John
     app.map_get("/user/{name}", |req| async move {
-        let name = req.param("name")?; 
+        let name: String = req.param("name")?; 
         let user: User = User {
-            name: name.into(),
+            name,
             age: 35
         };
 

--- a/examples/query_params.rs
+++ b/examples/query_params.rs
@@ -12,14 +12,14 @@ async fn main() -> std::io::Result<()> {
     // GET /hello?name=John
     app.map_get("/hello", |req| async move {
         let params = req.params().unwrap();
-        let name = params.get("name").unwrap(); // "11"
+        let name = params.get("name").unwrap(); // "John"
 
         ok!("Hello {}!", name)
     });
 
     // GET /hello-again?name=John
     app.map_get("/hello-again", |req| async move {
-        let name = req.param("name")?; // "11"
+        let name = req.param_str("name")?; // "John"
 
         ok!("Hello {}!", name)
     });

--- a/examples/route_params.rs
+++ b/examples/route_params.rs
@@ -12,14 +12,14 @@ async fn main() -> std::io::Result<()> {
     // GET /hello/John
     app.map_get("/hello/{name}", |req| async move {
         let params = req.params().unwrap();
-        let name = params.get("name").unwrap(); // "11"
+        let name = params.get("name").unwrap(); // "John"
 
         ok!("Hello {}!", name)
     });
 
     // GET /hello-again/John
     app.map_get("/hello-again/{name}", |req| async move {
-        let name = req.param("name")?; // "11"
+        let name = req.param_str("name")?; // "John"
 
         ok!("Hello {}!", name)
     });

--- a/src/app/endpoints/route.rs
+++ b/src/app/endpoints/route.rs
@@ -103,3 +103,45 @@ impl Route {
         segment.starts_with("{") && segment.ends_with("}")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use crate::{ok, HttpRequest};
+    use crate::app::endpoints::handlers::AsyncHandler;
+    use crate::app::endpoints::route::Route;
+
+    #[test]
+    fn it_inserts_and_finds_route() {
+        let handler = |_req: HttpRequest| async { ok!() };
+        let handler = Arc::new(AsyncHandler(handler));
+        
+        let path = ["test".into()];
+        
+        let mut route = Route::Static(HashMap::new());
+        route.insert(&path, handler);
+        
+        let route_params = route.find(&path);
+        
+        assert!(route_params.is_some());
+    }
+
+    #[test]
+    fn it_inserts_and_finds_route_with_params() {
+        let handler = |_req: HttpRequest| async { ok!() };
+        let handler = Arc::new(AsyncHandler(handler));
+
+        let path = ["test".into(), "{value}".into()];
+
+        let mut route = Route::Static(HashMap::new());
+        route.insert(&path, handler);
+
+        let path = ["test".into(), "some".into()];
+        
+        let route_params = route.find(&path).unwrap();
+        let val = route_params.params.get("value").unwrap();
+        
+        assert_eq!(val, "some");
+    }
+}

--- a/src/app/request/cancel.rs
+++ b/src/app/request/cancel.rs
@@ -5,24 +5,22 @@ pub trait Cancel {
     /// 
     ///# Example
     /// ```no_run
-    ///use volga::{App, AsyncEndpointsMapping, Results, Cancel};
-    ///
-    ///#[tokio::main]
-    ///async fn main() -> std::io::Result<()> {
-    ///    let mut app = App::build("127.0.0.1:7878").await?;
-    ///
-    ///    app.map_get("/test", |req| async move {
-    ///        let token = req.cancellation_token();
-    ///
-    ///         if token.is_cancelled() { 
-    ///             Results::text("Cancelled!")
-    ///         } else {
-    ///             Results::text("Pass!")
-    ///         } 
-    ///    });
-    ///
-    ///    app.run().await
-    ///}
+    /// use volga::{App, AsyncEndpointsMapping, ok, Cancel};
+    /// 
+    /// # #[tokio::main]
+    /// # async fn main() -> std::io::Result<()> {
+    /// # let mut app = App::build("127.0.0.1:7878").await?;
+    /// app.map_get("/test", |req| async move {
+    ///     let token = req.cancellation_token();
+    /// 
+    ///     if token.is_cancelled() { 
+    ///         ok!("Cancelled!")
+    ///     } else {
+    ///         ok!("Pass!")
+    ///     } 
+    /// });
+    /// # app.run().await
+    /// # }
     /// ```
     fn cancellation_token(&self) -> CancellationToken;
 }

--- a/src/app/request/file.rs
+++ b/src/app/request/file.rs
@@ -8,20 +8,18 @@ pub trait File {
     /// 
     /// # Example
     /// ```no_run
-    ///use volga::{App, AsyncEndpointsMapping, Results, File};
+    /// use volga::{App, AsyncEndpointsMapping, ok, File};
+    /// 
+    /// # #[tokio::main]
+    /// # async fn main() -> std::io::Result<()> {
+    /// # let mut app = App::build("127.0.0.1:7878").await?;
+    /// app.map_post("/test", |req| async move {
+    ///     req.to_file("file.dat").await?;
     ///
-    ///#[tokio::main]
-    ///async fn main() -> std::io::Result<()> {
-    ///    let mut app = App::build("127.0.0.1:7878").await?;
-    ///
-    ///    app.map_post("/test", |req| async move {
-    ///        req.to_file("file.dat").await?;
-    ///
-    ///        Results::text("Pass!")
-    ///    });
-    ///
-    ///    app.run().await
-    ///}
+    ///     ok!("Pass!")
+    /// });
+    /// # app.run().await
+    /// # }
     /// ```
     fn to_file(self, file_name: impl AsRef<Path>) -> impl Future<Output = Result<(), Error>>;
 }
@@ -34,20 +32,18 @@ pub trait SyncFile {
     /// 
     /// # Example
     /// ```no_run
-    ///use volga::{App, SyncEndpointsMapping, Results, SyncFile};
-    ///
-    ///#[tokio::main]
-    ///async fn main() -> std::io::Result<()> {
-    ///    let mut app = App::build("127.0.0.1:7878").await?;
-    ///
-    ///    app.map_post("/test", |req| move {
-    ///        req.to_file("file.dat")?;
-    ///
-    ///        Results::text("Pass!")
-    ///    });
-    ///
-    ///    app.run().await
-    ///}
+    /// use volga::{App, SyncEndpointsMapping, ok, SyncFile};
+    /// 
+    /// # #[tokio::main]
+    /// # async fn main() -> std::io::Result<()> {
+    /// # let mut app = App::build("127.0.0.1:7878").await?;
+    /// app.map_post("/test", |req| move {
+    ///     req.to_file("file.dat")?;
+    /// 
+    ///     ok!("Pass!")
+    /// });
+    /// # app.run().await
+    /// # }
     /// ```
     fn to_file(self, file_name: impl AsRef<Path>) -> Result<(), Error>;
 }

--- a/src/app/request/params.rs
+++ b/src/app/request/params.rs
@@ -1,4 +1,5 @@
 ﻿use std::io;
+use std::str::FromStr;
 use crate::RequestParams;
 
 pub trait Params {
@@ -6,44 +7,61 @@ pub trait Params {
     /// 
     /// # Example
     /// ```no_run
-    ///use volga::{App, AsyncEndpointsMapping, Results, Params};
+    /// use volga::{App, AsyncEndpointsMapping, ok, Params};
     ///
-    ///#[tokio::main]
-    ///async fn main() -> std::io::Result<()> {
-    ///    let mut app = App::build("127.0.0.1:7878").await?;
+    /// # #[tokio::main]
+    /// # async fn main() -> std::io::Result<()> {
+    /// # let mut app = App::build("127.0.0.1:7878").await?;
+    /// // GET /test?id=11
+    /// app.map_get("/test", |req| async move {
+    ///     let params = req.params().unwrap();
+    ///     let id = params.get("id").unwrap(); // "11"
     ///
-    ///    // GET /test?id=11
-    ///    app.map_get("/test", |req| async move {
-    ///        let params = req.params().unwrap();
-    ///        let id = params.get("id").unwrap(); // "11"
-    ///
-    ///        Results::text("Pass!")
-    ///    });
-    ///
-    ///    app.run().await
-    ///}
+    ///     ok!("ID is: {}", id)
+    /// });
+    /// # app.run().await
+    /// # }
     /// ```
     fn params(&self) -> Option<&RequestParams>;
 
     /// Returns a query or route param of HTTP request by `name`
-    /// 
+    /// and parses it to `T`.
+    ///
     /// # Example
     /// ```no_run
-    ///use volga::{App, AsyncEndpointsMapping, Results, Params};
+    /// use volga::{App, AsyncEndpointsMapping, ok, Params};
     ///
-    ///#[tokio::main]
-    ///async fn main() -> std::io::Result<()> {
-    ///    let mut app = App::build("127.0.0.1:7878").await?;
+    /// # #[tokio::main]
+    /// # async fn main() -> std::io::Result<()> {
+    /// # let mut app = App::build("127.0.0.1:7878").await?;
+    /// // GET /test?id=11
+    /// app.map_get("/test", |req| async move {
+    ///     let id: i32 = req.param("id")?; // 11
     ///
-    ///    // GET /test?id=11
-    ///    app.map_get("/test", |req| async move {
-    ///        let id = req.param("id")?; // "11"
-    ///
-    ///        Results::text("Pass!")
-    ///    });
-    ///
-    ///    app.run().await
-    ///}
+    ///     ok!("ID is: {}", id)
+    /// });
+    /// # app.run().await
+    /// # }
     /// ```
-    fn param(&self, name: &str) -> Result<&String, io::Error>;
+    fn param<T: FromStr>(&self, name: &str) -> Result<T, io::Error>;
+
+    /// Returns a query or route param of HTTP request by `name`
+    ///
+    /// # Example
+    /// ```no_run
+    /// use volga::{App, AsyncEndpointsMapping, ok, Params};
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() -> std::io::Result<()> {
+    /// # let mut app = App::build("127.0.0.1:7878").await?;
+    /// // GET /test?id=11
+    /// app.map_get("/test", |req| async move {
+    ///     let id = req.param_str("id")?; // "11"
+    ///
+    ///     ok!("ID is: {}", id)
+    /// });
+    /// # app.run().await
+    /// # }
+    /// ```
+    fn param_str(&self, name: &str) -> Result<&str, io::Error>;
 }

--- a/src/app/request/payload.rs
+++ b/src/app/request/payload.rs
@@ -9,29 +9,27 @@ pub trait Payload {
     /// 
     /// # Example
     /// ```no_run
-    ///use volga::{App, AsyncEndpointsMapping, Results, Payload};
-    ///use serde::Deserialize;
+    /// use volga::{App, AsyncEndpointsMapping, ok, Payload};
+    /// use serde::Deserialize;
+    ///  
+    /// #[derive(Deserialize)]
+    /// struct User {
+    ///     name: String,
+    ///     age: i32
+    /// }
     /// 
-    ///#[derive(Deserialize)]
-    ///struct User {
-    ///    name: String,
-    ///    age: i32
-    ///}
-    ///
-    ///#[tokio::main]
-    ///async fn main() -> std::io::Result<()> {
-    ///    let mut app = App::build("127.0.0.1:7878").await?;
-    ///
-    ///    // POST /test
-    ///    // { name: "John", age: 35 }
-    ///    app.map_post("/test", |req| async move {
-    ///        let params: User = req.payload().await?;
-    ///
-    ///        Results::text("Pass!")
-    ///    });
-    ///
-    ///    app.run().await
-    ///}
+    /// # #[tokio::main]
+    /// # async fn main() -> std::io::Result<()> {
+    /// # let mut app = App::build("127.0.0.1:7878").await?;
+    /// // POST /test
+    /// // { name: "John", age: 35 }
+    /// app.map_post("/test", |req| async move {
+    ///     let params: User = req.payload().await?;
+    /// 
+    ///     ok!("Pass!")
+    /// });
+    /// # app.run().await
+    /// # }
     /// ```
     fn payload<T: DeserializeOwned>(self) -> impl Future<Output = Result<T, std::io::Error>>;
 }
@@ -44,29 +42,27 @@ pub trait SyncPayload {
     /// 
     /// # Example
     /// ```no_run
-    ///use volga::{App, SyncEndpointsMapping, Results, SyncPayload};
-    ///use serde::Deserialize;
+    /// use volga::{App, SyncEndpointsMapping, ok, SyncPayload};
+    /// use serde::Deserialize;
+    ///  
+    /// #[derive(Deserialize)]
+    /// struct User {
+    ///     name: String,
+    ///     age: i32
+    /// }
     /// 
-    ///#[derive(Deserialize)]
-    ///struct User {
-    ///    name: String,
-    ///    age: i32
-    ///}
-    ///
-    ///#[tokio::main]
-    ///async fn main() -> std::io::Result<()> {
-    ///    let mut app = App::build("127.0.0.1:7878").await?;
-    ///
-    ///    // POST /test
-    ///    // { name: "John", age: 35 }
-    ///    app.map_post("/test", |req| move {
-    ///        let params: User = req.payload()?;
-    ///
-    ///        Results::text("Pass!")
-    ///    });
-    ///
-    ///    app.run().await
-    ///}
+    /// # #[tokio::main]
+    /// # async fn main() -> std::io::Result<()> {
+    /// # let mut app = App::build("127.0.0.1:7878").await?;
+    /// // POST /test
+    /// // { name: "John", age: 35 }
+    /// app.map_post("/test", |req| move {
+    ///     let params: User = req.payload()?;
+    /// 
+    ///     ok!("Pass!")
+    /// });
+    /// # app.run().await
+    /// # }
     /// ```
     fn payload<T: DeserializeOwned>(self) -> Result<T, std::io::Error>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,22 +16,25 @@
 //! tokio = "1.41.1"
 //! ```
 //! ```no_run
-//!use volga::*;
+//! use volga::*;
 //! 
-//!#[tokio::main]
-//!async fn main() -> std::io::Result<()> {
-//!    // Start the server
-//!    let mut app = App::build("127.0.0.1:7878").await?;
+//! #[tokio::main]
+//! async fn main() -> std::io::Result<()> {
+//!     // Start the server
+//!     let mut app = App::build("127.0.0.1:7878").await?;
 //! 
-//!    // Example of asynchronous request handler
-//!    app.map_get("/hello/{name}", |req| async move {
-//!         let name = req.param("name")?;
-//!         ok!("Hello {}!", name)
-//!    });
+//!     // Example of asynchronous request handler
+//!     app.map_get("/hello/{name}", |req| async move {
+//!          let name = req.param_str("name")?;
+//!          ok!("Hello {}!", name)
+//!     });
 //!     
-//!    app.run().await
+//!     app.run().await
 //! }
 //! ```
+
+#![forbid(unsafe_code)]
+#![deny(unreachable_pub)]
 
 pub mod app;
 

--- a/tests/app_async_request_params.rs
+++ b/tests/app_async_request_params.rs
@@ -6,8 +6,8 @@ async fn it_reads_route_params() {
         let mut app = App::build("127.0.0.1:7887").await?;
 
         app.map_get("/test/{name}/{age}", |req| async move {
-            let name = req.param("name")?;
-            let age = req.param("age")?;
+            let name = req.param_str("name")?;
+            let age: u32 = req.param("age")?;
             
             let response = format!("My name is: {}, I'm {} years old", name, age);
 
@@ -36,8 +36,8 @@ async fn it_reads_query_params() {
         let mut app = App::build("127.0.0.1:7888").await?;
 
         app.map_get("/test", |req| async move {
-            let name = req.param("name")?;
-            let age = req.param("age")?;
+            let name = req.param_str("name")?;
+            let age: u32 = req.param("age")?;
 
             let response = format!("My name is: {}, I'm {} years old", name, age);
 

--- a/tests/app_sync_request_params.rs
+++ b/tests/app_sync_request_params.rs
@@ -7,8 +7,8 @@ async fn it_reads_route_params() {
         let mut app = App::build("127.0.0.1:7889").await?;
 
         app.map_get("/test/{name}/{age}", |req| {
-            let name = req.param("name")?;
-            let age = req.param("age")?;
+            let name: String = req.param("name")?;
+            let age: u32 = req.param("age")?;
 
             let response = format!("My name is: {}, I'm {} years old", name, age);
 
@@ -37,8 +37,8 @@ async fn it_reads_query_params() {
         let mut app = App::build("127.0.0.1:7890").await?;
 
         app.map_get("/test", |req| {
-            let name = req.param("name")?;
-            let age = req.param("age")?;
+            let name = req.param_str("name")?;
+            let age: u32 = req.param("age")?;
 
             let response = format!("My name is: {}, I'm {} years old", name, age);
 


### PR DESCRIPTION
* `param()` is now a generic method that parses a query/route param into the desired type. If the `&str` is needed the `param_str()` method can be used.