### PR TITLE
HTTP `TRACE` method support and injecting the whole `HttpRequest` into request handler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,3 +100,11 @@ path = "examples/file_upload.rs"
 [[example]]
 name = "long_running_task"
 path = "examples/long_running_task.rs"
+
+[[example]]
+name = "http_request_handler"
+path = "examples/http_request_handler.rs"
+
+[[example]]
+name = "trace_request"
+path = "examples/trace_request.rs"

--- a/examples/http_request_handler.rs
+++ b/examples/http_request_handler.rs
@@ -1,0 +1,13 @@
+﻿use volga::{App, Router, HttpRequest, ok};
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let mut app = App::new();
+
+    // Example of request handler that takes the whole request
+    app.map_get("/hello", |req: HttpRequest| async move {
+        ok!("Request: {} {}", req.method(), req.uri())
+    });
+
+    app.run().await
+}

--- a/examples/trace_request.rs
+++ b/examples/trace_request.rs
@@ -1,0 +1,16 @@
+﻿use volga::{App, Router, HttpRequest, stream};
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let mut app = App::new();
+
+    // Example of TRACE handler
+    app.map_trace("/", |req: HttpRequest| async move {
+        let boxed_body = req.into_boxed_body();
+        stream!(boxed_body, [
+            ("content-type", "message/http")
+        ])
+    });
+
+    app.run().await
+}

--- a/src/app/endpoints/args/request.rs
+++ b/src/app/endpoints/args/request.rs
@@ -1,0 +1,28 @@
+﻿//! Extractors for the whole HTTP request
+
+use crate::HttpRequest;
+use std::io::Error;
+use futures_util::future::{ok, Ready};
+
+use crate::app::endpoints::args::{
+    FromPayload,
+    Payload,
+    Source
+};
+
+impl FromPayload for HttpRequest {
+    type Future = Ready<Result<Self, Error>>;
+
+    #[inline]
+    fn from_payload(payload: Payload) -> Self::Future {
+        if let Payload::Full(req) = payload {
+            ok(HttpRequest(req))
+        } else {
+            unreachable!()
+        }
+    }
+
+    fn source() -> Source {
+        Source::Full
+    }
+}

--- a/src/app/request.rs
+++ b/src/app/request.rs
@@ -1,4 +1,88 @@
-﻿use hyper::Request;
-use hyper::body::Incoming;
+﻿use http_body_util::BodyExt;
 
-pub type HttpRequest = Request<Incoming>;
+use hyper::{
+    Request, 
+    http::request::Parts,
+    body::Incoming
+};
+
+use std::{
+    ops::{Deref, DerefMut},
+    io::Error
+};
+use std::io::ErrorKind;
+use crate::{app::endpoints::args::FromRequestRef, headers::{FromHeaders, Header}, BoxBody};
+
+/// Wraps the incoming [`Request`] to enrich its functionality
+pub struct HttpRequest(pub Request<Incoming>);
+
+impl Deref for HttpRequest {
+    type Target = Request<Incoming>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for HttpRequest {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl HttpRequest {
+    /// Unwraps the inner request
+    #[inline]
+    pub fn into_inner(self) -> Request<Incoming> {
+        self.0
+    }
+
+    /// Consumes the request and returns just the body
+    #[inline]
+    pub fn into_body(self) -> Incoming {
+        self.0.into_body()
+    }
+
+    /// Consumes the request and returns the body as boxed trait object
+    #[inline]
+    pub fn into_boxed_body(self) -> BoxBody {
+        self.0.into_body()
+            .map_err(|e| Error::new(ErrorKind::InvalidInput, e))
+            .boxed()
+    }
+
+    /// Consumes the request and returns request head and body
+    pub fn into_parts(self) -> (Parts, Incoming) {
+        self.0.into_parts()
+    }
+    
+    /// Extracts a payload from request parts
+    ///
+    /// # Example
+    /// ```no_run
+    /// use volga::{HttpContext, HttpRequest, Query};
+    /// use serde::Deserialize;
+    ///
+    /// #[derive(Deserialize)]
+    /// struct Params {
+    ///     id: u32,
+    ///     key: String
+    /// }
+    ///
+    /// # fn docs(req: HttpRequest) -> std::io::Result<()> {
+    /// let params: Query<Params> = req.extract()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn extract<T: FromRequestRef>(&self) -> Result<T, Error> {
+        T::from_request(self)
+    }
+
+    /// Inserts the [`Header<T>`] to HTTP request headers
+    #[inline]
+    pub fn insert_header<T: FromHeaders>(&mut self, header: Header<T>) {
+        let (name, value) = header.into_parts();
+        self.headers_mut().insert(name, value);
+    }
+}

--- a/src/app/router.rs
+++ b/src/app/router.rs
@@ -171,6 +171,27 @@ pub trait Router {
     where
         F: GenericHandler<Args, Output = HttpResult>,
         Args: FromRequest + Send + Sync + 'static;
+
+    /// Adds a request handler that matches HTTP TRACE requests for the specified pattern.
+    /// 
+    /// # Examples
+    /// ```no_run
+    /// use volga::{App, Router, ok};
+    ///
+    ///# #[tokio::main]
+    ///# async fn main() -> std::io::Result<()> {
+    /// let mut app = App::new();
+    /// 
+    /// app.map_trace("/", |id: i32| async move {
+    ///    ok!([("content-type", "message/http")])
+    /// });
+    ///# app.run().await
+    ///# }
+    /// ```
+    fn map_trace<F, Args>(&mut self, pattern: &str, handler: F)
+    where
+        F: GenericHandler<Args, Output = HttpResult>,
+        Args: FromRequest + Send + Sync + 'static;
 }
 
 impl Router for App {
@@ -180,8 +201,7 @@ impl Router for App {
         Args: FromRequest + Send + Sync + 'static
     {
         let handler = Func::new(handler);
-        self.endpoints_mut()
-            .map_route(Method::GET, pattern, handler);
+        self.endpoints_mut().map_route(Method::GET, pattern, handler);
     }
 
     fn map_post<F, Args>(&mut self, pattern: &str, handler: F)
@@ -190,8 +210,7 @@ impl Router for App {
         Args: FromRequest + Send + Sync + 'static,
     {
         let handler = Func::new(handler);
-        self.endpoints_mut()
-            .map_route(Method::POST, pattern, handler);
+        self.endpoints_mut().map_route(Method::POST, pattern, handler);
     }
 
     fn map_put<F, Args>(&mut self, pattern: &str, handler: F)
@@ -200,8 +219,7 @@ impl Router for App {
         Args: FromRequest + Send + Sync + 'static,
     {
         let handler = Func::new(handler);
-        self.endpoints_mut()
-            .map_route(Method::PUT, pattern, handler);
+        self.endpoints_mut().map_route(Method::PUT, pattern, handler);
     }
 
     fn map_patch<F, Args>(&mut self, pattern: &str, handler: F)
@@ -210,8 +228,7 @@ impl Router for App {
         Args: FromRequest + Send + Sync + 'static,
     {
         let handler = Func::new(handler);
-        self.endpoints_mut()
-            .map_route(Method::PATCH, pattern, handler);
+        self.endpoints_mut().map_route(Method::PATCH, pattern, handler);
     }
 
     fn map_delete<F, Args>(&mut self, pattern: &str, handler: F)
@@ -220,8 +237,7 @@ impl Router for App {
         Args: FromRequest + Send + Sync + 'static,
     {
         let handler = Func::new(handler);
-        self.endpoints_mut()
-            .map_route(Method::DELETE, pattern, handler);
+        self.endpoints_mut().map_route(Method::DELETE, pattern, handler);
     }
 
     fn map_head<F, Args>(&mut self, pattern: &str, handler: F)
@@ -230,8 +246,7 @@ impl Router for App {
         Args: FromRequest + Send + Sync + 'static,
     {
         let handler = Func::new(handler);
-        self.endpoints_mut()
-            .map_route(Method::HEAD, pattern, handler);
+        self.endpoints_mut().map_route(Method::HEAD, pattern, handler);
     }
 
     fn map_options<F, Args>(&mut self, pattern: &str, handler: F)
@@ -240,7 +255,15 @@ impl Router for App {
         Args: FromRequest + Send + Sync + 'static,
     {
         let handler = Func::new(handler);
-        self.endpoints_mut()
-            .map_route(Method::OPTIONS, pattern, handler);
+        self.endpoints_mut().map_route(Method::OPTIONS, pattern, handler);
+    }
+
+    fn map_trace<F, Args>(&mut self, pattern: &str, handler: F)
+    where
+        F: GenericHandler<Args, Output = HttpResult>,
+        Args: FromRequest + Send + Sync + 'static,
+    {
+        let handler = Func::new(handler);
+        self.endpoints_mut().map_route(Method::TRACE, pattern, handler);
     }
 }


### PR DESCRIPTION
* Added `stream!` macro to respond with bytes streams
* Added back ability to inject the whole `HttpRequest` into request handler method