### PR TITLE
Route pattern matching improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volga"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 rust-version = "1.80.0"
 authors = ["Roman Emreis <roman.emreis@outlook.com>"]
@@ -19,6 +19,7 @@ futures-util = { version = "0.3.31", default-features = false, features = ["allo
 http-body-util = "0.1.2"
 hyper = { version = "1.5.1", features = ["server"], optional = true }
 hyper-util = { version = "0.1.10", features = ["server", "server-auto", "server-graceful", "service", "tokio"], optional = true }
+itoa = "1.0.14"
 mime = "0.3.17"
 pin-project-lite = "0.2.15"
 tokio = { version = "1.42.0", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Volga
 Fast, Easy, and very flexible Web Framework for Rust based on [Tokio](https://tokio.rs/) runtime and [hyper](https://hyper.rs/) for fun and painless microservices crafting.
 
-[![latest](https://img.shields.io/badge/latest-0.4.2-blue)](https://crates.io/crates/volga)
+[![latest](https://img.shields.io/badge/latest-0.4.3-blue)](https://crates.io/crates/volga)
 [![latest](https://img.shields.io/badge/rustc-1.80+-964B00)](https://crates.io/crates/volga)
 [![License: MIT](https://img.shields.io/badge/License-MIT-violet.svg)](https://github.com/RomanEmreis/volga/blob/main/LICENSE)
 [![Build](https://github.com/RomanEmreis/volga/actions/workflows/rust.yml/badge.svg)](https://github.com/RomanEmreis/volga/actions/workflows/rust.yml)
@@ -19,7 +19,7 @@ Fast, Easy, and very flexible Web Framework for Rust based on [Tokio](https://to
 ### Dependencies
 ```toml
 [dependencies]
-volga = "0.4.2"
+volga = "0.4.3"
 tokio = { version = "1", features = ["full"] }
 ```
 ### Simple request handler

--- a/src/app/endpoints.rs
+++ b/src/app/endpoints.rs
@@ -1,20 +1,30 @@
 ﻿use std::collections::HashMap;
+use hyper::{Method, Uri};
 
-use hyper::Method;
-
-use crate::HttpRequest;
 use crate::app::endpoints::{
     route::Route,
-    handlers::RouteHandler
+    handlers::RouteHandler,
+    route::PathArguments
 };
 
 pub(crate) mod handlers;
 pub(super) mod route;
 pub mod args;
 
+const ALLOW_METHOD_SEPARATOR : &str = ",";
+const PATH_SEPARATOR : char = '/';
+
 /// Describes a mapping between HTTP Verbs, routes and request handlers
 pub(crate) struct Endpoints {
-    routes: HashMap<Method, Route>
+    //routes: HashMap<Method, Route>
+    routes: Route
+}
+
+/// Specifies statuses that could be returned after route matching
+pub(crate) enum RouteOption {
+    RouteNotFound,
+    MethodNotFound(String),
+    Ok(EndpointContext)
 }
 
 /// Describes a context of the executing route
@@ -27,44 +37,149 @@ impl EndpointContext {
     pub(crate) fn into_parts(self) -> (RouteHandler, Vec<(String, String)>) {
         (self.handler, self.params)
     }
+    
+    fn new(handler: RouteHandler, params: PathArguments) -> Self {
+        Self { handler, params }
+    }
 }
 
 impl Endpoints {
     pub(super) fn new() -> Self {
-        Self { routes: HashMap::new() }
+        Self { routes: Route::Static(HashMap::new()) }
     }
 
     /// Gets a context of the executing route by its `HttpRequest`
     #[inline]
-    pub(crate) async fn get_endpoint(&self, request: &HttpRequest) -> Option<EndpointContext> {
-        let uri = request.uri();
-
+    pub(crate) fn get_endpoint(&self, method: &Method, uri: &Uri) -> RouteOption {
         let path_segments = Self::split_path(uri.path());
-        self.routes
-            .get(request.method())
-            .and_then(|router| router.find(&path_segments))
-            .and_then(|route_params| {
-                match route_params.route {
-                    Route::Handler(handler) => Some(EndpointContext { handler: handler.clone(), params: route_params.params }),
-                    _ => None
-                }
-            })
+        self.routes.find(&path_segments)
+            .map_or_else(
+                || RouteOption::RouteNotFound, 
+                |route_params| {
+                    match route_params.route {
+                        Route::Handler(handlers) => {
+                            handlers.get(method)
+                                .map_or_else(
+                                    || {
+                                        let allowed: Vec<&str> = handlers
+                                            .keys()
+                                            .map(|k| k.as_str())
+                                            .collect();
+                                        RouteOption::MethodNotFound(allowed.join(ALLOW_METHOD_SEPARATOR))
+                                    }, 
+                                    |handler| RouteOption::Ok(EndpointContext::new(handler.clone(), route_params.params)))
+                        },
+                        _ => RouteOption::RouteNotFound
+                    }  
+                })
     }
 
     /// Maps the request handler to the current HTTP Verb and route pattern
     #[inline]
     pub(super) fn map_route(&mut self, method: Method, pattern: &str, handler: RouteHandler) {
         let path_segments = Self::split_path(pattern);
-        self.routes.entry(method)
-            .or_insert_with(|| Route::Static(HashMap::new()))
-            .insert(&path_segments, handler);
+        self.routes.insert(&path_segments, method, handler);
+    }
+    
+    #[inline]
+    pub(super) fn contains(&mut self, method: &Method, pattern: &str) -> bool {
+        let path_segments = Self::split_path(pattern);
+        self.routes.find(&path_segments).and_then(|params| match &params.route {
+            Route::Handler(handlers) => Some(handlers.contains_key(method)),
+            _ => None,
+        }).unwrap_or(false)
     }
 
     #[inline]
     fn split_path(path: &str) -> Vec<String> {
-        path.trim_matches('/')
-            .split('/')
+        path.trim_matches(PATH_SEPARATOR)
+            .split(PATH_SEPARATOR)
             .map(|s| s.to_string())
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use hyper::{Method, Request};
+    use crate::app::endpoints::{Endpoints, RouteOption};
+    use crate::app::endpoints::handlers::Func;
+    use crate::Results;
+
+    #[test]
+    fn it_maps_and_gets_endpoint() {
+        let mut endpoints = Endpoints::new();
+        
+        let handler = Func::new(|| async { Results::ok() });
+        
+        endpoints.map_route(Method::POST, "path/to/handler", handler);
+        
+        let request = Request::post("https://example.com/path/to/handler").body(()).unwrap();
+        let post_handler = endpoints.get_endpoint(request.method(), request.uri());
+
+        match post_handler {
+            RouteOption::Ok(_) => (),
+            _ => panic!("`post_handler` must be is the `Ok` state")
+        }
+    }
+
+    #[test]
+    fn it_returns_route_not_found() {
+        let mut endpoints = Endpoints::new();
+
+        let handler = Func::new(|| async { Results::ok() });
+
+        endpoints.map_route(Method::POST, "path/to/handler", handler);
+
+        let request = Request::post("https://example.com/path/to/another-handler").body(()).unwrap();
+        let post_handler = endpoints.get_endpoint(request.method(), request.uri());
+
+        match post_handler {
+            RouteOption::RouteNotFound => (),
+            _ => panic!("`post_handler` must be is the `RouteNotFound` state")
+        } 
+    }
+
+    #[test]
+    fn it_returns_method_not_found() {
+        let mut endpoints = Endpoints::new();
+
+        let handler = Func::new(|| async { Results::ok() });
+
+        endpoints.map_route(Method::GET, "path/to/handler", handler);
+
+        let request = Request::post("https://example.com/path/to/handler").body(()).unwrap();
+        let post_handler = endpoints.get_endpoint(request.method(), request.uri());
+
+        match post_handler {
+            RouteOption::MethodNotFound(allow) => assert_eq!(allow, "GET"),
+            _ => panic!("`post_handler` must be is the `MethodNotFound` state")
+        }
+    }
+    
+    #[test]
+    fn is_has_route_after_map() {
+        let mut endpoints = Endpoints::new();
+
+        let handler = Func::new(|| async { Results::ok() });
+
+        endpoints.map_route(Method::GET, "path/to/handler", handler);
+
+        let has_route = endpoints.contains(&Method::GET, "path/to/handler");
+        
+        assert!(has_route);
+    }
+
+    #[test]
+    fn is_doesnt_have_route_after_map_a_different_one() {
+        let mut endpoints = Endpoints::new();
+
+        let handler = Func::new(|| async { Results::ok() });
+
+        endpoints.map_route(Method::GET, "path/to/handler", handler);
+
+        let has_route = endpoints.contains(&Method::PUT, "path/to/handler");
+
+        assert!(!has_route);
     }
 }

--- a/src/app/router.rs
+++ b/src/app/router.rs
@@ -201,7 +201,13 @@ impl Router for App {
         Args: FromRequest + Send + Sync + 'static
     {
         let handler = Func::new(handler);
-        self.endpoints_mut().map_route(Method::GET, pattern, handler);
+        let endpoints = self.endpoints_mut();
+        endpoints.map_route(Method::GET, pattern, handler.clone());
+        
+        let head = Method::HEAD;
+        if !endpoints.contains(&head, pattern) { 
+            endpoints.map_route(head, pattern, handler.clone());
+        } 
     }
 
     fn map_post<F, Args>(&mut self, pattern: &str, handler: F)

--- a/src/app/scope.rs
+++ b/src/app/scope.rs
@@ -8,21 +8,17 @@ use std::{
 };
 
 use hyper::{
+    header::{HeaderValue, CONTENT_LENGTH, ALLOW}, 
+    body::{Body, SizeHint, Incoming}, 
     Request, 
-    body::Incoming, 
     service::Service, 
-    Method
+    Method, 
+    HeaderMap
 };
 
-use crate::{
-    app::Pipeline, 
-    HttpResponse, 
-    HttpResult, 
-    HttpRequest, 
-    HttpBody,
-    status
-};
+use crate::{app::Pipeline, HttpResponse, HttpResult, HttpRequest, HttpBody, status};
 
+use crate::app::endpoints::RouteOption;
 #[cfg(feature = "middleware")]
 use crate::HttpContext;
 
@@ -62,42 +58,63 @@ impl Scope {
         cancellation_token: CancellationToken
     ) -> io::Result<HttpResponse>
     {
-        if let Some(endpoint_context) = pipeline.endpoints().get_endpoint(&request).await {
-            let (handler, params) = endpoint_context.into_parts();
-                        
-            let extensions = request.extensions_mut();
-            extensions.insert(cancellation_token);
-            extensions.insert(params);
-            
-            let request_method = request.method().clone();
-            
-            let response: HttpResult;
-            #[cfg(feature = "middleware")]
-            {
-                response = if pipeline.has_middleware_pipeline() {
-                    let ctx = HttpContext::new(request, handler);
-                    pipeline.execute(ctx).await
-                } else {
-                    handler.call(request).await
-                };
-            }
-            #[cfg(not(feature = "middleware"))]
-            {
-                response = handler.call(request).await;
-            }
+        match pipeline.endpoints().get_endpoint(request.method(), request.uri()) {
+            RouteOption::RouteNotFound => status!(404),
+            RouteOption::MethodNotFound(allowed) => status!(405, [
+                (ALLOW, allowed)
+            ]),
+            RouteOption::Ok(endpoint_context) => {
+                let (handler, params) = endpoint_context.into_parts();
 
-            match response {
-                Ok(mut response) => {
-                    if request_method == Method::HEAD {
-                        *response.body_mut() = HttpBody::empty();
-                    }
-                    Ok(response)
-                },
-                Err(error) if error.kind() == InvalidInput => status!(400, error.to_string()),
-                Err(error) => status!(500, error.to_string())
+                let extensions = request.extensions_mut();
+                extensions.insert(cancellation_token);
+                extensions.insert(params);
+
+                let request_method = request.method().clone();
+
+                let response: HttpResult;
+                #[cfg(feature = "middleware")]
+                {
+                    response = if pipeline.has_middleware_pipeline() {
+                        let ctx = HttpContext::new(request, handler);
+                        pipeline.execute(ctx).await
+                    } else {
+                        handler.call(request).await
+                    };
+                }
+                #[cfg(not(feature = "middleware"))]
+                {
+                    response = handler.call(request).await;
+                }
+
+                match response {
+                    Ok(mut response) => {
+                        if request_method == Method::HEAD {
+                            Self::keep_content_length(response.size_hint(), response.headers_mut());
+                            *response.body_mut() = HttpBody::empty();
+                        }
+                        Ok(response)
+                    },
+                    Err(error) if error.kind() == InvalidInput => status!(400, error.to_string()),
+                    Err(error) => status!(500, error.to_string())
+                }
             }
-        } else {
-            status!(404)
         }
+    }
+    
+    fn keep_content_length(size_hint: SizeHint, headers: &mut HeaderMap) {
+        if headers.contains_key(CONTENT_LENGTH) { 
+            return;
+        }
+        
+        if let Some(size) = size_hint.exact() { 
+            let content_length = if size == 0 { 
+                HeaderValue::from_static("0")
+            } else {
+                let mut buffer = itoa::Buffer::new();
+                HeaderValue::from_str(buffer.format(size)).unwrap()
+            };
+            headers.insert(CONTENT_LENGTH, content_length);
+        } 
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! ## Example
 //! ```toml
 //! [dependencies]
-//! volga = "0.4.2"
+//! volga = "0.4.3"
 //! tokio = { version = "1", features = ["full"] }
 //! ```
 //! ```no_run
@@ -73,6 +73,7 @@ pub use hyper::{
         CONTENT_DISPOSITION,
         TRANSFER_ENCODING,
         CONTENT_TYPE,
+        CONTENT_LENGTH,
         SERVER
     }
 };


### PR DESCRIPTION
* A default `HEAD` endpoint is now being mapped along with `GET` and can be overridden
* The HTTP 405 is now correctly returned if a method is not present for this route pattern
* An appropriate `Allow` header is now delivered on 405