### PR TITLE
header extractors and http response improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ async fn main() -> std::io::Result<()> {
 
     // Example of asynchronous request handler
     app.map_get("/hello/{name}", |name: String| async move {
-        ok!("Hello {}!", name)
+        ok!("Hello {name}!")
     });
     
     app.run().await

--- a/examples/headers.rs
+++ b/examples/headers.rs
@@ -3,9 +3,14 @@
     Router,
     ok,
     headers,
-    Headers,
     Results,
     ResponseContext
+};
+use volga::headers::{
+    Header, 
+    Headers, 
+    Accept,
+    ContentLength
 };
 
 #[tokio::main]
@@ -13,11 +18,21 @@ async fn main() -> std::io::Result<()> {
     let mut app = App::new();
 
     // Read request headers
-    app.map_get("/hi", |headers: Headers|async move { 
+    app.map_get("/api-key", |headers: Headers| async move { 
         let request_headers = headers.into_inner();
-        let api_key = request_headers.get("x-api-key").unwrap();
-        
-        ok!(api_key.to_str().unwrap())
+        let api_key = request_headers.get("x-api-key")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        ok!(api_key)
+    });
+    
+    app.map_get("/accept", |accept: Header<Accept>| async move { 
+        ok!("{accept}")
+    });
+
+    app.map_get("/content-length", |content_length: Header<ContentLength>| async move {
+        ok!(content_length.to_string())
     });
     
     // Respond with headers

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -24,8 +24,7 @@ async fn main() -> std::io::Result<()> {
             name,
             age: 35
         };
-
-        ok!(&user) // { name: "John", age: 35 }
+        ok!(user) // { name: "John", age: 35 }
     });
     
     // Read JSON body

--- a/examples/middleware.rs
+++ b/examples/middleware.rs
@@ -1,9 +1,4 @@
-﻿use volga::{
-    App, 
-    Router, 
-    Middleware,
-    ok, 
-};
+﻿use volga::{App, Router, Middleware, ok, status};
 
 #[tokio::main]
 #[allow(clippy::all)]
@@ -11,30 +6,13 @@ async fn main() -> std::io::Result<()> {
     // Start the server
     let mut app = App::new();
 
-    // Middleware 1
+    // Example of middleware
     app.use_middleware(|ctx, next| async move {
-        // Something can be done before the middleware 2
-        println!("Before Middleware 2");
-
-        let response = next(ctx).await;
-
-        // Something can be done after the next middleware 2 is completed
-        println!("After Middleware 2");
-
-        response
-    });
-
-    // Middleware 2
-    app.use_middleware(|ctx, next| async move {
-        // Something can be done before the next request handler
-        println!("Before request handler");
-
-        let response = next(ctx).await;
-
-        // Something can be done after the request handler is completed
-        println!("After request handler");
-
-        response
+        if ctx.request.headers().contains_key("user-agent") {
+            next(ctx).await
+        } else { 
+            status!(404)
+        }
     });
 
     // Request handler

--- a/src/app/endpoints/args/headers.rs
+++ b/src/app/endpoints/args/headers.rs
@@ -19,6 +19,8 @@ use crate::app::endpoints::args::{
     Payload
 };
 
+pub use extract::*;
+
 pub mod extract;
 
 #[derive(Debug)]

--- a/src/app/results.rs
+++ b/src/app/results.rs
@@ -1,18 +1,26 @@
-﻿use crate::app::body::{BoxBody, HttpBody};
-use std::collections::HashMap;
-use tokio::fs::File;
-use tokio::io;
+﻿use std::collections::HashMap;
+
+use crate::app::body::{BoxBody, HttpBody};
+
+use tokio::{io, fs::File};
+
 use bytes::Bytes;
+
 use serde::Serialize;
-use hyper::{Response, StatusCode};
-use hyper::header::{HeaderName, HeaderValue};
-use hyper::http::response::Builder;
+
+use hyper::{
+    header::{HeaderName, HeaderValue},
+    http::response::Builder,
+    Response,
+    StatusCode
+};
 use hyper::header::{ 
     CONTENT_DISPOSITION,
     TRANSFER_ENCODING,
     CONTENT_TYPE,
     SERVER
 };
+
 use mime::{
     APPLICATION_OCTET_STREAM,
     APPLICATION_JSON,
@@ -72,11 +80,11 @@ impl Results {
 
     /// Produces an `OK 200` response with the `JSON` body.
     #[inline]
-    pub fn json<T>(content: &T) -> HttpResult
-    where T:
-        ?Sized + Serialize
+    pub fn json<T>(content: T) -> HttpResult
+    where 
+        T: Serialize
     {
-        let content = serde_json::to_vec(content)?;
+        let content = serde_json::to_vec(&content)?;
         Self::status(
             StatusCode::OK,
             APPLICATION_JSON.as_ref(),
@@ -85,11 +93,11 @@ impl Results {
 
     /// Produces a response with `StatusCode` the `JSON` body.
     #[inline]
-    pub fn json_with_status<T>(status: StatusCode, content: &T) -> HttpResult
-    where T:
-        ?Sized + Serialize
+    pub fn json_with_status<T>(status: StatusCode, content: T) -> HttpResult
+    where 
+        T: Serialize
     {
-        let content = serde_json::to_vec(content)?;
+        let content = serde_json::to_vec(&content)?;
         Self::status(
             status,
             APPLICATION_JSON.as_ref(),
@@ -332,7 +340,7 @@ mod tests {
     #[tokio::test]
     async fn it_creates_json_response() {
         let payload = TestPayload { name: "test".into() };
-        let mut response = Results::json(&payload).unwrap();
+        let mut response = Results::json(payload).unwrap();
 
         let body = &response.body_mut().collect().await.unwrap().to_bytes();
         
@@ -344,7 +352,7 @@ mod tests {
     #[tokio::test]
     async fn it_creates_json_response_with_custom_status() {
         let payload = TestPayload { name: "test".into() };
-        let mut response = Results::json_with_status(StatusCode::NOT_FOUND, &payload).unwrap();
+        let mut response = Results::json_with_status(StatusCode::NOT_FOUND, payload).unwrap();
 
         let body = &response.body_mut().collect().await.unwrap().to_bytes();
         

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //! 
 //!     // Example of asynchronous request handler
 //!     app.map_get("/hello/{name}", |name: String| async move {
-//!          ok!("Hello {}!", name)
+//!          ok!("Hello {name}!")
 //!     });
 //!     
 //!     app.run().await
@@ -43,18 +43,17 @@ pub mod test_utils;
 pub use crate::app::{App, router::Router, body::{BoxBody, HttpBody}};
 pub use crate::app::results::{HttpResponse, HttpResult, HttpHeaders, Results, ResponseContext};
 pub use crate::app::request::HttpRequest;
+pub use crate::app::endpoints::args::{
+    path::Path,
+    json::Json,
+    file::File,
+    query::Query,
+    headers::{self},
+    cancellation_token::CancellationToken,
+};
 
 #[cfg(feature = "middleware")]
 pub use crate::app::http_context::HttpContext;
 
 #[cfg(feature = "middleware")]
 pub use crate::app::middlewares::{Next, Middleware};
-
-pub use crate::app::endpoints::args::{
-    path::Path,
-    query::Query,
-    headers::{self, Header, Headers},
-    json::Json,
-    file::File,
-    cancellation_token::CancellationToken,
-};

--- a/tests/headers.rs
+++ b/tests/headers.rs
@@ -1,7 +1,5 @@
-﻿use volga::{
-    App, Router, Headers, Header,
-    headers::extract::ContentType, ok
-};
+﻿use volga::{App, Router, ok};
+use volga::headers::{Header, Headers, ContentType};
 
 #[tokio::test]
 async fn it_reads_headers() {

--- a/tests/json_payload.rs
+++ b/tests/json_payload.rs
@@ -69,8 +69,7 @@ async fn it_writes_json_using_macro_response() {
 
         app.map_get("/test", || async move {
             let user = User { name: String::from("John"), age: 35 };
-
-            ok!(&user)
+            ok!(user)
         });
 
         app.run().await


### PR DESCRIPTION
* Now to use specific headers we can add `use volga::headers::{Header, Accept}` instead of `use volga::{Headers, headers::extract::Accept}`
* `Results::json()` method and macros `ok!()` and `status!()` now take ownership over `struct` objects that are passed to them