### PR TITLE
Added the `custom_headers` macro.

### DIFF
--- a/examples/headers.rs
+++ b/examples/headers.rs
@@ -1,34 +1,14 @@
-﻿use volga::{
-    App,
-    Router,
-    ok,
-    headers,
-    Results,
-    ResponseContext
-};
+﻿use volga::{App, Router, Results, ResponseContext, headers, ok};
 use volga::headers::{
     Header, 
     Headers, 
     Accept,
-    FromHeaders,
-    HeaderMap,
-    HeaderValue
+    custom_headers
 };
 
 // The `x-api-key` header
-struct ApiKey;
-
-// FromHeaders trait implementation for ApiKey header
-impl FromHeaders for ApiKey {
-    // Reading the header from request's HeaderMap 
-    fn from_headers(headers: &HeaderMap) -> Option<&HeaderValue> {
-        headers.get(Self::header_type())
-    }
-
-    // String representation of the header
-    fn header_type() -> &'static str {
-        "x-api-key"
-    }
+custom_headers! {
+    (ApiKey, "x-api-key")
 }
 
 #[tokio::main]

--- a/src/app/endpoints/args/headers.rs
+++ b/src/app/endpoints/args/headers.rs
@@ -16,8 +16,10 @@ use crate::{
 };
 
 pub use extract::*;
+pub use macros::custom_headers;
 
 pub mod extract;
+mod macros;
 
 /// Wraps the [`HeaderMap`] extracted from request
 ///

--- a/src/app/endpoints/args/headers/macros.rs
+++ b/src/app/endpoints/args/headers/macros.rs
@@ -1,0 +1,65 @@
+﻿/// Declares a custom HTTP headers
+///
+/// # Example
+/// ```rust
+/// use volga::headers::custom_headers;
+///
+/// // The `x-api-key` header
+/// custom_headers! {
+///     (ApiKey, "x-api-key")
+/// }
+/// ```
+#[macro_export]
+macro_rules! custom_headers {
+    ($(($struct_name:ident, $header_name:literal)),* $(,)?) => {
+        $(
+            pub struct $struct_name;
+
+            impl $crate::app::endpoints::args::headers::FromHeaders for $struct_name {
+                #[inline]
+                fn from_headers(headers: &hyper::HeaderMap) -> Option<&hyper::header::HeaderValue> {
+                    headers.get($header_name)
+                }
+                
+                #[inline]
+                fn header_type() -> &'static str {
+                    $header_name
+                }
+            }
+        )*
+    };
+}
+
+pub use custom_headers;
+
+#[cfg(test)]
+#[allow(unreachable_pub)]
+mod test {
+    use hyper::header::HeaderValue;
+    use hyper::HeaderMap;
+    use crate::headers::{Header, custom_headers};
+
+    custom_headers! {
+        (ApiKey, "x-api-key")
+    }
+    
+    #[test]
+    fn it_creates_custom_headers() {
+        let api_key = HeaderValue::from_str("some-api-key").unwrap();
+        let api_key_header = Header::<ApiKey>::new(&api_key);
+        
+        assert_eq!(api_key_header.value, "some-api-key")
+    }
+
+    #[test]
+    fn it_gets_custom_headers_from_map() {
+        let api_key = HeaderValue::from_str("some-api-key").unwrap();
+        
+        let mut map = HeaderMap::new();
+        map.insert("x-api-key", api_key);
+        
+        let api_key_header = Header::<ApiKey>::from_headers_map(&map).unwrap();
+
+        assert_eq!(*api_key_header, "some-api-key")
+    }
+}


### PR DESCRIPTION
Added the `custom_headers` macro to simplify declaration of custom HTTP headers.
# Exapmple of usage:
```rust
use volga::HttpResult;
use volga::headers::{Header, custom_headers};

custom_headers! {
   (ApiKey, "x-api-key"),
   (CorrelationId, "x-correlation-id"),
   (SpanId, "x-span-id"),
}

async fn request_handler(
   api_key: Header<ApiKey>, 
   corr_id: Header<CorrelationId>, 
   span_id: Header<SPanId>
) -> HttpResult {
   // do something ...
}
```