### PR TITLE
tls, tracing and static files improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ tracing = { version = "0.1.41", default-features = false, optional = true }
 reqwest = { version = "0.12.12", features = ["blocking", "json", "http2", "brotli", "deflate", "gzip", "zstd", "native-tls"] }
 serde = { version = "1.0.217", features = ["derive"] }
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
-uuid = { version = "1.12.1", features = ["v4"] }
+uuid = { version = "1.13.1", features = ["v4"] }
 criterion = { version = "0.5.1", features = ["async_tokio"] }
 
 [features]

--- a/examples/static_files.rs
+++ b/examples/static_files.rs
@@ -16,7 +16,8 @@ async fn main() -> std::io::Result<()> {
     // - redirects from "/" -> "/index.html" if presents
     // - redirects from "/{file_name}" -> "/file-name.ext"
     // - redirects to 404.html if unspecified route is requested
-    app.use_static_files();
+    app.map_group("/static")
+        .use_static_files();
 
     app.run().await
 }

--- a/examples/tls.rs
+++ b/examples/tls.rs
@@ -1,15 +1,15 @@
 ﻿use std::time::Duration;
-use volga::{App, Json, tls::TlsConfig, ok};
+use volga::{App, Json, ok};
 
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
     let mut app = App::new()
         .bind("127.0.0.1:7878")
-        .with_tls(TlsConfig::from_pem("examples/tls")
-            .with_https_redirection()
-            .with_http_port(7879)
-            .with_hsts_max_age(Duration::from_secs(30))
-            .with_hsts_exclude_hosts(&["example.com", "example.net"]));
+        .with_tls_from_pem("examples/tls")
+        .with_https_redirection()
+        .with_http_port(7879)
+        .with_hsts_max_age(Duration::from_secs(30))
+        .with_hsts_exclude_hosts(&["example.com", "example.net"]);
 
     app.use_hsts();
     

--- a/examples/tracing.rs
+++ b/examples/tracing.rs
@@ -1,4 +1,4 @@
-﻿use volga::{App, tracing::TracingConfig};
+﻿use volga::App;
 use tracing::trace;
 use tracing_subscriber::prelude::*;
 
@@ -9,13 +9,10 @@ async fn main() -> std::io::Result<()> {
         .with(tracing_subscriber::fmt::layer())
         .init();
     
-    // Configure tracing parameters
-    let tracing = TracingConfig::new()
-        .with_header()
-        .with_header_name("x-span-id");
-    
     let mut app = App::new()
-        .with_tracing(tracing);
+        .with_default_tracing()
+        .with_span_header()
+        .with_span_header_name("x-span-id");
 
     // this middleware won't be in the request span scope 
     // since it's defined above the tracing middleware

--- a/src/app/router.rs
+++ b/src/app/router.rs
@@ -279,8 +279,8 @@ impl App {
 
 /// Represents a group of routes
 pub struct RouteGroup<'a> {
-    app: &'a mut App,
-    prefix: &'a str,
+    pub(crate) app: &'a mut App,
+    pub(crate) prefix: &'a str,
 }
 
 macro_rules! define_route_group_methods({$($method:ident)*} => {

--- a/src/headers/cache_control.rs
+++ b/src/headers/cache_control.rs
@@ -6,6 +6,9 @@ use crate::error::Error;
 #[cfg(feature = "static-files")]
 use std::fs::Metadata;
 
+#[cfg(feature = "static-files")]
+const DEFAULT_MAX_AGE: u32 = 60 * 60 * 24; // 24 hours
+
 /// Represents the HTTP [`Cache-Control`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control)
 /// header holds directives (instructions) in both requests and responses that control caching 
 /// in browsers and shared caches (e.g., Proxies, CDNs).
@@ -107,11 +110,16 @@ impl From<CacheControl> for String {
 /// [`Last-Modified`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Last-Modified) and
 /// [`Cache-Control`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control)
 pub struct ResponseCaching {
-    /// Represents [`ETag`](https://developer.mozilla.org/ru/docs/Web/HTTP/Headers/ETag)
+    /// Represents 
+    /// [`ETag`](https://developer.mozilla.org/ru/docs/Web/HTTP/Headers/ETag)
     pub(crate) etag: ETag,
-    /// Represents [`Last-Modified`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Last-Modified)
+    
+    /// Represents 
+    /// [`Last-Modified`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Last-Modified)
     pub(crate) last_modified: SystemTime,
-    /// Represents [`Cache-Control`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control)
+    
+    /// Represents 
+    /// [`Cache-Control`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control)
     pub(crate) cache_control: CacheControl
 }
 
@@ -126,7 +134,7 @@ impl TryFrom<&Metadata> for ResponseCaching {
         let cache_control = CacheControl { 
             public: true, 
             immutable: true, 
-            max_age: Some(31536000), 
+            max_age: Some(DEFAULT_MAX_AGE), 
             ..Default::default()
         };
         
@@ -185,7 +193,7 @@ mod tests {
           cache_control: Default::default()
         };
         
-        assert_eq!(caching.etag(), "123");
+        assert_eq!(caching.etag(), "\"123\"");
     }
 
     #[test]

--- a/src/headers/etag.rs
+++ b/src/headers/etag.rs
@@ -12,6 +12,7 @@ use std::fs::Metadata;
 use std::time::UNIX_EPOCH;
 
 /// Represents Entity Tag (ETag) value
+#[derive(Debug, Clone)]
 pub struct ETag {
     inner: Cow<'static, str>,
 }
@@ -67,11 +68,25 @@ impl Display for ETag {
 impl ETag {
     #[inline]
     pub fn new(etag: &str) -> Self {
-        Self::from(etag.to_owned())
+        Self::from(format!("\"{etag}\""))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    
+    use crate::headers::ETag;
+
+    #[test]
+    fn it_creates_etag() {
+        let etag = ETag::new("foo");
+        
+        assert_eq!(etag.as_ref(), "\"foo\"");
+    }
+
+    #[test]
+    fn it_creates_etag_from_string() {
+        let etag = ETag::from(String::from("\"foo\""));
+
+        assert_eq!(etag.as_ref(), "\"foo\"");
+    }
 }

--- a/src/headers/helpers.rs
+++ b/src/headers/helpers.rs
@@ -12,15 +12,103 @@ use crate::headers::{
 #[allow(dead_code)]
 pub(crate) fn validate_etag(etag: &ETag, headers: &Headers) -> bool {
     headers.get(&IF_NONE_MATCH)
-        .map(|if_none_match| *if_none_match == etag.as_ref())
-        .unwrap_or(false)
+        .and_then(|if_none_match| if_none_match.to_str().ok())
+        .is_some_and(|value| value.split(',').any(|v| v.trim() == etag.as_ref()))
 }
 
 #[inline]
 #[allow(dead_code)]
 pub(crate) fn validate_last_modified(last_modified: SystemTime, headers: &Headers) -> bool {
-    let last_modified = Some(last_modified);
     headers.get(&IF_MODIFIED_SINCE)
-        .map(|if_modified_since| last_modified == if_modified_since.to_str().ok().and_then(|s| parse_http_date(s).ok()))
-        .unwrap_or(false)
+        .and_then(|if_modified_since| if_modified_since.to_str().ok())
+        .and_then(|if_modified_since| parse_http_date(if_modified_since).ok())
+        .is_some_and(|value| last_modified <= value)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+    use super::*;
+    use crate::headers::{
+        ETag, 
+        HeaderMap, HeaderValue, Headers,
+        IF_NONE_MATCH, IF_MODIFIED_SINCE
+    };
+
+    #[test]
+    fn it_validates_etag_list() {
+        let mut headers = HeaderMap::new();
+        headers.insert(IF_NONE_MATCH, HeaderValue::from_static("\"123\",\"321\",\"111\""));
+        
+        let headers = Headers::from(headers);
+        
+        assert!(validate_etag(&ETag::new("123"), &headers));
+    }
+
+    #[test]
+    fn it_validates_etag_not_present_in_list() {
+        let mut headers = HeaderMap::new();
+        headers.insert(IF_NONE_MATCH, HeaderValue::from_static("\"123\",\"321\",\"111\""));
+
+        let headers = Headers::from(headers);
+
+        assert!(!validate_etag(&ETag::new("555"), &headers));
+    }
+
+    #[test]
+    fn it_validates_etag_single() {
+        let mut headers = HeaderMap::new();
+        headers.insert(IF_NONE_MATCH, HeaderValue::from_static("\"123\""));
+
+        let headers = Headers::from(headers);
+
+        assert!(validate_etag(&ETag::new("123"), &headers));
+    }
+
+    #[test]
+    fn it_validates_etag_single_different_value() {
+        let mut headers = HeaderMap::new();
+        headers.insert(IF_NONE_MATCH, HeaderValue::from_static("\"123\""));
+
+        let headers = Headers::from(headers);
+
+        assert!(!validate_etag(&ETag::new("555"), &headers));
+    }
+
+    #[test]
+    fn it_validates_etag_when_if_none_match_missing() {
+        let headers = Headers::from(HeaderMap::new());
+
+        assert!(!validate_etag(&ETag::new("123"), &headers));
+    }
+    
+    #[test]
+    fn it_validates_last_modified() {
+        let now = SystemTime::now();
+        let mut headers = HeaderMap::new();
+        headers.insert(IF_MODIFIED_SINCE, HeaderValue::from_str(&httpdate::fmt_http_date(now)).unwrap());
+
+        let headers = Headers::from(headers);
+
+        assert!(validate_last_modified(now - Duration::from_secs(10), &headers));
+    }
+
+    #[test]
+    fn it_validates_last_modified_resource_has_been_updated() {
+        let now = SystemTime::now();
+        let mut headers = HeaderMap::new();
+        headers.insert(IF_MODIFIED_SINCE, HeaderValue::from_str(&httpdate::fmt_http_date(now)).unwrap());
+
+        let headers = Headers::from(headers);
+
+        assert!(!validate_last_modified(now + Duration::from_secs(10), &headers));
+    }
+
+    #[test]
+    fn it_validates_last_modified_when_if_modified_since_missing() {
+        let now = SystemTime::now();
+        let headers = Headers::from(HeaderMap::new());
+
+        assert!(!validate_last_modified(now, &headers));
+    }
 }


### PR DESCRIPTION
* Added shortcuts to simplify TLS, Tracing, and Static Files configuration
* Added ability to use `map_group` along with `use_static_files()` to add some prefix to static files requests
* Several improvements for static files serving