### PR TITLE
Make resolving from DI as async

### DIFF
--- a/examples/dependency_injection.rs
+++ b/examples/dependency_injection.rs
@@ -66,7 +66,7 @@ async fn main() -> std::io::Result<()> {
 }
 
 async fn log_request<T: RequestIdGenerator + Inject>(mut ctx: HttpContext, next: Next) -> HttpResult {
-    let log: RequestLog = ctx.resolve()?;
+    let log: RequestLog = ctx.resolve().await?;
     let req_id = HeaderValue::from_str(log.request_id.as_str()).unwrap();
     ctx.request
         .headers_mut()
@@ -132,9 +132,9 @@ impl RequestLog {
 
 /// Custom implementation of `Inject` trait that helps to construct the `RequestLog`
 impl Inject for RequestLog {
-    fn inject(container: &mut Container) -> Result<Self, Error> {
-        let req_gen = container.resolve::<UuidGenerator>()?;
-        let cache = container.resolve::<InMemoryCache>()?;
+    async fn inject(container: &mut Container) -> Result<Self, Error> {
+        let req_gen = container.resolve::<UuidGenerator>().await?;
+        let cache = container.resolve::<InMemoryCache>().await?;
         Ok(Self { 
             request_id: req_gen.generate_id(), 
             inner: Default::default(),

--- a/src/app/endpoints/args.rs
+++ b/src/app/endpoints/args.rs
@@ -1,7 +1,6 @@
 ﻿//! Extractors for HTTP request parts and body
 
 use std::{io::Error, future::Future};
-
 use hyper::{
     http::Extensions, 
     body::Incoming, 

--- a/src/app/endpoints/args/cancellation_token.rs
+++ b/src/app/endpoints/args/cancellation_token.rs
@@ -107,7 +107,21 @@ impl FromPayload for TokenGuard {
 mod tests {
     use hyper::http::Extensions;
     use tokio_util::sync::CancellationToken as TokioCancellationToken;
+    use crate::app::endpoints::args::{FromPayload, Payload};
     use crate::app::endpoints::args::cancellation_token::TokenGuard;
+
+    #[tokio::test]
+    async fn it_reads_from_payload() {
+        let token = TokioCancellationToken::new();
+        let mut extensions = Extensions::new();
+        extensions.insert(token.clone());
+
+        token.cancel();
+        
+        let token = TokenGuard::from_payload(Payload::Ext(&extensions)).await.unwrap();
+
+        assert!(token.is_cancelled());
+    }
 
     #[test]
     fn it_gets_from_extensions() {

--- a/src/app/endpoints/args/dc.rs
+++ b/src/app/endpoints/args/dc.rs
@@ -4,12 +4,16 @@ use std::{
     ops::{Deref, DerefMut},
     io::Error
 };
-
-use futures_util::future::{ready, Ready};
+use std::future::Future;
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use futures_util::{pin_mut, ready};
+use pin_project_lite::pin_project;
 
 use crate::app::{
     endpoints::args::{FromPayload, Payload, Source},
-    di::Inject
+    di::{Container, Inject}
 };
 
 /// `Dc` stands for Dependency Container, This struct wraps the injectable type of `T` 
@@ -61,15 +65,34 @@ impl<T: Inject> DerefMut for Dc<T> {
     }
 }
 
+pin_project! {
+    /// A future that resolves a dependency from DI container.
+    pub struct ExtractDependencyFut<T> {
+        #[pin]
+        container: Container,
+        _marker: PhantomData<T>
+    }
+}
+
+impl<T: Inject + 'static> Future for ExtractDependencyFut<T> {
+    type Output = Result<Dc<T>, Error>;
+    
+    #[inline]
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut this = self.project();
+        let fut = this.container.resolve::<T>();
+        pin_mut!(fut);
+        let result = ready!(fut.poll(cx));
+        Poll::Ready(result.map(Dc))
+    }
+}
+
 impl<T: Inject + 'static> FromPayload for Dc<T> {
-    type Future = Ready<Result<Self, Error>>;
+    type Future = ExtractDependencyFut<T>;
 
     fn from_payload(payload: Payload) -> Self::Future {
         if let Payload::Dc(container) = payload {
-            let dependency = container
-                .resolve::<T>()
-                .map(Dc);
-            ready(dependency)
+            ExtractDependencyFut { container: container.clone(), _marker: PhantomData }
         } else {
             unreachable!()
         }
@@ -77,5 +100,41 @@ impl<T: Inject + 'static> FromPayload for Dc<T> {
 
     fn source() -> Source {
         Source::Dc
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+    use super::Dc;
+    use crate::app::di::ContainerBuilder;
+    use crate::app::endpoints::args::{FromPayload, Payload};
+    
+    type Cache = Arc<Mutex<Vec<i32>>>;
+    
+    #[tokio::test]
+    async fn it_reads_from_payload() {
+        let mut container = ContainerBuilder::new();
+        
+        container.register_scoped::<Cache>();
+        
+        let container = container.build();
+        let mut scope = container.create_scope();
+        
+        let vec = scope.resolve::<Cache>().await.unwrap();
+        vec.lock().unwrap().push(1);
+        
+        let dc = Dc::<Cache>::from_payload(Payload::Dc(&mut scope)).await.unwrap();
+        dc.lock().unwrap().push(2);
+
+        let dc = Dc::<Cache>::from_payload(Payload::Dc(&mut scope)).await.unwrap();
+        dc.lock().unwrap().push(3);
+
+        let dc = Dc::<Cache>::from_payload(Payload::Dc(&mut scope)).await.unwrap();
+        let dc = dc.lock().unwrap();
+        
+        assert_eq!(dc[0], 1);
+        assert_eq!(dc[1], 2);
+        assert_eq!(dc[2], 3);
     }
 }

--- a/src/app/endpoints/args/headers.rs
+++ b/src/app/endpoints/args/headers.rs
@@ -279,7 +279,28 @@ mod tests {
     use std::ops::Deref;
     use hyper::HeaderMap;
     use hyper::http::HeaderValue;
-    use crate::headers::{ContentType, Header};
+    use crate::headers::{ContentType, Header, Headers};
+    use crate::app::endpoints::args::{FromPayload, Payload};
+
+    #[tokio::test]
+    async fn it_reads_headers_from_payload() {
+        let mut headers = HeaderMap::new();
+        headers.insert("Content-Type", HeaderValue::from_static("text/plain"));
+
+        let headers = Headers::from_payload(Payload::Headers(&headers)).await.unwrap();
+
+        assert_eq!(headers.get("content-type").unwrap(), "text/plain");
+    }
+
+    #[tokio::test]
+    async fn it_reads_header_from_payload() {
+        let mut headers = HeaderMap::new();
+        headers.insert("Content-Type", HeaderValue::from_static("text/plain"));
+
+        let header: Header<ContentType> = Header::from_payload(Payload::Headers(&headers)).await.unwrap();
+
+        assert_eq!(header.deref(), "text/plain");
+    }
 
     #[test]
     fn it_gets_header() {

--- a/src/app/endpoints/args/path.rs
+++ b/src/app/endpoints/args/path.rs
@@ -162,13 +162,39 @@ impl PathError {
 mod tests {
     use hyper::http::Extensions;
     use serde::Deserialize;
-    use crate::app::endpoints::route::PathArguments;
     use crate::Path;
+    use crate::app::endpoints::route::PathArguments;
+    use crate::app::endpoints::args::{FromPayload, Payload};
 
     #[derive(Deserialize)]
     struct Params {
         id: u32,
         name: String
+    }
+
+    #[tokio::test]
+    async fn it_reads_from_payload() {
+        let param = ("id".to_string(), "123".to_string());
+        
+        let id = i32::from_payload(Payload::Path(&param)).await.unwrap();
+        
+        assert_eq!(id, 123);
+    }
+
+    #[tokio::test]
+    async fn it_reads_path_from_payload() {
+        let args: PathArguments = vec![
+            ("id".to_string(), "123".to_string()),
+            ("name".to_string(), "John".to_string())
+        ];
+        
+        let mut ext = Extensions::new();
+        ext.insert(args);
+
+        let path = Path::<Params>::from_payload(Payload::Ext(&ext)).await.unwrap();
+
+        assert_eq!(path.id, 123u32);
+        assert_eq!(path.name, "John")
     }
     
     #[test]

--- a/src/app/http_context.rs
+++ b/src/app/http_context.rs
@@ -55,8 +55,8 @@ impl HttpContext {
 
     /// Resolves a service from Dependency Container
     #[cfg(feature = "di")]
-    pub fn resolve<T: Inject + 'static>(&mut self) -> Result<T, Error> {
-        self.request.resolve::<T>()
+    pub async fn resolve<T: Inject + 'static>(&mut self) -> Result<T, Error> {
+        self.request.resolve::<T>().await
     }
     
     /// Inserts the [`Header<T>`] to HTTP request headers

--- a/src/app/request.rs
+++ b/src/app/request.rs
@@ -98,8 +98,8 @@ impl HttpRequest {
     /// Resolves a service from Dependency Container
     #[inline]
     #[cfg(feature = "di")]
-    pub fn resolve<T: Inject + 'static>(&mut self) -> Result<T, Error> {
-        self.container.resolve::<T>()
+    pub async fn resolve<T: Inject + 'static>(&mut self) -> Result<T, Error> {
+        self.container.resolve::<T>().await
     }
     
     /// Extracts a payload from request parts

--- a/src/app/scope.rs
+++ b/src/app/scope.rs
@@ -67,7 +67,7 @@ impl Scope {
                 let (handler, params) = endpoint_context.into_parts();
 
                 #[cfg(feature = "di")]
-                let mut request = HttpRequest::new(request, shared.container.clone());
+                let mut request = HttpRequest::new(request, shared.container.create_scope());
                 #[cfg(not(feature = "di"))]
                 let mut request = HttpRequest::new(request);
                 


### PR DESCRIPTION
* `Inject` trait is now asynchronous
* `Clone` trait on `Container` now does the predictable clone instead of creating a scoped DI container
* A new method `create_scope` is now creates a new scope