### PR TITLE
Response Compression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volga"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2021"
 rust-version = "1.80.0"
 authors = ["Roman Emreis <roman.emreis@outlook.com>"]
@@ -14,6 +14,7 @@ categories = ["web-programming::http-server"]
 keywords = ["volga", "server", "http", "web", "framework"]
 
 [dependencies]
+async-compression = { version = "0.4.18", features = ["tokio"], optional = true }
 bytes = "1.9.0"
 futures-util = { version = "0.3.31", default-features = false, features = ["alloc"] }
 http-body-util = "0.1.2"
@@ -29,7 +30,7 @@ serde_json = "1.0.134"
 serde_urlencoded = "0.7.1"
 
 [dev-dependencies]
-reqwest = { version = "0.12.11", features = ["blocking", "json", "http2"] }
+reqwest = { version = "0.12.12", features = ["blocking", "json", "http2"] }
 serde = { version = "1.0.217", features = ["derive"] }
 uuid = { version = "1.11.0", features = ["v4"] }
 
@@ -37,7 +38,7 @@ uuid = { version = "1.11.0", features = ["v4"] }
 # Default HTTP/1 only server
 default = ["http1"]
 # HTTP/1 and HTTP/2 server
-full = ["http1", "http2", "middleware", "di"]
+full = ["http1", "http2", "middleware", "di", "compression-full"]
 
 # Mimimal HTTP/1
 mini = ["http1"]
@@ -46,6 +47,11 @@ mini2 = ["http2"]
 
 http1 = ["dep:hyper", "hyper?/http1", "dep:hyper-util", "hyper-util?/http1"]
 http2 = ["dep:hyper", "hyper?/http2", "dep:hyper-util", "hyper-util?/http2"]
+
+compression-full = ["brotli", "gzip", "zstd"]
+brotli = ["middleware", "async-compression/brotli"]
+gzip = ["middleware", "async-compression/zlib", "async-compression/gzip"]
+zstd = ["middleware", "async-compression/zstd"]
 
 middleware = []
 di = []
@@ -123,3 +129,8 @@ required-features = ["middleware", "di"]
 [[example]]
 name = "route_groups"
 path = "examples/route_groups.rs"
+
+[[example]]
+name = "compression"
+path = "examples/compression.rs"
+required-features = ["compression-full"]

--- a/examples/compression.rs
+++ b/examples/compression.rs
@@ -1,0 +1,24 @@
+﻿use volga::{App, ok};
+
+#[derive(serde::Serialize)]
+struct User {
+    name: String,
+    age: i32,
+}
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let mut app = App::new();
+
+    app.use_compression();
+    
+    app.map_get("/compressed", || async {
+        let mut values = Vec::new();
+        for i in 0..10000 {
+            values.push(User { age: i, name: i.to_string() });
+        }
+        ok!(values)
+    });
+
+    app.run().await
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -28,6 +28,20 @@ pub mod middlewares;
 pub mod http_context;
 #[cfg(feature = "di")]
 pub mod di;
+#[cfg(any(
+    feature = "brotli", 
+    feature = "gzip", 
+    feature = "zstd", 
+    feature = "compression-full"
+))]
+pub mod encoding;
+#[cfg(any(
+    feature = "brotli",
+    feature = "gzip",
+    feature = "zstd",
+    feature = "compression-full"
+))]
+pub mod compress;
 pub mod endpoints;
 pub mod body;
 pub mod request;

--- a/src/app/compress.rs
+++ b/src/app/compress.rs
@@ -1,0 +1,270 @@
+﻿//! Compression middleware
+//! 
+//! Middleware that compress HTTP response body
+
+use std::{
+    collections::HashSet,
+    cmp::Ordering,
+    str::FromStr,
+};
+
+#[cfg(feature = "brotli")]
+use async_compression::tokio::bufread::BrotliEncoder;
+
+#[cfg(feature = "gzip")]
+use async_compression::tokio::bufread::{ZlibEncoder, GzipEncoder};
+
+#[cfg(feature = "zstd")]
+use async_compression::tokio::bufread::ZstdEncoder;
+
+use async_compression::Level;
+use futures_util::TryStreamExt;
+use http_body_util::{BodyExt, StreamBody};
+use hyper::body::Frame;
+
+use tokio_util::io::{
+    ReaderStream, 
+    StreamReader
+};
+
+use super::App;
+use crate::{
+    headers::{
+        quality::Quality,
+        HeaderValue,
+        ACCEPT_ENCODING,
+        ACCEPT_RANGES,
+        CONTENT_ENCODING,
+        CONTENT_LENGTH,
+        VARY
+    },
+    encoding::Encoding,
+    HttpResponse,
+    HttpResult,
+    BoxBody,
+    status
+};
+
+static SUPPORTED_ENCODINGS: &[Encoding] = &[
+    Encoding::Identity,
+    #[cfg(feature = "brotli")]
+    Encoding::Brotli,
+    #[cfg(feature = "gzip")]
+    Encoding::Gzip,
+    #[cfg(feature = "gzip")]
+    Encoding::Deflate,
+    #[cfg(feature = "zstd")]
+    Encoding::Zstd,
+];
+
+trait Compressor {
+    fn compress(body: BoxBody) -> BoxBody;
+}
+
+#[cfg(feature = "gzip")]
+struct GzipCompressor;
+#[cfg(feature = "gzip")]
+impl Compressor for GzipCompressor {
+    fn compress(body: BoxBody) -> BoxBody {
+        let body_stream = body.into_data_stream();
+        let stream_reader = StreamReader::new(body_stream);
+
+        let encoder = GzipEncoder::new(stream_reader);
+        let compressed_body = ReaderStream::new(encoder);
+        StreamBody::new(compressed_body.map_ok(Frame::data)).boxed()
+    }
+}
+
+#[cfg(feature = "gzip")]
+struct DeflateCompressor;
+#[cfg(feature = "gzip")]
+impl Compressor for DeflateCompressor {
+    fn compress(body: BoxBody) -> BoxBody {
+        let body_stream = body.into_data_stream();
+        let stream_reader = StreamReader::new(body_stream);
+
+        let encoder = ZlibEncoder::new(stream_reader);
+        let compressed_body = ReaderStream::new(encoder);
+        StreamBody::new(compressed_body.map_ok(Frame::data)).boxed()
+    }
+}
+
+#[cfg(feature = "brotli")]
+struct BrotliCompressor;
+#[cfg(feature = "brotli")]
+impl Compressor for BrotliCompressor {
+    fn compress(body: BoxBody) -> BoxBody {
+        let body_stream = body.into_data_stream();
+        let stream_reader = StreamReader::new(body_stream);
+
+        let encoder = BrotliEncoder::with_quality(stream_reader, Level::Precise(4));
+        let compressed_body = ReaderStream::new(encoder);
+        StreamBody::new(compressed_body.map_ok(Frame::data)).boxed()
+    }
+}
+
+#[cfg(feature = "zstd")]
+struct ZstdCompressor;
+#[cfg(feature = "zstd")]
+impl Compressor for ZstdCompressor {
+    fn compress(body: BoxBody) -> BoxBody {
+        let body_stream = body.into_data_stream();
+        let stream_reader = StreamReader::new(body_stream);
+
+        let encoder = ZstdEncoder::new(stream_reader);
+        let compressed_body = ReaderStream::new(encoder);
+        StreamBody::new(compressed_body.map_ok(Frame::data)).boxed()
+    }
+}
+
+impl App {
+    /// Registers a middleware that applies a default compression algorithm
+    pub fn use_compression(&mut self) -> &mut Self {
+        self.use_middleware(|ctx, next| async move {
+            let accept_encoding = ctx.request
+                .headers()
+                .get(&ACCEPT_ENCODING)
+                .cloned();
+            let http_result = next(ctx).await;
+
+            Self::negotiate(accept_encoding, http_result)
+        });
+        self
+    }
+    
+    fn negotiate(accept_encoding: Option<HeaderValue>, http_result: HttpResult) -> HttpResult {
+        let accept_encoding = accept_encoding
+            .map(|val| val.to_str().unwrap_or("").to_string());
+        
+        let mut encodings_with_weights = vec![];
+        if let Some(header_value) = &accept_encoding {
+            for part in header_value.split(',') {
+                let quality = Quality::<Encoding>::from_str(part.trim())?;
+                encodings_with_weights.push(quality);
+            }
+            encodings_with_weights
+                .sort_by(|a, b| b.value
+                    .partial_cmp(&a.value)
+                    .unwrap_or(Ordering::Equal)
+                );
+        }
+        
+        let supported = SUPPORTED_ENCODINGS
+            .iter()
+            .collect::<HashSet<_>>();
+        
+        if encodings_with_weights.is_empty() || encodings_with_weights[0].item.is_any() {
+            return if supported.contains(&Encoding::Brotli) {
+                Self::brotli(http_result)
+            } else if supported.contains(&Encoding::Gzip) {
+                Self::gzip(http_result)
+            } else {
+                http_result
+            }
+        }
+
+        for encoding in encodings_with_weights {
+            if supported.contains(&encoding.item) { 
+                return Self::compress(encoding.item, http_result);
+            }
+        }
+        
+        let supported_encodings_str = supported
+            .iter()
+            .map(|&encoding| encoding.to_string())
+            .collect::<Vec<String>>()
+            .join(",");
+        
+        status!(
+            406, 
+            supported_encodings_str, 
+            [(VARY, ACCEPT_ENCODING)]
+        )
+    }
+
+    fn compress(encoding: Encoding, http_result: HttpResult) -> HttpResult {
+        match encoding {
+            #[cfg(feature = "brotli")]
+            Encoding::Brotli => Self::brotli(http_result),
+            #[cfg(feature = "gzip")]
+            Encoding::Gzip => Self::gzip(http_result),
+            #[cfg(feature = "gzip")]
+            Encoding::Deflate => Self::deflate(http_result),
+            #[cfg(feature = "zstd")]
+            Encoding::Zstd => Self::zstd(http_result),
+            _ => http_result
+        }
+    }
+
+    /// Registers a middleware that applies gzip compression algorithm
+    #[cfg(feature = "gzip")]
+    fn gzip(http_result: HttpResult) -> HttpResult {
+        if let Ok(response) = http_result {
+            let (mut parts, body) = response.into_parts();
+            parts.headers.remove(CONTENT_LENGTH);
+            parts.headers.remove(ACCEPT_RANGES);
+            parts.headers.append(
+                CONTENT_ENCODING,
+                Encoding::Gzip.into()
+            );
+            let body = GzipCompressor::compress(body);
+            Ok(HttpResponse::from_parts(parts, body))
+        } else {
+            http_result
+        }
+    }
+
+    /// Registers a middleware that applies a deflate compression algorithm
+    #[cfg(feature = "gzip")]
+    fn deflate(http_result: HttpResult) -> HttpResult {
+        if let Ok(response) = http_result {
+            let (mut parts, body) = response.into_parts();
+            parts.headers.remove(CONTENT_LENGTH);
+            parts.headers.remove(ACCEPT_RANGES);
+            parts.headers.append(
+                CONTENT_ENCODING,
+                Encoding::Deflate.into()
+            );
+            let body = DeflateCompressor::compress(body);
+            Ok(HttpResponse::from_parts(parts, body))
+        } else {
+            http_result
+        }
+    }
+
+    /// Registers a middleware that applies brotli compression algorithm
+    #[cfg(feature = "brotli")]
+    fn brotli(http_result: HttpResult) -> HttpResult {
+        if let Ok(response) = http_result {
+            let (mut parts, body) = response.into_parts();
+            parts.headers.remove(CONTENT_LENGTH);
+            parts.headers.remove(ACCEPT_RANGES);
+            parts.headers.append(
+                CONTENT_ENCODING,
+                Encoding::Brotli.into()
+            );
+            let body = BrotliCompressor::compress(body);
+            Ok(HttpResponse::from_parts(parts, body))
+        } else {
+            http_result
+        }
+    }
+
+    /// Registers a middleware that applies Zstandard compression algorithm
+    #[cfg(feature = "zstd")]
+    fn zstd(http_result: HttpResult) -> HttpResult {
+        if let Ok(response) = http_result {
+            let (mut parts, body) = response.into_parts();
+            parts.headers.remove(CONTENT_LENGTH);
+            parts.headers.remove(ACCEPT_RANGES);
+            parts.headers.append(
+                CONTENT_ENCODING,
+                Encoding::Zstd.into()
+            );
+            let body = ZstdCompressor::compress(body);
+            Ok(HttpResponse::from_parts(parts, body))
+        } else {
+            http_result
+        }
+    }
+}

--- a/src/app/encoding.rs
+++ b/src/app/encoding.rs
@@ -1,0 +1,194 @@
+﻿use crate::headers::{
+    quality::Ranked,
+    HeaderValue
+};
+
+use std::{
+    io::{Error, ErrorKind},
+    str::FromStr,
+    fmt
+};
+
+#[derive(Hash, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Encoding {
+    Any,
+    Identity,
+    Brotli,
+    Gzip,
+    Deflate,
+    Zstd
+}
+
+impl Encoding {
+    /// Returns `true` is encoding is `*` (star)
+    #[inline]
+    pub(crate) fn is_any(&self) -> bool {
+        self == &Encoding::Any
+    }
+}
+
+impl Ranked for Encoding {
+    #[inline]
+    fn rank(&self) -> u8 {
+        match self {
+            Encoding::Brotli => 5,
+            Encoding::Zstd => 4,
+            Encoding::Gzip => 3,
+            Encoding::Deflate => 2,
+            Encoding::Any => 1,
+            Encoding::Identity => 0,
+        }
+    }
+}
+
+impl FromStr for Encoding {
+    type Err = Error;
+    #[inline]
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "*" => Ok(Encoding::Any),
+            "identity" => Ok(Encoding::Identity),
+            "br" => Ok(Encoding::Brotli),
+            "gzip" => Ok(Encoding::Gzip),
+            "deflate" => Ok(Encoding::Deflate),
+            "zstd" => Ok(Encoding::Zstd),
+            _ => Err(EncodingError::unknown())
+        }
+    }
+}
+
+impl fmt::Display for Encoding {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(match *self { 
+            Encoding::Any => "*",
+            Encoding::Identity => "identity",
+            Encoding::Brotli => "br",
+            Encoding::Gzip => "gzip",
+            Encoding::Deflate => "deflate",
+            Encoding::Zstd => "zstd"
+        })
+    }
+}
+
+#[cfg(any(
+    feature = "brotli",
+    feature = "gzip",
+    feature = "zstd",
+    feature = "compression-full"
+))]
+impl From<Encoding> for HeaderValue {
+    #[inline]
+    fn from(encoding: Encoding) -> HeaderValue {
+        HeaderValue::from_str(&encoding.to_string())
+            .unwrap_or(HeaderValue::from_static("identity"))
+    }
+}
+
+struct EncodingError;
+impl EncodingError {
+    fn unknown() -> Error { 
+        Error::new(ErrorKind::InvalidInput, "Encoding error: Unknown encoding")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+    use crate::headers::HeaderValue;
+    use crate::headers::quality::Ranked;
+    use super::Encoding;
+    
+    #[test]
+    fn it_parses_from_str() {
+        let encodings = [
+            ("*", Encoding::Any),
+            ("identity", Encoding::Identity),
+            ("br", Encoding::Brotli),
+            ("gzip", Encoding::Gzip),
+            ("deflate", Encoding::Deflate),
+            ("zstd", Encoding::Zstd),
+        ];
+        
+        for (encoding_str, encoding) in encodings {
+            assert_eq!(Encoding::from_str(encoding_str).unwrap(), encoding);
+        }
+    }
+    
+    #[test]
+    fn it_converts_to_str() {
+        let encodings = [
+            ("*", Encoding::Any),
+            ("identity", Encoding::Identity),
+            ("br", Encoding::Brotli),
+            ("gzip", Encoding::Gzip),
+            ("deflate", Encoding::Deflate),
+            ("zstd", Encoding::Zstd),
+        ];
+
+        for (encoding_str, encoding) in encodings {
+            assert_eq!(encoding.to_string(), encoding_str);
+        }
+    }
+    
+    #[test]
+    fn it_returns_error() {
+        let encoding_str = "abc";
+        
+        let encoding = Encoding::from_str(encoding_str);
+        
+        assert!(encoding.is_err());
+    }
+    
+    #[test]
+    fn it_returns_true_for_any_encoding() {
+        assert!(Encoding::Any.is_any());
+    }
+
+    #[test]
+    fn it_returns_false_for_other_encodings() {
+        let encodings = [
+            Encoding::Identity,
+            Encoding::Brotli,
+            Encoding::Gzip,
+            Encoding::Deflate,
+            Encoding::Zstd
+        ];
+
+        for encoding in &encodings {
+            assert!(!encoding.is_any());
+        }
+    }
+    
+    #[test]
+    fn it_converts_to_header_value() {
+        let encodings = [
+            Encoding::Any,
+            Encoding::Identity,
+            Encoding::Brotli,
+            Encoding::Gzip,
+            Encoding::Deflate,
+            Encoding::Zstd
+        ];
+
+        for encoding in encodings {
+            assert_eq!(HeaderValue::from(encoding), encoding.to_string());
+        }
+    }
+
+    #[test]
+    fn it_returns_correct_ranks() {
+        let encodings = [
+            Encoding::Identity,
+            Encoding::Any,
+            Encoding::Deflate,
+            Encoding::Gzip,
+            Encoding::Zstd,
+            Encoding::Brotli,
+        ];
+
+        for (i, encoding) in encodings.iter().enumerate() {
+            assert_eq!(i, encoding.rank() as usize);
+        }
+    }
+}

--- a/src/app/endpoints/args.rs
+++ b/src/app/endpoints/args.rs
@@ -8,7 +8,10 @@ use hyper::{
     HeaderMap, 
 };
 
-use crate::{app::endpoints::route::PathArguments, HttpRequest};
+use crate::{
+    app::endpoints::route::PathArguments, 
+    HttpRequest
+};
 
 #[cfg(feature = "di")]
 use crate::app::di::Container;

--- a/src/app/endpoints/args/headers.rs
+++ b/src/app/endpoints/args/headers.rs
@@ -14,12 +14,17 @@ pub use hyper::{
     header::{
         InvalidHeaderValue, 
         ToStrError,
+        ACCEPT_ENCODING,
+        ACCEPT_RANGES,
         CONTENT_DISPOSITION,
         TRANSFER_ENCODING,
-        CONTENT_TYPE,
+        CONTENT_ENCODING,
         CONTENT_LENGTH,
+        CONTENT_RANGE,
+        CONTENT_TYPE,
         LOCATION,
-        SERVER
+        SERVER,
+        VARY
     }
 };
 
@@ -32,6 +37,7 @@ pub use extract::*;
 pub use macros::custom_headers;
 
 pub mod extract;
+pub mod quality;
 mod macros;
 
 /// Wraps the [`HeaderMap`] extracted from request

--- a/src/app/endpoints/args/headers/quality.rs
+++ b/src/app/endpoints/args/headers/quality.rs
@@ -72,11 +72,17 @@ impl QualityError {
 }
 
 #[cfg(test)]
+#[cfg(any(
+    feature = "brotli",
+    feature = "gzip",
+    feature = "zstd",
+    feature = "compression-full"
+))]
 mod tests {
     use super::Quality;
     use std::str::FromStr;
-    use crate::encoding::Encoding;
     use crate::headers::quality::Ranked;
+    use crate::encoding::Encoding;
 
     #[test]
     fn it_parses_from_str_with_value() {

--- a/src/app/endpoints/args/headers/quality.rs
+++ b/src/app/endpoints/args/headers/quality.rs
@@ -1,0 +1,118 @@
+﻿use std::io::{Error, ErrorKind};
+use std::num::ParseFloatError;
+use std::str::FromStr;
+
+/// Marks a struct as supporting q-factor
+pub trait Ranked {
+    /// Returns a struct default q-factor
+    fn rank(&self) -> u8;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+pub struct Quality<T: FromStr + Ranked> {
+    pub item: T,
+    pub value: f32,
+}
+
+impl<T: FromStr + Ranked> Quality<T> {
+    const PREFIX: [&'static str; 2] = ["q=", "Q="];
+    const DELIMITER: &'static str = ";";
+    
+    pub fn new(item: T, value: f32) -> Self {
+        Quality { item, value }
+    }
+    
+    #[inline]
+    pub fn ranked(item: T) -> Self {
+        let rank = item.rank() as f32;
+        Quality::new(item, rank)
+    }
+}
+
+impl<T: FromStr + Ranked> FromStr for Quality<T>
+where 
+    Error: From<<T as FromStr>::Err>
+{
+    type Err = Error;
+    #[inline]
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts = s.rsplit_once(Self::DELIMITER)
+            .map(|(item, q_val)| (item.trim(), q_val.trim()));
+        
+        if let Some((item, q_val)) = parts {
+            let item = T::from_str(item)?;
+            let q = &q_val[0..2];
+            if Self::PREFIX.contains(&q) {
+                let q_val = &q_val[2..];
+                let value = q_val.parse::<f32>()
+                    .map_err(QualityError::parsing_error)?;
+                Ok(Quality::new(item, value))
+            } else { 
+                Ok(Quality::ranked(item))
+            } 
+        } else if let Ok(item) = T::from_str(s) {
+            Ok(Quality::ranked(item))
+        } else {
+            Err(QualityError::missing_value())
+        }
+    }
+}
+
+struct QualityError;
+impl QualityError {
+    #[inline]
+    fn parsing_error(err: ParseFloatError) -> Error {
+        Error::new(ErrorKind::InvalidData, format!("Q-value error: {err}"))
+    }
+
+    #[inline]
+    fn missing_value() -> Error {
+        Error::new(ErrorKind::InvalidData, "Q-value error: missing value")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Quality;
+    use std::str::FromStr;
+    use crate::encoding::Encoding;
+    use crate::headers::quality::Ranked;
+
+    #[test]
+    fn it_parses_from_str_with_value() {
+        let str = "br;q=0.8";
+        
+        let quality = Quality::<Encoding>::from_str(str).unwrap();
+
+        assert_eq!(quality.value, 0.8);
+        assert_eq!(quality.item, Encoding::Brotli);
+    }
+
+    #[test]
+    fn it_parses_from_str_with_rank_value() {
+        let str = "gzip";
+
+        let quality = Quality::<Encoding>::from_str(str).unwrap();
+
+        assert_eq!(quality.value, Encoding::Gzip.rank() as f32);
+        assert_eq!(quality.item, Encoding::Gzip);
+    }
+
+    #[test]
+    fn it_returns_parse_error() {
+        let str = "gzip;Q=";
+
+        let quality = Quality::<Encoding>::from_str(str);
+
+        assert!(quality.is_err());
+    }
+
+    #[test]
+    fn it_returns_missing_value_error() {
+        let str = "abc";
+
+        let quality = Quality::<Encoding>::from_str(str);
+
+        assert!(quality.is_err());
+    }
+}

--- a/src/app/results/builder.rs
+++ b/src/app/results/builder.rs
@@ -5,7 +5,7 @@ pub const RESPONSE_ERROR: &str = "HTTP Response: Unable to create a response";
 #[macro_export]
 macro_rules! builder {
     () => {
-        $crate::Response::builder()
+        $crate::http::Response::builder()
             .header($crate::headers::SERVER, $crate::SERVER_NAME)
     };
     ($status:expr) => {

--- a/src/app/results/macros.rs
+++ b/src/app/results/macros.rs
@@ -45,7 +45,7 @@ macro_rules! ok {
     // handles ok!()
     () => {
         $crate::response!(
-            $crate::StatusCode::OK, 
+            $crate::http::StatusCode::OK, 
             $crate::HttpBody::empty(),
             [
                 ($crate::headers::CONTENT_TYPE, "text/plain")
@@ -56,7 +56,7 @@ macro_rules! ok {
     // handles ok!([("key", "val")])
     ([ $( ($key:expr, $value:expr) ),* $(,)? ]) => {
         $crate::response!(
-            $crate::StatusCode::OK, 
+            $crate::http::StatusCode::OK, 
             $crate::app::body::HttpBody::empty(),
             [ $( ($key, $value) ),* ]
         )
@@ -65,7 +65,7 @@ macro_rules! ok {
     // handles ok!({ json })
     ({ $($json:tt)* }) => {
         $crate::response!(
-            $crate::StatusCode::OK,
+            $crate::http::StatusCode::OK,
             $crate::HttpBody::json(serde_json::json_internal!({ $($json)* })),
             [
                 ($crate::headers::CONTENT_TYPE, "application/json"),
@@ -76,7 +76,7 @@ macro_rules! ok {
     // handles ok!({ json }, [("key", "val")])
     ({ $($json:tt)* }, [ $( ($key:expr, $value:expr) ),* $(,)? ]) => {
         $crate::response!(
-            $crate::StatusCode::OK,
+            $crate::http::StatusCode::OK,
             $crate::HttpBody::json(serde_json::json_internal!({ $($json)* })),
             [
                 ($crate::headers::CONTENT_TYPE, "application/json"),
@@ -88,7 +88,7 @@ macro_rules! ok {
     // handles ok!(json)
     ($var:ident) => {
         $crate::response!(
-            $crate::StatusCode::OK,
+            $crate::http::StatusCode::OK,
             $crate::HttpBody::json($var),
             [
                 ($crate::headers::CONTENT_TYPE, "application/json"),
@@ -97,10 +97,10 @@ macro_rules! ok {
     };
     
     // handles ok!(json, [("key", "val")])
-    ($e:expr, [ $( ($key:expr, $value:expr) ),* $(,)? ]) => {
+    ($body:expr, [ $( ($key:expr, $value:expr) ),* $(,)? ]) => {
         $crate::response!(
-            $crate::StatusCode::OK,
-            $crate::HttpBody::json($e),
+            $crate::http::StatusCode::OK,
+            $crate::HttpBody::json($body),
             [
                 ($crate::headers::CONTENT_TYPE, "application/json"),
                 $( ($key, $value) ),*
@@ -111,7 +111,7 @@ macro_rules! ok {
     // handles ok!("Hello {name}")
     ($fmt:tt) => {
         $crate::response!(
-            $crate::StatusCode::OK,
+            $crate::http::StatusCode::OK,
             $crate::HttpBody::json(format!($fmt)),
             [
                 ($crate::headers::CONTENT_TYPE, "application/json"),
@@ -120,10 +120,10 @@ macro_rules! ok {
     };
     
     // handles ok!(thing.to_string()) or ok!(5 + 5)
-    ($e:expr) => {
+    ($body:expr) => {
         $crate::response!(
-            $crate::StatusCode::OK,
-            $crate::HttpBody::json($e),
+            $crate::http::StatusCode::OK,
+            $crate::HttpBody::json($body),
             [
                 ($crate::headers::CONTENT_TYPE, "application/json"),
             ]
@@ -133,7 +133,7 @@ macro_rules! ok {
     // handles ok!("Hello {}", name)
     ($($fmt:tt)*) => {
         $crate::response!(
-            $crate::StatusCode::OK,
+            $crate::http::StatusCode::OK,
             $crate::HttpBody::json(format!($($fmt)*)),
             [
                 ($crate::headers::CONTENT_TYPE, "application/json"),
@@ -175,10 +175,10 @@ macro_rules! ok {
 /// ```
 #[macro_export]
 macro_rules! file {
-    ($file_name:expr, $e:expr) => {
+    ($file_name:expr, $body:expr) => {
         $crate::response!(
-            $crate::StatusCode::OK, 
-            $crate::HttpBody::wrap_stream($e),
+            $crate::http::StatusCode::OK, 
+            $crate::HttpBody::wrap_stream($body),
             [
                 ($crate::headers::CONTENT_TYPE, "application/octet-stream"),
                 ($crate::headers::TRANSFER_ENCODING, "chunked"),
@@ -187,10 +187,10 @@ macro_rules! file {
         )
     };
     
-    ($file_name:expr, $e:expr, [ $( ($key:expr, $value:expr) ),* $(,)? ]) => {
+    ($file_name:expr, $body:expr, [ $( ($key:expr, $value:expr) ),* $(,)? ]) => {
         $crate::response!(
-            $crate::StatusCode::OK, 
-            $crate::HttpBody::wrap_stream($e),
+            $crate::http::StatusCode::OK, 
+            $crate::HttpBody::wrap_stream($body),
             [
                 ($crate::headers::CONTENT_TYPE, "application/octet-stream"),
                 ($crate::headers::TRANSFER_ENCODING, "chunked"),
@@ -228,13 +228,13 @@ macro_rules! file {
 /// ```
 #[macro_export]
 macro_rules! stream {
-    ($e:expr) => {
-        $crate::response!($crate::StatusCode::OK, $e)
+    ($body:expr) => {
+        $crate::response!($crate::http::StatusCode::OK, $body)
     };
-    ($e:expr, [ $( ($key:expr, $value:expr) ),* $(,)? ]) => {
+    ($body:expr, [ $( ($key:expr, $value:expr) ),* $(,)? ]) => {
         $crate::response!(
-            $crate::StatusCode::OK, 
-            $e,
+            $crate::http::StatusCode::OK, 
+            $body,
             [ $( ($key, $value) ),* ]
         )
     };
@@ -263,8 +263,8 @@ macro_rules! not_found {
     ([ $( ($key:expr, $value:expr) ),* $(,)? ]) => {
         $crate::status!(404, [ $( ($key, $value) ),* ])
     };
-    ($e:expr) => {
-        $crate::status!(404, $e)
+    ($body:expr) => {
+        $crate::status!(404, $body)
     };
 }
 
@@ -291,8 +291,14 @@ macro_rules! bad_request {
     ({ $($json:tt)* }) => {
         $crate::status!(400, { $($json)* })
     };
-    ($e:expr) => {
-        $crate::status!(400, $e)
+    ([ $( ($key:expr, $value:expr) ),* $(,)? ]) => {
+        $crate::status!(400, [ $( ($key, $value) ),* ])
+    };
+    ($body:expr, [ $( ($key:expr, $value:expr) ),* $(,)? ]) => {
+        $crate::status!(400, $body, [ $( ($key, $value) ),* ])
+    };
+    ($body:expr) => {
+        $crate::status!(400, $body)
     };
 }
 
@@ -373,7 +379,7 @@ macro_rules! headers {
 macro_rules! status {
     ($status:expr, { $($json:tt)* }) => {
         $crate::response!(
-            $crate::StatusCode::from_u16($status).unwrap_or($crate::StatusCode::OK),
+            $crate::http::StatusCode::from_u16($status).unwrap_or($crate::http::StatusCode::OK),
             $crate::HttpBody::json(serde_json::json_internal!({ $($json)* })),
             [
                 ($crate::headers::CONTENT_TYPE, "application/json"),
@@ -383,7 +389,7 @@ macro_rules! status {
     
     ($status:expr) => {
         $crate::response!(
-            $crate::StatusCode::from_u16($status).unwrap_or($crate::StatusCode::OK), 
+            $crate::http::StatusCode::from_u16($status).unwrap_or($crate::http::StatusCode::OK), 
             $crate::HttpBody::empty(),
             [
                 ($crate::headers::CONTENT_TYPE, "text/plain")
@@ -393,16 +399,24 @@ macro_rules! status {
     
     ($status:expr, [ $( ($key:expr, $value:expr) ),* $(,)? ]) => {
         $crate::response!(
-            $crate::StatusCode::from_u16($status).unwrap_or($crate::StatusCode::OK), 
+            $crate::http::StatusCode::from_u16($status).unwrap_or($crate::http::StatusCode::OK), 
             $crate::HttpBody::empty(),
             [ $( ($key, $value) ),* ]
         )
     };
     
-    ($status:expr, $e:expr) => {
+    ($status:expr, $body:expr, [ $( ($key:expr, $value:expr) ),* $(,)? ]) => {
         $crate::response!(
-            $crate::StatusCode::from_u16($status).unwrap_or($crate::StatusCode::OK),
-            $crate::HttpBody::json($e),
+            $crate::http::StatusCode::from_u16($status).unwrap_or($crate::http::StatusCode::OK), 
+            $crate::HttpBody::json($body),
+            [ $( ($key, $value) ),* ]
+        )
+    };
+    
+    ($status:expr, $body:expr) => {
+        $crate::response!(
+            $crate::http::StatusCode::from_u16($status).unwrap_or($crate::http::StatusCode::OK),
+            $crate::HttpBody::json($body),
             [
                 ($crate::headers::CONTENT_TYPE, "application/json"),
             ]
@@ -1048,6 +1062,25 @@ mod tests {
 
         assert_eq!(body.len(), 0);
         assert_eq!(response.status(), 400);
+        assert_eq!(response.headers().get("x-api-key").unwrap(), "some api key");
+        assert_eq!(response.headers().get("x-req-id").unwrap(), "some req id");
+    }
+
+    #[tokio::test]
+    async fn it_creates_empty_status_response_with_body_and_headers() {
+        let payload = TestPayload { name: "test".into() };
+        let response = status!(406, payload, [
+            ("x-api-key", "some api key"),
+            ("x-req-id", "some req id"),
+        ]);
+
+        assert!(response.is_ok());
+
+        let mut response = response.unwrap();
+        let body = &response.body_mut().collect().await.unwrap().to_bytes();
+
+        assert_eq!(String::from_utf8_lossy(body), "{\"name\":\"test\"}");
+        assert_eq!(response.status(), 406);
         assert_eq!(response.headers().get("x-api-key").unwrap(), "some api key");
         assert_eq!(response.headers().get("x-req-id").unwrap(), "some req id");
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! ## Example
 //! ```toml
 //! [dependencies]
-//! volga = "0.4.5"
+//! volga = "0.4.6"
 //! tokio = { version = "1", features = ["full"] }
 //! ```
 //! ```no_run
@@ -60,7 +60,7 @@ pub use crate::app::endpoints::args::{
 };
 
 pub mod routing {
-    pub  use crate::app::router::RouteGroup;
+    pub use crate::app::router::RouteGroup;
 }
 
 #[cfg(feature = "middleware")]
@@ -80,5 +80,12 @@ pub mod di {
     };
 }
 
+#[cfg(any(feature = "brotli", feature = "gzip"))]
+pub mod encoding {
+    pub use crate::app::encoding::Encoding;
+}
+
 // Re-exporting HTTP status codes, Response and some headers from hyper/http
-pub use hyper::{StatusCode, Response};
+pub mod http {
+    pub use hyper::{StatusCode, Response};
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,12 @@ pub mod di {
     };
 }
 
-#[cfg(any(feature = "brotli", feature = "gzip"))]
+#[cfg(any(
+    feature = "brotli",
+    feature = "gzip",
+    feature = "zstd",
+    feature = "compression-full"
+))]
 pub mod encoding {
     pub use crate::app::encoding::Encoding;
 }


### PR DESCRIPTION
* Added response compression feature with support of brotli, gzip, deflate and zstd algos

# Example

```toml
[dependencies]
volga = { version = "0.4.6", features = ["compression-full"] }
```

```rust
app.use_compression();
```