### PR TITLE
Websocket improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ serde_urlencoded = "0.7.1"
 # optional
 async-compression = { version = "0.4.18", features = ["tokio"], optional = true }
 base64 = { version = "0.22.1", optional = true }
-chrono = { version = "0.4.39", optional = true }
+chrono = { version = "0.4.40", optional = true }
 handlebars = { version = "6.3.1", optional = true }
 httpdate = { version = "1.0.3", optional = true }
 hyper = { version = "1.6.0", features = ["server"], optional = true }
@@ -47,7 +47,7 @@ hyper = { version = "1.6.0", features = ["client"] }
 reqwest = { version = "0.12.12", features = ["blocking", "json", "http2", "brotli", "deflate", "gzip", "zstd", "native-tls"] }
 serde = { version = "1.0.218", features = ["derive"] }
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
-uuid = { version = "1.13.2", features = ["v4"] }
+uuid = { version = "1.15.0", features = ["v4"] }
 criterion = { version = "0.5.1", features = ["async_tokio"] }
 
 [features]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Volga
 Fast, Easy, and very flexible Web Framework for Rust based on [Tokio](https://tokio.rs/) runtime and [hyper](https://hyper.rs/) for fun and painless microservices crafting.
 
-[![latest](https://img.shields.io/badge/latest-0.5.3-blue)](https://crates.io/crates/volga)
+[![latest](https://img.shields.io/badge/latest-0.5.4-blue)](https://crates.io/crates/volga)
 [![latest](https://img.shields.io/badge/rustc-1.80+-964B00)](https://crates.io/crates/volga)
 [![License: MIT](https://img.shields.io/badge/License-MIT-violet.svg)](https://github.com/RomanEmreis/volga/blob/main/LICENSE)
 [![Build](https://github.com/RomanEmreis/volga/actions/workflows/rust.yml/badge.svg)](https://github.com/RomanEmreis/volga/actions/workflows/rust.yml)
@@ -21,7 +21,7 @@ Fast, Easy, and very flexible Web Framework for Rust based on [Tokio](https://to
 ### Dependencies
 ```toml
 [dependencies]
-volga = "0.5.3"
+volga = "0.5.4"
 tokio = { version = "1", features = ["full"] }
 ```
 ### Simple request handler
@@ -34,7 +34,7 @@ async fn main() -> std::io::Result<()> {
     let mut app = App::new();
 
     // Example of request handler
-    app.map_get("/hello/{name}", |name: String| async move {
+    app.map_get("/hello/{name}", async |name: String| {
         ok!("Hello {name}!")
     });
     

--- a/examples/websockets.rs
+++ b/examples/websockets.rs
@@ -8,7 +8,6 @@ use volga::{
 
 use std::sync::{Arc, RwLock};
 use tracing_subscriber::prelude::*;
-use futures_util::{SinkExt, StreamExt};
 
 type Counter = Arc<RwLock<i32>>;
 
@@ -36,11 +35,11 @@ async fn main() -> std::io::Result<()> {
         let (mut sender, mut receiver) = ws.split();
 
         tokio::task::spawn(async move {
-            let _ = sender.send("Hello from WebSockets server!".into()).await;
+            let _ = sender.send("Hello from WebSockets server!").await;
         });
         
         tokio::task::spawn(async move {
-            while let Some(Ok(msg)) = receiver.next().await {
+            while let Some(Ok(msg)) = receiver.recv::<String>().await {
                 let value = inc(&counter).await;
                 tracing::info!("received: {msg}; msg #{value}")
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //! ## Example
 //! ```toml
 //! [dependencies]
-//! volga = "0.5.3"
+//! volga = "0.5.4"
 //! tokio = { version = "1", features = ["full"] }
 //! ```
 //! ```no_run
@@ -26,7 +26,7 @@
 //!     let mut app = App::new();
 //! 
 //!     // Example of request handler
-//!     app.map_get("/hello/{name}", |name: String| async move {
+//!     app.map_get("/hello/{name}", async |name: String| {
 //!          ok!("Hello {name}!")
 //!     });
 //!     

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -9,8 +9,7 @@ pub use self::{
     connection::WebSocketConnection,
     websocket::WebSocket,
     args::{
-        FromMessage, 
-        IntoMessage, 
+        Message,
         MessageHandler, 
         WebSocketHandler
     }
@@ -162,8 +161,8 @@ impl App {
     where
         F: MessageHandler<M, Args, Output = R> + 'static,
         Args: FromRequest + Clone + Send + Sync + 'static,
-        M: FromMessage + Send,
-        R: IntoMessage + Send
+        M: TryFrom<Message, Error = Error> + Send,
+        R: TryInto<Message, Error = Error> + Send
     {
         self.map_conn(pattern, move |req: HttpRequest| {
             let handler = handler.clone();

--- a/src/ws/websocket.rs
+++ b/src/ws/websocket.rs
@@ -1,15 +1,12 @@
 use crate::{error::Error, headers::HeaderValue};
-use super::{FromMessage, IntoMessage};
+use super::Message;
 
-use futures_util::{  
-    sink::{Sink, SinkExt},
-    stream::{
-        Stream,
-        StreamExt, 
-        SplitSink, 
-        SplitStream
-    }
-};
+use futures_util::{sink::{Sink, SinkExt}, stream::{
+    Stream,
+    StreamExt,
+    SplitSink,
+    SplitStream
+}};
 
 use hyper_util::rt::TokioIo;
 use hyper::upgrade::Upgraded;
@@ -20,13 +17,48 @@ use std::{
     task::{ready, Context, Poll}
 };
 
-use tokio_tungstenite::{
-    tungstenite::Message,
-    WebSocketStream,
-};
+use tokio_tungstenite::{tungstenite, WebSocketStream};
 
-pub type WsSink = SplitSink<WebSocketStream<TokioIo<Upgraded>>, Message>;
-pub type WsStream = SplitStream<WebSocketStream<TokioIo<Upgraded>>>;
+/// A [`Sink`] part of [`WebSocket`] split 
+pub struct WsSink(SplitSink<WebSocketStream<TokioIo<Upgraded>>, tungstenite::Message>);
+
+/// A [`Stream`] part of [`WebSocket`] split
+pub struct WsStream(SplitStream<WebSocketStream<TokioIo<Upgraded>>>);
+
+impl WsSink {
+    /// Unwraps the inner [`Sink`]
+    #[inline]
+    pub fn into_inner(self) -> SplitSink<WebSocketStream<TokioIo<Upgraded>>, tungstenite::Message> {
+        self.0
+    }
+    
+    /// Sends a message.
+    #[inline]
+    pub async fn send<T: TryInto<Message, Error = Error>>(&mut self, msg: T) -> Result<(), Error> {
+        let msg = msg.try_into()?.into();
+        self.0.send(msg)
+            .await
+            .map_err(Error::from)
+    }
+}
+
+impl WsStream {
+    /// Unwraps the inner [`Stream`]
+    #[inline]
+    pub fn into_inner(self) -> SplitStream<WebSocketStream<TokioIo<Upgraded>>> {
+        self.0
+    }
+    
+    /// Receives a message.
+    #[inline]
+    pub async fn recv<T: TryFrom<Message, Error = Error>>(&mut self) -> Option<Result<T, Error>> {
+        self.0.next()
+            .await
+            .map(|result| result
+                .map_err(Error::from)
+                .and_then(|msg| T::try_from(Message(msg))))
+    }    
+}
 
 /// Represents a stream of WebSocket messages.
 pub struct WebSocket {
@@ -46,18 +78,18 @@ impl WebSocket {
 
     /// Receives a message.
     #[inline]
-    pub async fn recv<T: FromMessage>(&mut self) -> Option<Result<T, Error>> {
+    pub async fn recv<T: TryFrom<Message, Error = Error>>(&mut self) -> Option<Result<T, Error>> {
         self.next()
             .await
-            .map(|r| r.and_then(|msg| T::from_message(msg)))
+            .map(|r| r.and_then(|msg| T::try_from(msg)))
     }
 
     /// Sends a message.
     #[inline]
-    pub async fn send<T: IntoMessage>(&mut self, msg: T) -> Result<(), Error> {
-        let msg = msg.into_message()?;
+    pub async fn send<T: TryInto<Message, Error = Error>>(&mut self, msg: T) -> Result<(), Error> {
+        let msg = msg.try_into()?;
         self.inner
-            .send(msg)
+            .send(msg.into_inner())
             .await
             .map_err(Error::from)
     }
@@ -72,7 +104,8 @@ impl WebSocket {
     /// or allow direct interaction between the two objects (e.g. via `Sink::send_all`).
     #[inline]
     pub fn split(self) -> (WsSink, WsStream) {
-        self.inner.split()
+        let (tx, rx) = self.inner.split();
+        (WsSink(tx), WsStream(rx))
     }
 
     /// Maps a `handler` that has to be called every time a message is received.
@@ -80,8 +113,8 @@ impl WebSocket {
     pub async fn on_msg<F, M, R, Fut>(&mut self, handler: F)
     where
         F: Fn(M) -> Fut + Send + 'static,
-        M: FromMessage,
-        R: IntoMessage,
+        M: TryFrom<Message, Error = Error>,
+        R: TryInto<Message, Error = Error>,
         Fut: Future<Output = R> + Send
     {
         while let Some(msg) = self.recv::<M>().await {
@@ -102,7 +135,7 @@ impl Stream for WebSocket {
                 None => return Poll::Ready(None),
                 Some(Err(err)) => return Poll::Ready(Some(Err(err.into()))),
                 Some(Ok(msg)) => {
-                    let Message::Frame(_) = msg else { return Poll::Ready(Some(Ok(msg))) };
+                    let tungstenite::Message::Frame(_) = msg else { return Poll::Ready(Some(Ok(Message(msg)))) };
                 }
             }
         }
@@ -122,7 +155,7 @@ impl Sink<Message> for WebSocket {
 
     #[inline]
     fn start_send(mut self: Pin<&mut Self>, item: Message) -> Result<(), Self::Error> {
-        match Pin::new(&mut self.inner).start_send(item) {
+        match Pin::new(&mut self.inner).start_send(item.0) {
             Ok(_) => Ok(()),
             Err(err) => Err(Error::server_error(err))
         }


### PR DESCRIPTION
* Removed `FromMessage` and `IntoMessage` now there are several `TryFrom` implementations for most used types.
* Introduced a `Message` type that wraps a `tungstenite::Message` internally