### PR TITLE
Changed design of `with_tls`, `with_tracing`, `with_host_env` and `with_hsts` methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,10 @@ name = "tracing"
 required-features = ["tracing"]
 
 [[test]]
+name = "static_files"
+required-features = ["static-files"]
+
+[[test]]
 name = "ws"
 required-features = ["ws"]
 

--- a/examples/global_error_handler.rs
+++ b/examples/global_error_handler.rs
@@ -1,7 +1,6 @@
 ﻿use volga::{App, problem};
 use std::io::Error;
 use tracing_subscriber::prelude::*;
-use volga::tracing::TracingConfig;
 
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
@@ -10,7 +9,7 @@ async fn main() -> std::io::Result<()> {
         .init();
     
     let mut app = App::new()
-        .with_tracing(TracingConfig::new().with_header());
+        .with_tracing(|tracing| tracing.with_header());
     
     app.use_tracing();
     

--- a/src/app/env.rs
+++ b/src/app/env.rs
@@ -132,7 +132,20 @@ impl App {
     /// Defaults:
     /// - content_root: `/`
     /// - index_path: `index.html`
-    pub fn with_hosting_environment(mut self, env: HostEnv) -> Self {
+    pub fn with_host_environment<T>(mut self, config: T) -> Self
+    where
+        T: FnOnce(HostEnv) -> HostEnv
+    {
+        self.host_env = config(self.host_env);
+        self
+    }
+
+    /// Configures web server's hosting environment
+    ///
+    /// Defaults:
+    /// - content_root: `/`
+    /// - index_path: `index.html`
+    pub fn set_host_environment(mut self, env: HostEnv) -> Self {
         self.host_env = env;
         self
     }
@@ -298,6 +311,19 @@ mod tests {
         let app = App::new()
             .with_fallback_file("404.html")
             .with_content_root("tests/resources");
+
+        assert_eq!(app.host_env.content_root, PathBuf::from("tests/resources"));
+        assert_eq!(app.host_env.index_path, PathBuf::from("tests/resources/index.html"));
+        assert_eq!(app.host_env.fallback_path, Some(PathBuf::from("tests/resources/404.html")));
+        assert!(!app.host_env.show_directory);
+    }
+
+    #[test]
+    fn it_updates_fallback_file_with_content_root_via_with_host_environment() {
+        let app = App::new()
+            .with_content_root("tests/resources")
+            .with_host_environment(|env| env
+                .with_fallback_file("404.html"));
 
         assert_eq!(app.host_env.content_root, PathBuf::from("tests/resources"));
         assert_eq!(app.host_env.index_path, PathBuf::from("tests/resources/index.html"));

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -65,13 +65,45 @@ impl App {
         self.tracing_config = Some(TracingConfig::default());
         self
     }
+
+    /// Configures web server with specific Tracing configurations.
+    ///
+    /// Defaults:
+    /// - include_header: `false`
+    /// - span_header_name: `request-id`
+    /// 
+    /// # Example
+    /// ```no_run
+    /// use volga::App;
+    ///
+    /// let app = App::new()
+    ///     .with_tracing(|config| config.with_header());
+    /// ```
+    /// 
+    /// If tracing was already preconfigured, it does not overwrite it
+    /// ```no_run
+    /// use volga::App;
+    /// use volga::tracing::TracingConfig;
+    ///
+    /// let app = App::new()
+    ///     .set_tracing(TracingConfig::new().with_header()) // sets include_header to true 
+    ///     .with_tracing(|config| config
+    ///         .with_header_name("x-span-id"));               // sets a specific header name, include_header remains true
+    /// ```
+    pub fn with_tracing<T>(mut self, config: T) -> Self 
+    where
+        T : FnOnce(TracingConfig) -> TracingConfig
+    {
+        self.tracing_config = Some(config(self.tracing_config.unwrap_or_default()));
+        self
+    }
     
     /// Configures web server with specific Tracing configurations
     ///
     /// Defaults:
     /// - include_header: `false`
     /// - span_header_name: `request-id`
-    pub fn with_tracing(mut self, config: TracingConfig) -> Self {
+    pub fn set_tracing(mut self, config: TracingConfig) -> Self {
         self.tracing_config = Some(config);
         self
     }
@@ -125,7 +157,7 @@ impl App {
     ///
     /// let mut app = App::new();
     /// // is equivalent to:
-    /// let mut app = App::new().with_tracing(TracingConfig::default());
+    /// let mut app = App::new().set_tracing(TracingConfig::default());
     ///
     /// // if the tracing middleware is enabled
     /// app.use_tracing(); 

--- a/tests/static_files.rs
+++ b/tests/static_files.rs
@@ -1,0 +1,72 @@
+﻿use volga::App;
+
+#[tokio::test]
+async fn it_responds_with_index_file() {
+    tokio::spawn(async {
+        let mut app = App::new()
+            .bind("127.0.0.1:7831")
+            .with_content_root("tests/static");
+        app.use_static_files();
+        app.run().await
+    });
+
+    let response = tokio::spawn(async {
+        let client = if cfg!(all(feature = "http1", not(feature = "http2"))) {
+            reqwest::Client::builder().http1_only().build().unwrap()
+        } else {
+            reqwest::Client::builder().http2_prior_knowledge().build().unwrap()
+        };
+        client.get("http://127.0.0.1:7831").send().await
+    }).await.unwrap().unwrap();
+
+    assert!(response.status().is_success());
+    assert_eq!(response.headers().get("Content-Type").unwrap(), "text/html");
+}
+
+#[tokio::test]
+async fn it_responds_with_fallback_file() {
+    tokio::spawn(async {
+        let mut app = App::new()
+            .bind("127.0.0.1:7832")
+            .with_content_root("tests/static")
+            .with_fallback_file("index.html");
+        app.map_group("/static").use_static_files();
+        app.run().await
+    });
+
+    let response = tokio::spawn(async {
+        let client = if cfg!(all(feature = "http1", not(feature = "http2"))) {
+            reqwest::Client::builder().http1_only().build().unwrap()
+        } else {
+            reqwest::Client::builder().http2_prior_knowledge().build().unwrap()
+        };
+        client.get("http://127.0.0.1:7832/test/thing").send().await
+    }).await.unwrap().unwrap();
+
+    assert!(response.status().is_success());
+    assert_eq!(response.headers().get("Content-Type").unwrap(), "text/html");
+}
+
+#[tokio::test]
+async fn it_responds_with_files_listing() {
+    tokio::spawn(async {
+        let mut app = App::new()
+            .bind("127.0.0.1:7833")
+            .with_content_root("tests/static")
+            .with_files_listing();
+        app.use_static_files();
+        app.run().await
+    });
+
+    let response = tokio::spawn(async {
+        let client = if cfg!(all(feature = "http1", not(feature = "http2"))) {
+            reqwest::Client::builder().http1_only().build().unwrap()
+        } else {
+            reqwest::Client::builder().http2_prior_knowledge().build().unwrap()
+        };
+        client.get("http://127.0.0.1:7833").send().await
+    }).await.unwrap().unwrap();
+
+    assert!(response.status().is_success());
+    assert_eq!(response.headers().get("Content-Type").unwrap(), "text/html; charset=utf-8");
+}

--- a/tests/tls.rs
+++ b/tests/tls.rs
@@ -9,7 +9,7 @@ async fn it_works_with_tls_with_no_auth() {
     tokio::spawn(async {
         let mut app = App::new()
             .bind("127.0.0.1:7921")
-            .with_tls(TlsConfig::from_pem_files(
+            .set_tls(TlsConfig::from_pem_files(
                 "tests/tls/server.pem",
                 "tests/tls/server.key"));
         
@@ -44,7 +44,7 @@ async fn it_works_with_tls_with_required_auth_authenticated() {
     tokio::spawn(async {
         let mut app = App::new()
             .bind("127.0.0.1:7922")
-            .with_tls(TlsConfig::new()
+            .with_tls(|tls| tls
                 .with_cert_path("tests/tls/server.pem")
                 .with_key_path("tests/tls/server.key")
                 .with_required_client_auth("tests/tls/ca.pem"));
@@ -95,10 +95,10 @@ async fn it_works_with_tls_with_required_auth_unauthenticated() {
     tokio::spawn(async {
         let mut app = App::new()
             .bind("127.0.0.1:7923")
-            .with_tls(TlsConfig::from_pem_files(
+            .set_tls(TlsConfig::from_pem_files(
                 "tests/tls/server.pem",
-                "tests/tls/server.key")
-                .with_required_client_auth("tests/tls/ca.pem"));
+                "tests/tls/server.key"))
+            .with_required_client_auth("tests/tls/ca.pem");
         
         app.map_get("/tls", || async {
             "Pass!"
@@ -139,10 +139,10 @@ async fn it_works_with_tls_with_optional_auth_authenticated() {
     tokio::spawn(async {
         let mut app = App::new()
             .bind("127.0.0.1:7924")
-            .with_tls(TlsConfig::from_pem_files(
+            .set_tls(TlsConfig::from_pem_files(
                 "tests/tls/server.pem",
-                "tests/tls/server.key")
-                .with_optional_client_auth("tests/tls/ca.pem"));
+                "tests/tls/server.key"))
+            .with_optional_client_auth("tests/tls/ca.pem");
         
         app.map_get("/tls", || async {
             "Pass!"
@@ -190,7 +190,7 @@ async fn it_works_with_tls_with_optional_auth_unauthenticated() {
     tokio::spawn(async {
         let mut app = App::new()
             .bind("127.0.0.1:7925")
-            .with_tls(TlsConfig::default()
+            .with_tls(|tls| tls
                 .with_cert_path("tests/tls/server.pem")
                 .with_key_path("tests/tls/server.key")
                 .with_optional_client_auth("tests/tls/ca.pem"));
@@ -234,11 +234,11 @@ async fn it_works_with_tls_with_required_auth_authenticated_and_https_redirectio
     tokio::spawn(async {
         let mut app = App::new()
             .bind(([127,0,0,1], 7926))
-            .with_tls(TlsConfig::from_pem_files(
+            .set_tls(TlsConfig::from_pem_files(
                 "tests/tls/server.pem",
-                "tests/tls/server.key")
-                .with_https_redirection()
-                .with_http_port(7927))
+                "tests/tls/server.key"))
+            .with_https_redirection()
+            .with_http_port(7927)
             .with_hsts_preload(false)
             .with_hsts_sub_domains(true)
             .with_hsts_max_age(Duration::from_secs(60))

--- a/tests/tracing.rs
+++ b/tests/tracing.rs
@@ -1,7 +1,6 @@
 ﻿use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use volga::{App, Results};
-use volga::tracing::TracingConfig;
 
 #[tokio::test]
 async fn it_adds_request_id() {
@@ -12,8 +11,7 @@ async fn it_adds_request_id() {
         
         let mut app = App::new()
             .bind("127.0.0.1:7830")
-            .with_tracing(TracingConfig::default()
-                .with_header());
+            .with_tracing(|tracing| tracing.with_header());
         app.use_tracing();
         app.map_get("/test", || async {
             Results::text("Pass!")


### PR DESCRIPTION
# Breaking Changes  

* **`App::with_hosting_environment()`** has been **renamed and redesigned**. The previous functionality is now available via **`set_host_environment()`**.  
* Introduced a new **`with_host_environment()`** method, which accepts a closure for configuring the existing `HostEnv` instance.  

* **`App::with_tracing()`** has been **renamed and redesigned**. The previous functionality is now provided by **`set_tracing()`**.  
* Introduced a new **`with_tracing()`** method, which accepts a closure to configure the existing `TracingConfig` instance. If `TracingConfig` is `None`, a default instance is created.  

* **`App::with_tls()`** has been **renamed and redesigned**. The previous functionality is now provided by **`set_tls()`**.  
* Introduced a new **`with_tls()`** method, which accepts a closure to configure the existing `TlsConfig` instance. If `TlsConfig` is `None`, a default instance is created.  

* **`App::with_hsts()`** has been **renamed and redesigned**. The previous functionality is now provided by **`set_hsts()`**.  
* Introduced a new **`with_hsts()`** method, which accepts a closure to configure the existing `HstsConfig` instance.  