### PR TITLE
Reconsidered default features and usage of `Router` and `Middleware` traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ uuid = { version = "1.11.0", features = ["v4"] }
 
 [features]
 # Default HTTP/1 only server
-default = ["http1", "middleware", "di"]
+default = ["http1"]
 # HTTP/1 and HTTP/2 server
 full = ["http1", "http2", "middleware", "di"]
 

--- a/examples/custom_request_headers.rs
+++ b/examples/custom_request_headers.rs
@@ -1,7 +1,7 @@
-﻿use volga::{App, Router, ok, Middleware};
-use volga::headers::{
-    Header,
-    custom_headers
+﻿use volga::{
+    headers::{Header, custom_headers},
+    App, 
+    ok
 };
 
 const CORRELATION_ID_HEADER: &str = "x-correlation-id";

--- a/examples/dependency_injection.rs
+++ b/examples/dependency_injection.rs
@@ -1,7 +1,5 @@
 ﻿use volga::{
-    App, Router, Middleware,
-    HttpContext, Next,
-    HttpResult,
+    App, HttpContext, Next, HttpResult,
     headers::{Header, custom_headers},
     Inject, Dc, ok, not_found
 };

--- a/examples/file_download.rs
+++ b/examples/file_download.rs
@@ -1,9 +1,5 @@
 ﻿use tokio::fs::File;
-use volga::{
-    App,
-    Router,
-    file
-};
+use volga::{App, file};
 
 #[tokio::main]
 async fn main() -> std::io::Result<()> {

--- a/examples/file_upload.rs
+++ b/examples/file_upload.rs
@@ -1,9 +1,4 @@
-﻿use volga::{
-    App,
-    Router,
-    ok,
-    File
-};
+﻿use volga::{App, ok, File};
 
 #[tokio::main]
 async fn main() -> std::io::Result<()> {

--- a/examples/head_request.rs
+++ b/examples/head_request.rs
@@ -1,4 +1,4 @@
-﻿use volga::{App, Router, ok};
+﻿use volga::{App, ok};
 
 #[tokio::main]
 async fn main() -> std::io::Result<()> {

--- a/examples/headers.rs
+++ b/examples/headers.rs
@@ -1,4 +1,4 @@
-﻿use volga::{App, Router, Results, ResponseContext, headers, ok};
+﻿use volga::{App, Results, ResponseContext, headers, ok};
 use volga::headers::{
     Header, 
     Headers, 

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,8 +1,4 @@
-﻿use volga::{
-    App,
-    Router,
-    ok,
-};
+﻿use volga::{App, ok};
 
 #[tokio::main]
 async fn main() -> std::io::Result<()> {

--- a/examples/http_request_handler.rs
+++ b/examples/http_request_handler.rs
@@ -1,4 +1,4 @@
-﻿use volga::{App, Router, HttpRequest, ok};
+﻿use volga::{App, HttpRequest, ok};
 
 #[tokio::main]
 async fn main() -> std::io::Result<()> {

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -1,5 +1,5 @@
 ﻿use serde::{Deserialize, Serialize};
-use volga::{App, ok, Router, Json};
+use volga::{App, ok, Json};
 
 #[derive(Debug, Serialize, Deserialize)]
 struct User {

--- a/examples/long_running_task.rs
+++ b/examples/long_running_task.rs
@@ -1,10 +1,5 @@
 ﻿use tokio::time::{interval, Duration};
-use volga::{
-    App,
-    Router,
-    ok,
-    CancellationToken
-};
+use volga::{App, CancellationToken, ok};
 
 async fn long_running_task() {
     let mut interval = interval(Duration::from_millis(1000));

--- a/examples/middleware.rs
+++ b/examples/middleware.rs
@@ -1,4 +1,4 @@
-﻿use volga::{App, Router, Middleware, ok, status, CancellationToken};
+﻿use volga::{App, CancellationToken, ok, status};
 use volga::headers::{Header, Accept};
 
 #[tokio::main]

--- a/examples/options_request.rs
+++ b/examples/options_request.rs
@@ -1,4 +1,4 @@
-﻿use volga::{App, Router, ok};
+﻿use volga::{App, ok};
 
 #[tokio::main]
 async fn main() -> std::io::Result<()> {

--- a/examples/query_params.rs
+++ b/examples/query_params.rs
@@ -1,6 +1,6 @@
 ﻿use std::collections::HashMap;
 use serde::Deserialize;
-use volga::{App, ok, Router, Query, status};
+use volga::{App, Query, ok, status};
 
 #[derive(Deserialize)]
 struct User {

--- a/examples/route_params.rs
+++ b/examples/route_params.rs
@@ -1,11 +1,6 @@
 ﻿use std::collections::HashMap;
 use serde::Deserialize;
-use volga::{
-    App, 
-    Router,
-    ok,
-    Path
-};
+use volga::{App, Path, ok};
 
 #[derive(Deserialize)]
 struct User {

--- a/examples/trace_request.rs
+++ b/examples/trace_request.rs
@@ -1,4 +1,4 @@
-﻿use volga::{App, Router, HttpRequest, stream};
+﻿use volga::{App, HttpRequest, stream};
 
 #[tokio::main]
 async fn main() -> std::io::Result<()> {

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,8 @@
-﻿use std::net::SocketAddr;
-use std::sync::Arc;
+﻿use std::{
+    net::SocketAddr,
+    future::Future,
+    sync::Arc
+};
 
 use hyper_util::rt::TokioIo;
 
@@ -12,27 +15,24 @@ use tokio::{
 
 use crate::app::{
     pipeline::{Pipeline, PipelineBuilder},
-    endpoints::Endpoints,
     scope::Scope,
     server::Server
 };
 
-#[cfg(feature = "middleware")]
-use crate::app::middlewares::{Middlewares, Middleware};
 #[cfg(feature = "di")]
-use crate::app::di::{Inject, Container, ContainerBuilder};
+use crate::app::di::{Container, ContainerBuilder};
 
 #[cfg(feature = "middleware")]
 pub mod middlewares;
 #[cfg(feature = "middleware")]
 pub mod http_context;
+#[cfg(feature = "di")]
+pub mod di;
 pub mod endpoints;
 pub mod body;
 pub mod request;
 pub mod results;
 pub mod router;
-#[cfg(feature = "di")]
-pub mod di;
 pub(crate) mod pipeline;
 mod scope;
 mod server;
@@ -65,7 +65,11 @@ struct Connection {
 
 impl Default for Connection {
     fn default() -> Self {
-        let socket = SocketAddr::from(([127, 0, 0, 1], DEFAULT_PORT));
+        #[cfg(target_os = "windows")]
+        let ip = [127, 0, 0, 1];
+        #[cfg(not(target_os = "windows"))]
+        let ip = [0, 0, 0, 0];
+        let socket = SocketAddr::from((ip, DEFAULT_PORT));
         Self { socket }
     }
 }
@@ -104,6 +108,7 @@ impl Default for App {
     }
 }
 
+/// General impl
 impl App {
     /// Initializes a new instance of the `App` which will be bound to the 127.0.0.1:7878 socket by default.
     /// 
@@ -135,37 +140,29 @@ impl App {
         self
     }
 
-    #[cfg(feature = "di")]
-    pub fn register_singleton<T: Inject + 'static>(&mut self, instance: T) {
-        self.container.register_singleton(instance);
-    }
-
-    #[cfg(feature = "di")]
-    pub fn register_scoped<T: Inject + 'static>(&mut self) {
-        self.container.register_scoped::<T>();
-    }
-
-    #[cfg(feature = "di")]
-    pub fn register_transient<T: Inject + 'static>(&mut self) {
-        self.container.register_transient::<T>();
+    /// Runs the `App`
+    #[cfg(feature = "middleware")]
+    pub fn run(mut self) -> impl Future<Output = io::Result<()>> {
+        self.use_endpoints();
+        self.run_internal()
     }
 
     /// Runs the `App`
-    pub async fn run(mut self) -> io::Result<()> {
-        #[cfg(feature = "middleware")]
-        {
-            // Register default middleware
-            self.use_endpoints();
-        }
-
+    #[cfg(not(feature = "middleware"))]
+    pub fn run(self) -> impl Future<Output = io::Result<()>> {
+        self.run_internal()
+    }
+    
+    #[inline]
+    async fn run_internal(self) -> io::Result<()> {
         let socket = self.connection.socket;
         let tcp_listener = TcpListener::bind(socket).await?;
         println!("Start listening: {socket}");
-        
+
         let (shutdown_sender, mut shutdown_signal) = broadcast::channel::<()>(1);
-        
+
         Self::subscribe_for_ctrl_c_signal(&shutdown_sender);
-        
+
         let app_instance = AppInstance::new(self);
         loop {
             tokio::select! {
@@ -184,15 +181,6 @@ impl App {
         Ok(())
     }
 
-    #[cfg(feature = "middleware")]
-    pub(crate) fn middlewares_mut(&mut self) -> &mut Middlewares {
-        self.pipeline.middlewares_mut()
-    }
-
-    pub(crate) fn endpoints_mut(&mut self) -> &mut Endpoints {
-        self.pipeline.endpoints_mut()
-    }
-
     #[inline]
     fn subscribe_for_ctrl_c_signal(shutdown_sender: &broadcast::Sender<()>) {
         let ctrl_c_shutdown_sender = shutdown_sender.clone();
@@ -207,15 +195,6 @@ impl App {
                 Err(err) => eprintln!("Failed to send shutdown signal: {}", err)
             }
         });
-    }
-
-    #[cfg(feature = "middleware")]
-    fn use_endpoints(&mut self) {
-        if self.pipeline.has_middleware_pipeline() {
-            self.use_middleware(|ctx, _| async move {
-                ctx.execute().await
-            });
-        }
     }
 
     async fn handle_connection(io: TokioIo<TcpStream>, app_instance: Arc<AppInstance>) {

--- a/src/app.rs
+++ b/src/app.rs
@@ -215,6 +215,9 @@ mod tests {
     fn it_creates_connection_with_default_socket() {
         let connection = Connection::default();
 
+        #[cfg(target_os = "windows")]
+        assert_eq!(connection.socket, SocketAddr::from(([127, 0, 0, 1], 7878)));
+        #[cfg(not(target_os = "windows"))]
         assert_eq!(connection.socket, SocketAddr::from(([127, 0, 0, 1], 7878)));
     }
 
@@ -229,6 +232,9 @@ mod tests {
     fn it_creates_app_with_default_socket() {
         let app = App::new();
         
+        #[cfg(target_os = "windows")]
+        assert_eq!(app.connection.socket, SocketAddr::from(([127, 0, 0, 1], 7878)));
+        #[cfg(not(target_os = "windows"))]
         assert_eq!(app.connection.socket, SocketAddr::from(([127, 0, 0, 1], 7878)));
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -218,7 +218,7 @@ mod tests {
         #[cfg(target_os = "windows")]
         assert_eq!(connection.socket, SocketAddr::from(([127, 0, 0, 1], 7878)));
         #[cfg(not(target_os = "windows"))]
-        assert_eq!(connection.socket, SocketAddr::from(([127, 0, 0, 1], 7878)));
+        assert_eq!(connection.socket, SocketAddr::from(([0, 0, 0, 0], 7878)));
     }
 
     #[test]
@@ -235,7 +235,7 @@ mod tests {
         #[cfg(target_os = "windows")]
         assert_eq!(app.connection.socket, SocketAddr::from(([127, 0, 0, 1], 7878)));
         #[cfg(not(target_os = "windows"))]
-        assert_eq!(app.connection.socket, SocketAddr::from(([127, 0, 0, 1], 7878)));
+        assert_eq!(app.connection.socket, SocketAddr::from(([0, 0, 0, 0], 7878)));
     }
 
     #[test]

--- a/src/app/di.rs
+++ b/src/app/di.rs
@@ -2,6 +2,7 @@
 use std::any::{Any, TypeId};
 use std::io::{Error, ErrorKind};
 use std::sync::Arc;
+use crate::App;
 
 /// Marks a type that can be used with DI
 pub trait Inject: Default + Clone + Send + Sync {}
@@ -128,6 +129,21 @@ impl DiError {
 
     fn resolve_error(type_name: &str) -> Error {
         Error::new(ErrorKind::Other, format!("Services Error: unable to resolve the service: {}", type_name))
+    }
+}
+
+/// DI specific impl for [`App`]
+impl App {
+    pub fn register_singleton<T: Inject + 'static>(&mut self, instance: T) {
+        self.container.register_singleton(instance);
+    }
+
+    pub fn register_scoped<T: Inject + 'static>(&mut self) {
+        self.container.register_scoped::<T>();
+    }
+
+    pub fn register_transient<T: Inject + 'static>(&mut self) {
+        self.container.register_transient::<T>();
     }
 }
 

--- a/src/app/endpoints/args/dc.rs
+++ b/src/app/endpoints/args/dc.rs
@@ -1,10 +1,16 @@
 ﻿//! Extractors for Dependency Injection
 
-use std::io::Error;
-use std::ops::{Deref, DerefMut};
+use std::{
+    ops::{Deref, DerefMut},
+    io::Error
+};
+
 use futures_util::future::{ready, Ready};
-use crate::app::endpoints::args::{FromPayload, Payload, Source};
-use crate::app::di::Inject;
+
+use crate::app::{
+    endpoints::args::{FromPayload, Payload, Source},
+    di::Inject
+};
 
 /// `Dc` stands for Dependency Container, This struct wraps the injectable type of `T` 
 /// `T` must be registered in Dependency Injection Container

--- a/src/app/request.rs
+++ b/src/app/request.rs
@@ -17,7 +17,6 @@ use crate::{app::endpoints::args::FromRequestRef, headers::{FromHeaders, Header}
 use crate::app::di::Container;
 
 /// Wraps the incoming [`Request`] to enrich its functionality
-//pub struct HttpRequest(pub Request<Incoming>);
 pub struct HttpRequest {
     pub inner: Request<Incoming>,
     #[cfg(feature = "di")]
@@ -100,7 +99,7 @@ impl HttpRequest {
     ///
     /// # Example
     /// ```no_run
-    /// use volga::{HttpContext, HttpRequest, Query};
+    /// use volga::{HttpRequest, Query};
     /// use serde::Deserialize;
     ///
     /// #[derive(Deserialize)]

--- a/src/app/results/macros.rs
+++ b/src/app/results/macros.rs
@@ -160,7 +160,7 @@ macro_rules! ok {
 /// ```
 /// ## Custom headers
 ///```no_run
-/// use volga::{file, App, Router};
+/// use volga::{file, App};
 /// use tokio::fs::File;
 ///
 /// # async fn dox() -> std::io::Result<()> {

--- a/src/app/router.rs
+++ b/src/app/router.rs
@@ -6,29 +6,13 @@ use crate::app::endpoints::{
     handlers::{Func, GenericHandler}
 };
 
-/// Declares a set ot methods that map routes to a specific pattern and HTTP Verb
-/// 
-/// # Examples
-/// ```no_run
-/// use volga::{App, Router, ok};
-///
-/// #[tokio::main]
-/// async fn main() -> std::io::Result<()> {
-///     let mut app = App::new();
-/// 
-///     app.map_get("/hello", || async {
-///         ok!("Hello World!")
-///     });
-/// 
-///     app.run().await
-/// }
-/// ```
-pub trait Router {
+/// Routes mapping 
+impl App {
     /// Adds a request handler that matches HTTP GET requests for the specified pattern.
     /// 
     /// # Examples
     /// ```no_run
-    /// use volga::{App, Router, ok};
+    /// use volga::{App, ok};
     ///
     ///# #[tokio::main]
     ///# async fn main() -> std::io::Result<()> {
@@ -40,16 +24,26 @@ pub trait Router {
     ///# app.run().await
     ///# }
     /// ```
-    fn map_get<F, Args>(&mut self, pattern: &str, handler: F)
+    pub fn map_get<F, Args>(&mut self, pattern: &str, handler: F)
     where
         F: GenericHandler<Args, Output = HttpResult>,
-        Args: FromRequest + Send + Sync + 'static;
+        Args: FromRequest + Send + Sync + 'static
+    {
+        let handler = Func::new(handler);
+        let endpoints = self.pipeline.endpoints_mut();
+        endpoints.map_route(Method::GET, pattern, handler.clone());
+        
+        let head = Method::HEAD;
+        if !endpoints.contains(&head, pattern) { 
+            endpoints.map_route(head, pattern, handler.clone());
+        } 
+    }
 
     /// Adds a request handler that matches HTTP POST requests for the specified pattern.
     /// 
     /// # Examples
     /// ```no_run
-    /// use volga::{App, Router, File, ok};
+    /// use volga::{App, File, ok};
     ///
     ///# #[tokio::main]
     ///# async fn main() -> std::io::Result<()> {
@@ -62,16 +56,22 @@ pub trait Router {
     ///# app.run().await
     ///# }
     /// ```
-    fn map_post<F, Args>(&mut self, pattern: &str, handler: F)
+    pub fn map_post<F, Args>(&mut self, pattern: &str, handler: F)
     where
         F: GenericHandler<Args, Output = HttpResult>,
-        Args: FromRequest + Send + Sync + 'static;
+        Args: FromRequest + Send + Sync + 'static,
+    {
+        let handler = Func::new(handler);
+        self.pipeline
+            .endpoints_mut()
+            .map_route(Method::POST, pattern, handler);
+    }
 
     /// Adds a request handler that matches HTTP PUT requests for the specified pattern.
     /// 
     /// # Examples
     /// ```no_run
-    /// use volga::{App, Router, ok};
+    /// use volga::{App, ok};
     ///
     ///# #[tokio::main]
     ///# async fn main() -> std::io::Result<()> {
@@ -83,16 +83,22 @@ pub trait Router {
     ///# app.run().await
     ///# }
     /// ```
-    fn map_put<F, Args>(&mut self, pattern: &str, handler: F)
+    pub fn map_put<F, Args>(&mut self, pattern: &str, handler: F)
     where
         F: GenericHandler<Args, Output = HttpResult>,
-        Args: FromRequest + Send + Sync + 'static;
+        Args: FromRequest + Send + Sync + 'static,
+    {
+        let handler = Func::new(handler);
+        self.pipeline
+            .endpoints_mut()
+            .map_route(Method::PUT, pattern, handler);
+    }
 
     /// Adds a request handler that matches HTTP PATCH requests for the specified pattern.
     /// 
     /// # Examples
     /// ```no_run
-    /// use volga::{App, Router, ok};
+    /// use volga::{App, ok};
     ///
     ///# #[tokio::main]
     ///# async fn main() -> std::io::Result<()> {
@@ -104,16 +110,22 @@ pub trait Router {
     ///# app.run().await
     ///# }
     /// ```
-    fn map_patch<F, Args>(&mut self, pattern: &str, handler: F)
+    pub fn map_patch<F, Args>(&mut self, pattern: &str, handler: F)
     where
         F: GenericHandler<Args, Output = HttpResult>,
-        Args: FromRequest + Send + Sync + 'static;
+        Args: FromRequest + Send + Sync + 'static,
+    {
+        let handler = Func::new(handler);
+        self.pipeline
+            .endpoints_mut()
+            .map_route(Method::PATCH, pattern, handler);
+    }
 
     /// Adds a request handler that matches HTTP DELETE requests for the specified pattern.
     /// 
     /// # Examples
     /// ```no_run
-    /// use volga::{App, Router, ok};
+    /// use volga::{App, ok};
     ///
     ///# #[tokio::main]
     ///# async fn main() -> std::io::Result<()> {
@@ -125,16 +137,22 @@ pub trait Router {
     ///# app.run().await
     ///# }
     /// ```
-    fn map_delete<F, Args>(&mut self, pattern: &str, handler: F)
+    pub fn map_delete<F, Args>(&mut self, pattern: &str, handler: F)
     where
         F: GenericHandler<Args, Output = HttpResult>,
-        Args: FromRequest + Send + Sync + 'static;
+        Args: FromRequest + Send + Sync + 'static,
+    {
+        let handler = Func::new(handler);
+        self.pipeline
+            .endpoints_mut()
+            .map_route(Method::DELETE, pattern, handler);
+    }
 
     /// Adds a request handler that matches HTTP HEAD requests for the specified pattern.
     /// 
     /// # Examples
     /// ```no_run
-    /// use volga::{App, Router, ok};
+    /// use volga::{App, ok};
     ///
     ///# #[tokio::main]
     ///# async fn main() -> std::io::Result<()> {
@@ -146,16 +164,22 @@ pub trait Router {
     ///# app.run().await
     ///# }
     /// ```
-    fn map_head<F, Args>(&mut self, pattern: &str, handler: F)
+    pub fn map_head<F, Args>(&mut self, pattern: &str, handler: F)
     where
         F: GenericHandler<Args, Output = HttpResult>,
-        Args: FromRequest + Send + Sync + 'static;
+        Args: FromRequest + Send + Sync + 'static,
+    {
+        let handler = Func::new(handler);
+        self.pipeline
+            .endpoints_mut()
+            .map_route(Method::HEAD, pattern, handler);
+    }
 
     /// Adds a request handler that matches HTTP OPTIONS requests for the specified pattern.
     /// 
     /// # Examples
     /// ```no_run
-    /// use volga::{App, Router, ok};
+    /// use volga::{App, ok};
     ///
     ///# #[tokio::main]
     ///# async fn main() -> std::io::Result<()> {
@@ -167,16 +191,22 @@ pub trait Router {
     ///# app.run().await
     ///# }
     /// ```
-    fn map_options<F, Args>(&mut self, pattern: &str, handler: F)
+    pub fn map_options<F, Args>(&mut self, pattern: &str, handler: F)
     where
         F: GenericHandler<Args, Output = HttpResult>,
-        Args: FromRequest + Send + Sync + 'static;
+        Args: FromRequest + Send + Sync + 'static,
+    {
+        let handler = Func::new(handler);
+        self.pipeline
+            .endpoints_mut()
+            .map_route(Method::OPTIONS, pattern, handler);
+    }
 
     /// Adds a request handler that matches HTTP TRACE requests for the specified pattern.
     /// 
     /// # Examples
     /// ```no_run
-    /// use volga::{App, Router, ok};
+    /// use volga::{App, ok};
     ///
     ///# #[tokio::main]
     ///# async fn main() -> std::io::Result<()> {
@@ -188,88 +218,14 @@ pub trait Router {
     ///# app.run().await
     ///# }
     /// ```
-    fn map_trace<F, Args>(&mut self, pattern: &str, handler: F)
-    where
-        F: GenericHandler<Args, Output = HttpResult>,
-        Args: FromRequest + Send + Sync + 'static;
-}
-
-impl Router for App {
-    fn map_get<F, Args>(&mut self, pattern: &str, handler: F)
-    where
-        F: GenericHandler<Args, Output = HttpResult>,
-        Args: FromRequest + Send + Sync + 'static
-    {
-        let handler = Func::new(handler);
-        let endpoints = self.endpoints_mut();
-        endpoints.map_route(Method::GET, pattern, handler.clone());
-        
-        let head = Method::HEAD;
-        if !endpoints.contains(&head, pattern) { 
-            endpoints.map_route(head, pattern, handler.clone());
-        } 
-    }
-
-    fn map_post<F, Args>(&mut self, pattern: &str, handler: F)
+    pub fn map_trace<F, Args>(&mut self, pattern: &str, handler: F)
     where
         F: GenericHandler<Args, Output = HttpResult>,
         Args: FromRequest + Send + Sync + 'static,
     {
         let handler = Func::new(handler);
-        self.endpoints_mut().map_route(Method::POST, pattern, handler);
-    }
-
-    fn map_put<F, Args>(&mut self, pattern: &str, handler: F)
-    where
-        F: GenericHandler<Args, Output = HttpResult>,
-        Args: FromRequest + Send + Sync + 'static,
-    {
-        let handler = Func::new(handler);
-        self.endpoints_mut().map_route(Method::PUT, pattern, handler);
-    }
-
-    fn map_patch<F, Args>(&mut self, pattern: &str, handler: F)
-    where
-        F: GenericHandler<Args, Output = HttpResult>,
-        Args: FromRequest + Send + Sync + 'static,
-    {
-        let handler = Func::new(handler);
-        self.endpoints_mut().map_route(Method::PATCH, pattern, handler);
-    }
-
-    fn map_delete<F, Args>(&mut self, pattern: &str, handler: F)
-    where
-        F: GenericHandler<Args, Output = HttpResult>,
-        Args: FromRequest + Send + Sync + 'static,
-    {
-        let handler = Func::new(handler);
-        self.endpoints_mut().map_route(Method::DELETE, pattern, handler);
-    }
-
-    fn map_head<F, Args>(&mut self, pattern: &str, handler: F)
-    where
-        F: GenericHandler<Args, Output = HttpResult>,
-        Args: FromRequest + Send + Sync + 'static,
-    {
-        let handler = Func::new(handler);
-        self.endpoints_mut().map_route(Method::HEAD, pattern, handler);
-    }
-
-    fn map_options<F, Args>(&mut self, pattern: &str, handler: F)
-    where
-        F: GenericHandler<Args, Output = HttpResult>,
-        Args: FromRequest + Send + Sync + 'static,
-    {
-        let handler = Func::new(handler);
-        self.endpoints_mut().map_route(Method::OPTIONS, pattern, handler);
-    }
-
-    fn map_trace<F, Args>(&mut self, pattern: &str, handler: F)
-    where
-        F: GenericHandler<Args, Output = HttpResult>,
-        Args: FromRequest + Send + Sync + 'static,
-    {
-        let handler = Func::new(handler);
-        self.endpoints_mut().map_route(Method::TRACE, pattern, handler);
+        self.pipeline
+            .endpoints_mut()
+            .map_route(Method::TRACE, pattern, handler);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ pub mod app;
 #[cfg(test)]
 pub mod test_utils;
 
-pub use crate::app::{App, router::Router, body::{BoxBody, HttpBody}};
+pub use crate::app::{App, body::{BoxBody, HttpBody}};
 pub use crate::app::request::HttpRequest;
 pub use crate::app::results::{
     HttpResponse, 
@@ -60,16 +60,16 @@ pub use crate::app::endpoints::args::{
 };
 
 #[cfg(feature = "middleware")]
-pub use crate::app::http_context::HttpContext;
-
-#[cfg(feature = "middleware")]
-pub use crate::app::middlewares::{Next, Middleware};
-
-#[cfg(feature = "di")]
-pub use crate::app::endpoints::args::dc::Dc;
+pub use crate::app::{
+    middlewares::Next,
+    http_context::HttpContext
+};
 
 #[cfg(feature = "di")]
-pub use crate::app::di::Inject;
+pub use crate::app::{
+    endpoints::args::dc::Dc,
+    di::Inject
+};
 
 // Re-exporting HTTP status codes, Response and some headers from hyper/http
 pub use hyper::{

--- a/tests/file_download.rs
+++ b/tests/file_download.rs
@@ -1,4 +1,4 @@
-﻿use volga::{App, file, Router};
+﻿use volga::{App, file};
 use tokio::fs::File;
 
 #[tokio::test]

--- a/tests/file_upload.rs
+++ b/tests/file_upload.rs
@@ -1,4 +1,4 @@
-﻿use volga::{App, Router, File, HttpBody, ok};
+﻿use volga::{App, File, HttpBody, ok};
 
 #[tokio::test]
 async fn it_saves_uploaded_file() {

--- a/tests/headers.rs
+++ b/tests/headers.rs
@@ -1,4 +1,4 @@
-﻿use volga::{App, Router, ok};
+﻿use volga::{App, ok};
 use volga::headers::{Header, Headers, ContentType};
 
 #[tokio::test]

--- a/tests/json_payload.rs
+++ b/tests/json_payload.rs
@@ -1,5 +1,5 @@
 ﻿use serde::{Deserialize, Serialize};
-use volga::{App, ok, Results, Router, Json};
+use volga::{App, ok, Results, Json};
 
 #[derive(Deserialize, Serialize)]
 struct User {

--- a/tests/mapping_tests.rs
+++ b/tests/mapping_tests.rs
@@ -1,5 +1,5 @@
 ﻿use reqwest::Method;
-use volga::{App, HttpRequest, Results, Router};
+use volga::{App, HttpRequest, Results};
 
 #[tokio::test]
 async fn it_maps_to_get_request() {

--- a/tests/middleware_mapping_tests.rs
+++ b/tests/middleware_mapping_tests.rs
@@ -1,4 +1,4 @@
-﻿use volga::{App, Router, Middleware, Results};
+﻿use volga::{App, Results};
 
 #[tokio::test]
 async fn it_adds_middleware_request() {

--- a/tests/request_params.rs
+++ b/tests/request_params.rs
@@ -1,6 +1,6 @@
 ﻿use std::collections::HashMap;
 use serde::Deserialize;
-use volga::{App, Results, Router, Query};
+use volga::{App, Results, Query};
 
 #[derive(Deserialize)]
 struct User {


### PR DESCRIPTION
* Removed `Router` trait, now route mapping is directly available by using the same `map_*` methods
* Removed `Middleware` trait now middleware registration is directly available by using the same methods if a feature is turned on
* By default the only `http1` feature is enabled