### PR TITLE
 `HEAD` and `OPTIONS` HTTP methods support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volga"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 rust-version = "1.80.0"
 authors = ["Roman Emreis <roman.emreis@outlook.com>"]
@@ -14,7 +14,7 @@ categories = ["web-programming::http-server"]
 keywords = ["volga", "server", "http", "web", "framework"]
 
 [dependencies]
-bytes = "1.8.0"
+bytes = "1.9.0"
 futures-util = { version = "0.3.31", default-features = false, features = ["alloc"] }
 http-body-util = "0.1.2"
 hyper = { version = "1.5.1", features = ["server"], optional = true }
@@ -22,8 +22,8 @@ hyper-util = { version = "0.1.10", features = ["server", "server-auto", "server-
 mime = "0.3.17"
 pin-project-lite = "0.2.15"
 tokio = { version = "1.42.0", features = ["full"] }
-tokio-util = "0.7.12"
-serde = "1.0.215"
+tokio-util = "0.7.13"
+serde = "1.0.216"
 serde_json = "1.0.133"
 serde_urlencoded = "0.7.1"
 
@@ -75,6 +75,19 @@ path = "examples/json.rs"
 [[example]]
 name = "headers"
 path = "examples/headers.rs"
+
+[[example]]
+name = "head_request"
+path = "examples/head_request.rs"
+
+[[example]]
+name = "options_request"
+path = "examples/options_request.rs"
+
+[[example]]
+name = "custom_request_headers"
+path = "examples/custom_request_headers.rs"
+required-features = ["middleware"]
 
 [[example]]
 name = "file_download"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Volga
 Fast, Easy, and very flexible Web Framework for Rust based on [Tokio](https://tokio.rs/) runtime and [hyper](https://hyper.rs/) for fun and painless microservices crafting.
 
-[![latest](https://img.shields.io/badge/latest-0.4.1-blue)](https://crates.io/crates/volga)
+[![latest](https://img.shields.io/badge/latest-0.4.2-blue)](https://crates.io/crates/volga)
 [![latest](https://img.shields.io/badge/rustc-1.80+-964B00)](https://crates.io/crates/volga)
 [![License: MIT](https://img.shields.io/badge/License-MIT-violet.svg)](https://github.com/RomanEmreis/volga/blob/main/LICENSE)
 [![Build](https://github.com/RomanEmreis/volga/actions/workflows/rust.yml/badge.svg)](https://github.com/RomanEmreis/volga/actions/workflows/rust.yml)
@@ -19,8 +19,8 @@ Fast, Easy, and very flexible Web Framework for Rust based on [Tokio](https://to
 ### Dependencies
 ```toml
 [dependencies]
-volga = "0.4.1"
-tokio = "1.41.1"
+volga = "0.4.2"
+tokio = { version = "1", features = ["full"] }
 ```
 ### Simple request handler
 ```rust

--- a/examples/custom_request_headers.rs
+++ b/examples/custom_request_headers.rs
@@ -1,0 +1,34 @@
+﻿use volga::{App, Router, ok, Middleware};
+use volga::headers::{
+    Header,
+    custom_headers
+};
+
+const CORRELATION_ID_HEADER: &str = "x-correlation-id";
+
+// Custom header
+custom_headers! {
+    (CorrelationId, CORRELATION_ID_HEADER)
+}
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let mut app = App::new();
+
+    // Setting up the "x-correlation-id" header if it's not provided
+    app.use_middleware(|mut ctx, next| async move { 
+        if ctx.extract::<Header<CorrelationId>>().is_err() {
+            let correlation_id = Header::<CorrelationId>::from_static("123-321-456");
+            ctx.insert_header(correlation_id);
+        } 
+        next(ctx).await
+    });
+    
+    // Reading custom header and insert it to response headers
+    app.map_get("/hello", |correlation_id: Header<CorrelationId>| async move {
+        let (header, value) = correlation_id.into_string_parts()?;
+        ok!([(header, value)])
+    });
+
+    app.run().await
+}

--- a/examples/head_request.rs
+++ b/examples/head_request.rs
@@ -1,0 +1,20 @@
+﻿use volga::{App, Router, ok};
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let mut app = App::new();
+
+    // HEAD /hello
+    app.map_head("/hello", || async {
+        ok!([
+            ("x-custom-head", "some-value")
+        ])
+    });
+
+    // GET /hello
+    app.map_get("/hello", || async {
+        ok!("Hello World!")
+    });
+
+    app.run().await
+}

--- a/examples/headers.rs
+++ b/examples/headers.rs
@@ -2,14 +2,8 @@
 use volga::headers::{
     Header, 
     Headers, 
-    Accept,
-    custom_headers
+    Accept
 };
-
-// The `x-api-key` header
-custom_headers! {
-    (ApiKey, "x-api-key")
-}
 
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
@@ -27,11 +21,6 @@ async fn main() -> std::io::Result<()> {
     // Reading header with Header<T>
     app.map_get("/accept", |accept: Header<Accept>| async move { 
         ok!("{accept}")
-    });
-
-    // Reading custom header
-    app.map_get("/api-key", |api_key: Header<ApiKey>| async move {
-        ok!("Received key: {}", api_key)
     });
     
     // Respond with headers

--- a/examples/options_request.rs
+++ b/examples/options_request.rs
@@ -1,0 +1,20 @@
+﻿use volga::{App, Router, ok};
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let mut app = App::new();
+
+    // OPTIONS /hello
+    app.map_options("/hello", || async {
+        ok!([
+            ("Allow", "GET, OPTIONS")
+        ])
+    });
+
+    // GET /hello
+    app.map_get("/hello", || async {
+        ok!("Hello World!")
+    });
+
+    app.run().await
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -126,7 +126,6 @@ impl App {
         Self::subscribe_for_ctrl_c_signal(&shutdown_sender);
         
         let pipeline = Arc::new(self.pipeline.build());
-        
         loop {
             tokio::select! {
                 Ok((stream, _)) = tcp_listener.accept() => {
@@ -141,7 +140,6 @@ impl App {
                 }
             }
         }
-
         Ok(())
     }
 

--- a/src/app/endpoints/args/headers/macros.rs
+++ b/src/app/endpoints/args/headers/macros.rs
@@ -11,7 +11,7 @@
 /// ```
 #[macro_export]
 macro_rules! custom_headers {
-    ($(($struct_name:ident, $header_name:literal)),* $(,)?) => {
+    ($(($struct_name:ident, $header_name:expr)),* $(,)?) => {
         $(
             pub struct $struct_name;
 

--- a/src/app/endpoints/args/json.rs
+++ b/src/app/endpoints/args/json.rs
@@ -82,6 +82,7 @@ pin_project! {
 impl<T: DeserializeOwned + Send> Future for ExtractJsonPayloadFut<T> {
     type Output = Result<Json<T>, Error>;
 
+    #[inline]
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
         let result = ready!(this.fut.poll(cx))

--- a/src/app/endpoints/route.rs
+++ b/src/app/endpoints/route.rs
@@ -109,7 +109,6 @@ impl Route {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::sync::Arc;
     
     use crate::ok;
     use crate::app::endpoints::handlers::Func;
@@ -118,7 +117,7 @@ mod tests {
     #[test]
     fn it_inserts_and_finds_route() {
         let handler = || async { ok!() };
-        let handler = Arc::new(Func::new(handler));
+        let handler = Func::new(handler);
         
         let path = ["test".into()];
         
@@ -133,7 +132,7 @@ mod tests {
     #[test]
     fn it_inserts_and_finds_route_with_params() {
         let handler = || async { ok!() };
-        let handler = Arc::new(Func::new(handler));
+        let handler = Func::new(handler);
 
         let path = ["test".into(), "{value}".into()];
 

--- a/src/app/http_context.rs
+++ b/src/app/http_context.rs
@@ -1,9 +1,12 @@
 ﻿use std::io::Error;
 
-use crate::app::endpoints::handlers::RouteHandler;
-use crate::app::endpoints::args::FromRequestRef;
+use crate::app::endpoints::{
+    handlers::RouteHandler,
+    args::FromRequestRef
+};
 
 use crate::{
+    headers::{Header, FromHeaders},
     HttpRequest, 
     HttpResult
 };
@@ -35,6 +38,15 @@ impl HttpContext {
     /// ```
     pub fn extract<T: FromRequestRef>(&self) -> Result<T, Error> {
         T::from_request(&self.request)
+    }
+    
+    /// Inserts the [`Header<T>`] to HTTP request headers
+    #[inline]
+    pub fn insert_header<T: FromHeaders>(&mut self, header: Header<T>) {
+        let (name, value) = header.into_parts();
+        self.request
+            .headers_mut()
+            .insert(name, value);
     }
     
     pub(super) fn new(request: HttpRequest, handler: RouteHandler) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,8 @@
 //! ## Example
 //! ```toml
 //! [dependencies]
-//! volga = "0.4.1"
-//! tokio = "1.41.1"
+//! volga = "0.4.2"
+//! tokio = { version = "1", features = ["full"] }
 //! ```
 //! ```no_run
 //! use volga::*;
@@ -57,3 +57,6 @@ pub use crate::app::http_context::HttpContext;
 
 #[cfg(feature = "middleware")]
 pub use crate::app::middlewares::{Next, Middleware};
+
+// Re-exporting HTTP status codes from hyper/http
+pub use hyper::StatusCode;


### PR DESCRIPTION
* Added `HEAD` and `OPTIONS` HTTP methods support
* Custom header improvements
* Re-exported `http::StatusCode`