### PR TITLE
Authorization and Authentication tools

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ pin-project-lite = "0.2.16"
 tokio = { version = "1.46.1", features = ["full"] }
 tokio-util = "0.7.15"
 serde = "1.0.219"
-serde_json = "1.0.140"
+serde_json = "1.0.141"
 serde_urlencoded = "0.7.1"
 
 # optional

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,8 @@ serde_urlencoded = "0.7.1"
 async-compression = { version = "0.4.27", features = ["tokio"], optional = true }
 base64 = { version = "0.22.1", optional = true }
 chrono = { version = "0.4.41", optional = true }
-cookie = { version = "0.18.1", features = ["percent-encode"], optional = true } 
+cookie = { version = "0.18.1", features = ["percent-encode"], optional = true }
+jsonwebtoken = { version = "9.3.1", optional = true }
 handlebars = { version = "6.3.2", optional = true }
 httpdate = { version = "1.0.3", optional = true }
 hyper = { version = "1.6.0", features = ["server"], optional = true }
@@ -46,6 +47,7 @@ tokio-tungstenite = { version = "0.27.0", optional = true }
 tracing = { version = "0.1.41", default-features = false, optional = true }
 
 [dev-dependencies]
+jsonwebtoken = "9.3.1"
 hyper = { version = "1.6.0", features = ["client"] }
 reqwest = { version = "0.12.22", features = ["blocking", "multipart", "stream", "json", "http2", "brotli", "deflate", "gzip", "zstd", "native-tls"] }
 serde = { version = "1.0.219", features = ["derive"] }
@@ -61,6 +63,7 @@ default = ["http1"]
 full = [
     "http1", 
     "http2",
+    "auth",
     "middleware", 
     "di",
     "tls",
@@ -77,6 +80,9 @@ full = [
 http1 = ["dep:hyper", "hyper?/http1", "dep:hyper-util", "hyper-util?/http1", "dep:httpdate"]
 http2 = ["dep:hyper", "hyper?/http2", "dep:hyper-util", "hyper-util?/http2", "dep:httpdate"]
 
+auth = ["basic-auth", "jwt-auth"]
+basic-auth = ["dep:base64", "middleware"]
+jwt-auth = ["dep:jsonwebtoken", "middleware"]
 di = []
 middleware = []
 multipart = ["dep:multer"]
@@ -272,7 +278,7 @@ path = "examples/sse.rs"
 [[example]]
 name = "cookies"
 path = "examples/cookies.rs"
-required-features = ["cookie"]
+required-features = ["cookie","basic-auth"]
 
 [[example]]
 name = "signed_cookies"
@@ -293,3 +299,8 @@ required-features = ["middleware"]
 name = "response_handler"
 path = "examples/response_handler.rs"
 required-features = ["middleware"]
+
+[[example]]
+name = "jwt"
+path = "examples/jwt.rs"
+required-features = ["jwt-auth","middleware"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,16 @@ all-features = true
 name = "server"
 harness = false
 
+[[bench]]
+name = "di"
+harness = false
+required-features = ["di"]
+
+[[bench]]
+name = "mw"
+harness = false
+required-features = ["middleware"]
+
 [[test]]
 name = "middleware_mapping_tests"
 required-features = ["middleware"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ tokio-tungstenite = { version = "0.27.0", optional = true }
 tracing = { version = "0.1.41", default-features = false, optional = true }
 
 [dev-dependencies]
+base64 = { version = "0.22.1" }
 jsonwebtoken = "9.3.1"
 hyper = { version = "1.6.0", features = ["client"] }
 reqwest = { version = "0.12.22", features = ["blocking", "multipart", "stream", "json", "http2", "brotli", "deflate", "gzip", "zstd", "native-tls"] }
@@ -123,6 +124,11 @@ required-features = ["di"]
 name = "mw"
 harness = false
 required-features = ["middleware"]
+
+[[bench]]
+name = "auth"
+harness = false
+required-features = ["jwt-auth","middleware"]
 
 [[test]]
 name = "middleware_mapping_tests"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,6 +149,10 @@ required-features = ["middleware"]
 [[test]]
 name = "sse"
 
+[[test]]
+name = "jwt"
+required-features = ["jwt-auth", "middleware"]
+
 [[example]]
 name = "hello_world"
 path = "examples/hello_world.rs"

--- a/benches/auth.rs
+++ b/benches/auth.rs
@@ -1,4 +1,4 @@
-use volga::App;
+use volga::{App, claims};
 
 use std::hint::black_box;
 use criterion::{criterion_group, criterion_main, Criterion};
@@ -9,7 +9,7 @@ use tokio::{runtime::Runtime, time::Instant};
 use std::time::Duration;
 use jsonwebtoken::{DecodingKey, EncodingKey};
 use serde::{Deserialize, Serialize};
-use volga::auth::{roles, AuthClaims};
+use volga::auth::roles;
 
 const TEST_TOKEN: &str = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJlbWFpbC5jb20iLCJjb21wYW55IjoiQXdlc29tZSBDby4iLCJyb2xlIjoiYWRtaW4iLCJleHAiOjE3NTMwMDEzODl9.5g6aE4KpRobZqsS8WFJndbHYakG6GydPtIpKt3L1X5o";
 
@@ -70,17 +70,13 @@ fn benchmark(c: &mut Criterion) {
 criterion_group!(benches, benchmark);
 criterion_main!(benches);
 
-#[derive(Serialize, Deserialize)]
-struct Claims {
-    sub: String,
-    company: String,
-    role: String,
-    permissions: Vec<String>,
-    exp: u64,
-}
-
-impl AuthClaims for Claims {
-    fn role(&self) -> Option<&str> {
-        Some(&self.role)
+claims! {
+    #[derive(Serialize, Deserialize)]
+    struct Claims {
+        sub: String,
+        company: String,
+        role: String,
+        permissions: Vec<String>,
+        exp: u64,
     }
 }

--- a/benches/auth.rs
+++ b/benches/auth.rs
@@ -1,0 +1,86 @@
+use volga::App;
+
+use std::hint::black_box;
+use criterion::{criterion_group, criterion_main, Criterion};
+use futures_util::future::join_all;
+use reqwest::Client;
+use tokio::{runtime::Runtime, time::Instant};
+
+use std::time::Duration;
+use jsonwebtoken::{DecodingKey, EncodingKey};
+use serde::{Deserialize, Serialize};
+use volga::auth::{roles, AuthClaims};
+
+const TEST_TOKEN: &str = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJlbWFpbC5jb20iLCJjb21wYW55IjoiQXdlc29tZSBDby4iLCJyb2xlIjoiYWRtaW4iLCJleHAiOjE3NTMwMDEzODl9.5g6aE4KpRobZqsS8WFJndbHYakG6GydPtIpKt3L1X5o";
+
+async fn routing(iters: u64, url: &str, token: &str) -> Duration {
+    #[cfg(all(feature = "http1", not(feature = "http2")))]
+    let client = Client::builder().http1_only().build().unwrap();
+    #[cfg(feature = "http2")]
+    let client = Client::builder().http2_prior_knowledge().build().unwrap();
+
+    let url = format!("http://localhost:7878{url}");
+
+    let start = Instant::now();
+
+    let requests = (0..iters).map(|_| client.get(&url)
+        .header(volga::headers::AUTHORIZATION, format!("Bearer {token}"))
+        .send());
+    
+    let responses = join_all(requests).await;
+
+    let elapsed = start.elapsed();
+
+    let failed = responses.iter().filter(|r| r.is_err()).count();
+    if failed > 0 {
+        eprintln!("failed {failed} requests");
+    };
+    elapsed
+}
+
+fn benchmark(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    rt.block_on(async {
+        tokio::spawn(async {
+            let mut app = App::new()
+                .with_no_delay()
+                .without_body_limit()
+                .without_greeter()
+                .with_bearer_auth(|auth| auth
+                    .validate_exp(false)
+                    .set_encoding_key(EncodingKey::from_secret(b"test secret"))
+                    .set_decoding_key(DecodingKey::from_secret(b"test secret")));
+
+            app.map_get("/protected", || async { "Hello, World!" })
+                .authorize::<Claims>(roles(["admin", "user"]));
+            
+            _ = app.run().await;
+        });
+    });
+
+    c.bench_function("unauthorized", |b| b.iter_custom(
+        |iters| rt.block_on(routing(iters, black_box("/protected"), "invalid"))
+    ));
+
+    c.bench_function("protected", |b| b.iter_custom(
+        |iters| rt.block_on(routing(iters, black_box("/protected"), TEST_TOKEN))
+    ));
+}
+
+criterion_group!(benches, benchmark);
+criterion_main!(benches);
+
+#[derive(Serialize, Deserialize)]
+struct Claims {
+    sub: String,
+    company: String,
+    role: String,
+    permissions: Vec<String>,
+    exp: u64,
+}
+
+impl AuthClaims for Claims {
+    fn role(&self) -> Option<&str> {
+        Some(&self.role)
+    }
+}

--- a/benches/di.rs
+++ b/benches/di.rs
@@ -1,4 +1,6 @@
-﻿use volga::{status, App};
+use volga::App;
+
+use volga::di::Dc;
 
 use std::hint::black_box;
 use criterion::{criterion_group, criterion_main, Criterion};
@@ -7,7 +9,7 @@ use reqwest::Client;
 use tokio::{runtime::Runtime, time::Instant};
 
 use std::{
-    io::Error,
+    sync::{Arc, RwLock},
     time::Duration
 };
 
@@ -18,14 +20,14 @@ async fn routing(iters: u64, url: &str) -> Duration {
     let client = Client::builder().http2_prior_knowledge().build().unwrap();
 
     let url = format!("http://localhost:7878{url}");
-    
+
     let start = Instant::now();
-    
+
     let requests = (0..iters).map(|_| client.get(&url).send());
     let responses = join_all(requests).await;
-    
+
     let elapsed = start.elapsed();
-    
+
     let failed = responses.iter().filter(|r| r.is_err()).count();
     if failed > 0 {
         eprintln!("failed {failed} requests");
@@ -41,25 +43,37 @@ fn benchmark(c: &mut Criterion) {
                 .with_no_delay()
                 .without_body_limit()
                 .without_greeter();
-            
-            app.map_get("/", || async { "Hello, World!" });
-            app.map_get("/err", || async { Error::other("error") });
-            app.map_err(|err: volga::error::Error| async move { status!(500, err.to_string()) });
-            app.map_fallback(|| async { status!(404) });
+
+            app.add_singleton(Counter::default());
+            app.add_scoped::<Cache>();
+            app.add_transient::<Transient>();
+            app.map_post("/singleton", |c: Dc<Counter>| async move { *c.0.write().unwrap() += 1; });
+            app.map_post("/scoped", |c: Dc<Cache>| async move { c.0.write().unwrap().push(1); });
+            app.map_put("/transient", |c: Dc<Transient>| async move { let _ = c; });
+
             _ = app.run().await;
         });
     });
-    
-    c.bench_function("ok", |b| b.iter_custom(
-        |iters| rt.block_on(routing(iters, black_box("/")))
+
+    c.bench_function("singleton", |b| b.iter_custom(
+        |iters| rt.block_on(routing(iters, black_box("/singleton")))
     ));
-    c.bench_function("err", |b| b.iter_custom(
-        |iters| rt.block_on(routing(iters, black_box("/err")))
+    c.bench_function("scoped", |b| b.iter_custom(
+        |iters| rt.block_on(routing(iters, black_box("/scoped")))
     ));
-    c.bench_function("fallback", |b| b.iter_custom(
-        |iters| rt.block_on(routing(iters, black_box("/fall")))
+    c.bench_function("transient", |b| b.iter_custom(
+        |iters| rt.block_on(routing(iters, black_box("/transient")))
     ));
 }
 
 criterion_group!(benches, benchmark);
 criterion_main!(benches);
+
+#[derive(Default, Clone, Debug)]
+struct Counter(Arc<RwLock<i32>>);
+
+#[derive(Default, Clone, Debug)]
+struct Cache(Arc<RwLock<Vec<i32>>>);
+
+#[derive(Default, Clone, Debug)]
+struct Transient;

--- a/benches/mw.rs
+++ b/benches/mw.rs
@@ -1,4 +1,4 @@
-﻿use volga::{status, App};
+use volga::App;
 
 use std::hint::black_box;
 use criterion::{criterion_group, criterion_main, Criterion};
@@ -6,10 +6,7 @@ use futures_util::future::join_all;
 use reqwest::Client;
 use tokio::{runtime::Runtime, time::Instant};
 
-use std::{
-    io::Error,
-    time::Duration
-};
+use std::time::Duration;
 
 async fn routing(iters: u64, url: &str) -> Duration {
     #[cfg(all(feature = "http1", not(feature = "http2")))]
@@ -18,14 +15,14 @@ async fn routing(iters: u64, url: &str) -> Duration {
     let client = Client::builder().http2_prior_knowledge().build().unwrap();
 
     let url = format!("http://localhost:7878{url}");
-    
+
     let start = Instant::now();
-    
+
     let requests = (0..iters).map(|_| client.get(&url).send());
     let responses = join_all(requests).await;
-    
+
     let elapsed = start.elapsed();
-    
+
     let failed = responses.iter().filter(|r| r.is_err()).count();
     if failed > 0 {
         eprintln!("failed {failed} requests");
@@ -41,23 +38,19 @@ fn benchmark(c: &mut Criterion) {
                 .with_no_delay()
                 .without_body_limit()
                 .without_greeter();
-            
-            app.map_get("/", || async { "Hello, World!" });
-            app.map_get("/err", || async { Error::other("error") });
-            app.map_err(|err: volga::error::Error| async move { status!(500, err.to_string()) });
-            app.map_fallback(|| async { status!(404) });
+
+            app.map_get("/valid", || async {}).filter(|| async { true });
+            app.map_get("/invalid", || async {}).filter(|| async { false });
+
             _ = app.run().await;
         });
     });
-    
-    c.bench_function("ok", |b| b.iter_custom(
-        |iters| rt.block_on(routing(iters, black_box("/")))
+
+    c.bench_function("valid filter", |b| b.iter_custom(
+        |iters| rt.block_on(routing(iters, black_box("/valid")))
     ));
-    c.bench_function("err", |b| b.iter_custom(
-        |iters| rt.block_on(routing(iters, black_box("/err")))
-    ));
-    c.bench_function("fallback", |b| b.iter_custom(
-        |iters| rt.block_on(routing(iters, black_box("/fall")))
+    c.bench_function("invalid filter", |b| b.iter_custom(
+        |iters| rt.block_on(routing(iters, black_box("/invalid")))
     ));
 }
 

--- a/examples/cookies.rs
+++ b/examples/cookies.rs
@@ -1,18 +1,18 @@
 ﻿//! Run with:
 //!
 //! ```no_rust
-//! cargo run --example cookies --features cookie
+//! cargo run --example cookies --features cookie,basic-auth
 //! ```
 
 use uuid::Uuid;
 use volga::{
     App, HttpResult, http::Cookies,
+    auth::Basic,
     error::Error,
-    headers::{Header, Authorization},
     status, ok, see_other
 };
 
-async fn login(cookies: Cookies, auth: Header<Authorization>) -> Result<(HttpResult, Cookies), Error> {
+async fn login(cookies: Cookies, auth: Basic) -> Result<(HttpResult, Cookies), Error> {
     let session_id = authorize(auth)?;
     Ok((see_other!("/me"), cookies.add(("session-id", session_id))))
 }
@@ -26,10 +26,12 @@ async fn me(cookies: Cookies) -> HttpResult {
     
 }
 
-fn authorize(_auth: Header<Authorization>) -> Result<String, Error> {
-    // authorize the user and create a session
-    
-    Ok(Uuid::new_v4().to_string())
+fn authorize(auth: Basic) -> Result<String, Error> {
+    if auth.validate("foo", "bar") {
+        Ok(Uuid::new_v4().to_string())    
+    } else { 
+        Err(Error::client_error("Invalid Credentials"))
+    } 
 }
 
 #[tokio::main]

--- a/examples/cookies.rs
+++ b/examples/cookies.rs
@@ -7,6 +7,7 @@
 use uuid::Uuid;
 use volga::{
     App, HttpResult, http::Cookies,
+    headers::WWW_AUTHENTICATE,
     auth::Basic,
     error::Error,
     status, ok, see_other
@@ -21,7 +22,7 @@ async fn me(cookies: Cookies) -> HttpResult {
     cookies
         .get("session-id")
         .map_or_else(
-            || status!(401, "Unauthorized"),
+            || status!(401, "Unauthorized", [(WWW_AUTHENTICATE, "Basic realm=\"Restricted area\"")]),
             |_session_id| ok!("Success"))
     
 }

--- a/examples/jwt.rs
+++ b/examples/jwt.rs
@@ -8,8 +8,8 @@ use std::{ops::Add, time::{SystemTime, UNIX_EPOCH, Duration}};
 use serde::{Serialize, Deserialize};
 use volga::{
     App, Json, HttpResult, 
-    auth::{AuthClaims, BearerTokenService, DecodingKey, EncodingKey, roles}, 
-    ok, status, bad_request
+    auth::{BearerTokenService, DecodingKey, EncodingKey, roles}, 
+    ok, status, bad_request, claims
 };
 
 async fn login(payload: Json<Payload>, bts: BearerTokenService) -> HttpResult {
@@ -59,17 +59,13 @@ fn main() {
     app.run_blocking()
 }
 
-#[derive(Serialize, Deserialize)]
-struct Claims {
-    sub: String,
-    company: String,
-    role: String,
-    exp: u64,
-}
-
-impl AuthClaims for Claims {
-    fn role(&self) -> Option<&str> {
-        Some(&self.role)
+claims! {
+    #[derive(Serialize, Deserialize)]
+    struct Claims {
+        sub: String,
+        company: String,
+        role: String,
+        exp: u64,
     }
 }
 

--- a/examples/jwt.rs
+++ b/examples/jwt.rs
@@ -1,0 +1,85 @@
+//! Run with:
+//!
+//! ```no_rust
+//! JWT_SECRET=secret cargo run --example jwt --features jwt-auth,middleware
+//! ```
+
+use std::{ops::Add, time::{SystemTime, UNIX_EPOCH, Duration}};
+use serde::{Serialize, Deserialize};
+use volga::{
+    App, Json, HttpResult, 
+    auth::{AuthClaims, BearerTokenService, DecodingKey, EncodingKey, roles}, 
+    ok, status, bad_request
+};
+
+async fn login(payload: Json<Payload>, bts: BearerTokenService) -> HttpResult {
+    if payload.client_id.is_empty() || payload.client_secret.is_empty() {
+        return bad_request!("Missing Credentials");
+    }
+    if payload.client_id != "foo" || payload.client_secret != "bar" {
+        return status!(401, "Invalid Credentials");
+    }
+
+    let exp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("Time went backwards")
+        .add(Duration::from_secs(300))
+        .as_secs();
+    
+    let claims = Claims {
+        sub: "email.com".to_owned(),
+        company: "Awesome Co.".to_owned(),
+        role: "admin".to_owned(),
+        exp,
+    };
+    
+    let access_token = bts.encode(&claims)?
+        .to_string();
+    
+    ok!(AuthData { access_token })
+}
+
+async fn me() -> &'static str {
+    "Hello from protected area"
+}
+
+fn main() {
+    let secret = std::env::var("JWT_SECRET")
+        .expect("JWT_SECRET must be set");
+
+    let mut app = App::new()
+        .with_bearer_auth(|auth| auth
+            .set_encoding_key(EncodingKey::from_secret(secret.as_bytes()))
+            .set_decoding_key(DecodingKey::from_secret(secret.as_bytes())));
+    
+    app.map_post("/login", login);
+    app.map_get("/me", me)
+        .authorize::<Claims>(roles(["admin", "user"]));
+    
+    app.run_blocking()
+}
+
+#[derive(Serialize, Deserialize)]
+struct Claims {
+    sub: String,
+    company: String,
+    role: String,
+    exp: u64,
+}
+
+impl AuthClaims for Claims {
+    fn role(&self) -> Option<&str> {
+        Some(&self.role)
+    }
+}
+
+#[derive(Serialize)]
+struct AuthData {
+    access_token: String,
+}
+
+#[derive(Deserialize)]
+struct Payload {
+    client_id: String,
+    client_secret: String,
+}

--- a/src/app/env.rs
+++ b/src/app/env.rs
@@ -38,7 +38,7 @@ impl Default for HostEnv {
 }
 
 impl HostEnv {
-    /// Creates a new [`HostEnv`] with given content root
+    /// Creates a new [`HostEnv`] with the given content root
     #[inline]
     pub fn new<T: ?Sized + AsRef<OsStr>>(content_root: &T) -> Self {
         let content_root = PathBuf::from(content_root);

--- a/src/app/scope.rs
+++ b/src/app/scope.rs
@@ -94,6 +94,11 @@ impl Scope {
                     
                     #[cfg(feature = "di")]
                     extensions.insert(shared.container.create_scope());
+                    
+                    #[cfg(feature = "jwt-auth")]
+                    if let Some(bts) = &shared.bearer_token_service {
+                        extensions.insert(bts.clone());
+                    } 
                 }
 
                 let mut request = HttpRequest::new(Request::from_parts(parts.clone(), body))

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,0 +1,240 @@
+//! Tools and utils for Authorization & Authentication
+
+#[cfg(feature = "jwt-auth")]
+use {
+    crate::{App, routing::{Route, RouteGroup}, http::StatusCode, error::Error, status, HttpResult},
+    std::{future::Future, sync::Arc},
+};
+
+#[cfg(feature = "jwt-auth")]
+pub use {
+    jsonwebtoken::{Algorithm, EncodingKey, DecodingKey, errors::{ErrorKind, Error as JwtError}},
+    authorizer::{Authorizer, AuthClaims, role, roles, permissions, predicate},
+    crate::middleware::{HttpContext, NextFn},
+    bearer::{BearerAuthConfig, Bearer, BearerTokenService},
+    crate::headers::{HeaderValue, WWW_AUTHENTICATE}
+};
+#[cfg(feature = "basic-auth")]
+pub use basic::Basic;
+
+#[cfg(feature = "basic-auth")]
+pub mod basic;
+#[cfg(feature = "jwt-auth")]
+pub mod bearer;
+#[cfg(feature = "jwt-auth")]
+pub mod authorizer;
+
+#[cfg(feature = "jwt-auth")]
+impl From<JwtError> for Error {
+    #[inline]
+    fn from(err: JwtError) -> Self {
+        let kind = err.kind();
+        let status_code = map_jwt_error_to_status(kind);
+        Error::from_parts(status_code, None, err)
+    }
+}
+
+#[cfg(feature = "jwt-auth")]
+fn map_jwt_error_to_status(err: &ErrorKind) -> StatusCode {
+    use ErrorKind::*;
+    match err {
+        ExpiredSignature
+        | InvalidToken
+        | InvalidIssuer
+        | InvalidAudience
+        | InvalidSubject
+        | InvalidSignature
+        | MissingRequiredClaim(_)
+        | ImmatureSignature
+        | InvalidAlgorithmName
+        | InvalidAlgorithm => StatusCode::UNAUTHORIZED,
+        Base64(_)
+        | Json(_)
+        | Utf8(_)
+        | Crypto(_)
+        | InvalidKeyFormat => StatusCode::BAD_REQUEST,
+        _ => StatusCode::INTERNAL_SERVER_ERROR,
+    }
+}
+
+#[cfg(feature = "jwt-auth")]
+fn map_jwt_error_to_www_authenticate(err: &ErrorKind) -> &'static str {
+    use ErrorKind::*;
+    match err {
+        ExpiredSignature => r#"Bearer error="invalid_token", error_description="Token has expired""#,
+        InvalidSignature => r#"Bearer error="invalid_token", error_description="Invalid signature""#,
+        InvalidToken => r#"Bearer error="invalid_token", error_description="Token is malformed or invalid""#,
+        ImmatureSignature => r#"Bearer error="invalid_token", error_description="Token is not valid yet (nbf)""#,
+        MissingRequiredClaim(_) => r#"Bearer error="invalid_token", error_description="Missing required claim""#,
+        InvalidIssuer => r#"Bearer error="invalid_token", error_description="Invalid issuer (iss)""#,
+        InvalidAudience => r#"Bearer error="invalid_token", error_description="Invalid audience (aud)""#,
+        InvalidSubject => r#"Bearer error="invalid_token", error_description="Invalid subject (sub)""#,
+        InvalidAlgorithm | InvalidAlgorithmName => r#"Bearer error="invalid_token", error_description="Invalid algorithm""#,
+        Base64(_) => r#"Bearer error="invalid_request", error_description="Token is not properly base64-encoded""#,
+        Json(_) => r#"Bearer error="invalid_request", error_description="Token payload is not valid JSON""#,
+        Utf8(_) => r#"Bearer error="invalid_request", error_description="Token contains invalid UTF-8 characters""#,
+        InvalidKeyFormat => r#"Bearer error="invalid_request", error_description="Invalid key format""#,
+        Crypto(_) => r#"Bearer error="invalid_token", error_description="Cryptographic error during token validation""#,
+        _ => r#"Bearer error="server_error", error_description="Internal token processing error""#,
+    }
+}
+
+#[cfg(feature = "jwt-auth")]
+impl App {
+    /// Configures a web server with a Bearer Token Authentication & Authorization configuration
+    ///
+    /// Default: `None`
+    /// 
+    /// # Example
+    /// ```no_run
+    /// use volga::App;
+    /// 
+    /// let app = App::new()
+    ///     .with_bearer_auth(|auth| auth);
+    /// ```
+    pub fn with_bearer_auth<F>(mut self, config: F) -> Self
+    where
+        F: FnOnce(BearerAuthConfig) -> BearerAuthConfig
+    {
+        self.auth_config = Some(config(Default::default()));
+        self
+    }
+
+    /// Adds authorization middleware for all routes
+    ///
+    /// # Example
+    /// ```no_run
+    /// use volga::{App, auth::{AuthClaims, roles}};
+    /// use serde::Deserialize;
+    ///
+    /// #[derive(Deserialize)]
+    /// struct MyClaims {
+    ///     role: String
+    /// }
+    ///
+    /// impl AuthClaims for MyClaims {
+    ///     fn role(&self) -> Option<&str> {
+    ///         Some(self.role.as_str())
+    ///     }
+    /// }
+    ///
+    /// let mut app = App::new()
+    ///     .with_bearer_auth(|auth| auth);
+    ///
+    /// app.authorize::<MyClaims>(roles(["admin", "user"]));
+    /// 
+    /// app.map_get("/hello", || async { "Hello, World!" });
+    /// ```
+    pub fn authorize<C: AuthClaims + Send +  Sync + 'static>(&mut self, authorizer: Authorizer<C>) -> &mut Self {
+        self.ensure_bearer_auth_configured();
+        let authorizer = Arc::new(authorizer);
+        self.wrap(move |ctx, next| authorize_impl(authorizer.clone(), ctx, next))
+    }
+    
+    fn ensure_bearer_auth_configured(&self) {
+        let config = match &self.auth_config {
+            Some(config) => config,
+            _ => panic!("Bearer Auth is not configured"),
+        };
+
+        config
+            .decoding_key()
+            .expect("Bearer Auth security key is not configured");
+    }
+}
+
+#[cfg(feature = "jwt-auth")]
+impl<'a> Route<'a> {
+    /// Adds authorization middleware for this route
+    /// 
+    /// # Example
+    /// ```no_run
+    /// use volga::{App, auth::{AuthClaims, roles}};
+    /// use serde::Deserialize;
+    /// 
+    /// #[derive(Deserialize)]
+    /// struct MyClaims {
+    ///     role: String
+    /// }
+    /// 
+    /// impl AuthClaims for MyClaims {
+    ///     fn role(&self) -> Option<&str> {
+    ///         Some(self.role.as_str())
+    ///     }
+    /// }
+    /// 
+    /// let mut app = App::new()
+    ///     .with_bearer_auth(|auth| auth);
+    /// 
+    /// app.map_get("/hello", || async { "Hello, World!" })
+    ///     .authorize::<MyClaims>(roles(["admin", "user"]));
+    /// ```
+    pub fn authorize<C: AuthClaims + Send +  Sync + 'static>(self, authorizer: Authorizer<C>) -> Self {
+        self.ensure_bearer_auth_configured();
+        let authorizer = Arc::new(authorizer);
+        self.wrap(move |ctx, next| authorize_impl(authorizer.clone(), ctx, next))
+    }
+}
+
+#[cfg(feature = "jwt-auth")]
+impl<'a> RouteGroup<'a> {
+    /// Adds authorization middleware for this group of routes
+    ///
+    /// # Example
+    /// ```no_run
+    /// use volga::{App, auth::{AuthClaims, roles}};
+    /// use serde::Deserialize;
+    ///
+    /// #[derive(Deserialize)]
+    /// struct MyClaims {
+    ///     role: String
+    /// }
+    ///
+    /// impl AuthClaims for MyClaims {
+    ///     fn role(&self) -> Option<&str> {
+    ///         Some(self.role.as_str())
+    ///     }
+    /// }
+    ///
+    /// let mut app = App::new()
+    ///     .with_bearer_auth(|auth| auth);
+    ///
+    /// app.map_group("/greet")
+    ///     .authorize::<MyClaims>(roles(["admin", "user"]))
+    ///     .map_get("/hello", || async { "Hello, World!" });
+    /// ```
+    pub fn authorize<C: AuthClaims + Send +  Sync + 'static>(self, authorizer: Authorizer<C>) -> Self {
+        self.app.ensure_bearer_auth_configured();
+        let authorizer = Arc::new(authorizer);
+        self.wrap(move |ctx, next| authorize_impl(authorizer.clone(), ctx, next))
+    }
+}
+
+#[cfg(feature = "jwt-auth")]
+fn authorize_impl<C>(authorizer: Arc<Authorizer<C>>, ctx: HttpContext, next: NextFn) -> impl Future<Output = HttpResult>
+where
+    C: AuthClaims + Send +  Sync + 'static
+{
+    let authorizer = authorizer.clone();
+    async move {
+        let bearer: Bearer = ctx.extract()?;
+        let bts: BearerTokenService = ctx.extract()?;
+        match bts.decode(bearer) {
+            Ok(claims) if authorizer.validate(&claims) => next(ctx).await,
+            Ok(_) => status!(403, [
+                (WWW_AUTHENTICATE, authorizer::DEFAULT_ERROR_MSG)
+            ]),
+            Err(err) => {
+                let www_authenticate = err
+                    .into_inner()
+                    .downcast_ref::<JwtError>()
+                    .map(|e| map_jwt_error_to_www_authenticate(e.kind()))
+                    .unwrap_or(authorizer::DEFAULT_ERROR_MSG);
+                status!(403, [
+                    (WWW_AUTHENTICATE, www_authenticate)
+                ])
+            }
+        }
+    }
+}
+

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -238,3 +238,235 @@ where
     }
 }
 
+#[cfg(all(test, feature = "jwt-auth"))]
+mod tests {
+    use super::*;
+    use jsonwebtoken::errors::{ErrorKind, Error as JwtError};
+    use crate::http::StatusCode;
+
+    #[test]
+    fn it_maps_expired_signature_to_unauthorized() {
+        let status = map_jwt_error_to_status(&ErrorKind::ExpiredSignature);
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn it_maps_invalid_token_to_unauthorized() {
+        let status = map_jwt_error_to_status(&ErrorKind::InvalidToken);
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn it_maps_invalid_issuer_to_unauthorized() {
+        let status = map_jwt_error_to_status(&ErrorKind::InvalidIssuer);
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn it_maps_invalid_audience_to_unauthorized() {
+        let status = map_jwt_error_to_status(&ErrorKind::InvalidAudience);
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn it_maps_invalid_subject_to_unauthorized() {
+        let status = map_jwt_error_to_status(&ErrorKind::InvalidSubject);
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn it_maps_invalid_signature_to_unauthorized() {
+        let status = map_jwt_error_to_status(&ErrorKind::InvalidSignature);
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn it_maps_missing_required_claim_to_unauthorized() {
+        let status = map_jwt_error_to_status(&ErrorKind::MissingRequiredClaim("test".to_string()));
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn it_maps_immature_signature_to_unauthorized() {
+        let status = map_jwt_error_to_status(&ErrorKind::ImmatureSignature);
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn it_maps_invalid_algorithm_name_to_unauthorized() {
+        let status = map_jwt_error_to_status(&ErrorKind::InvalidAlgorithmName);
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn it_maps_invalid_algorithm_to_unauthorized() {
+        let status = map_jwt_error_to_status(&ErrorKind::InvalidAlgorithm);
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn it_maps_base64_error_to_bad_request() {
+        let status = map_jwt_error_to_status(&ErrorKind::Base64(base64::DecodeError::InvalidByte(0, 0)));
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn it_maps_json_error_to_bad_request() {
+        // Create a JSON error by attempting to deserialize invalid JSON
+        let json_result: Result<serde_json::Value, _> = serde_json::from_str("invalid json");
+        let json_error = json_result.unwrap_err();
+        let status = map_jwt_error_to_status(&ErrorKind::Json(Arc::from(json_error)));
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn it_maps_utf8_error_to_bad_request() {
+        // Create a FromUtf8Error by attempting to convert invalid UTF-8 bytes
+        let invalid_utf8_bytes = vec![0, 159, 146, 150];
+        let utf8_error = String::from_utf8(invalid_utf8_bytes).unwrap_err();
+        let status = map_jwt_error_to_status(&ErrorKind::Utf8(utf8_error));
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn it_maps_invalid_key_format_to_bad_request() {
+        let status = map_jwt_error_to_status(&ErrorKind::InvalidKeyFormat);
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn it_maps_expired_signature_to_www_authenticate() {
+        let www_auth = map_jwt_error_to_www_authenticate(&ErrorKind::ExpiredSignature);
+        assert_eq!(www_auth, r#"Bearer error="invalid_token", error_description="Token has expired""#);
+    }
+
+    #[test]
+    fn it_maps_invalid_signature_to_www_authenticate() {
+        let www_auth = map_jwt_error_to_www_authenticate(&ErrorKind::InvalidSignature);
+        assert_eq!(www_auth, r#"Bearer error="invalid_token", error_description="Invalid signature""#);
+    }
+
+    #[test]
+    fn it_maps_invalid_token_to_www_authenticate() {
+        let www_auth = map_jwt_error_to_www_authenticate(&ErrorKind::InvalidToken);
+        assert_eq!(www_auth, r#"Bearer error="invalid_token", error_description="Token is malformed or invalid""#);
+    }
+
+    #[test]
+    fn it_maps_immature_signature_to_www_authenticate() {
+        let www_auth = map_jwt_error_to_www_authenticate(&ErrorKind::ImmatureSignature);
+        assert_eq!(www_auth, r#"Bearer error="invalid_token", error_description="Token is not valid yet (nbf)""#);
+    }
+
+    #[test]
+    fn it_maps_missing_required_claim_to_www_authenticate() {
+        let www_auth = map_jwt_error_to_www_authenticate(&ErrorKind::MissingRequiredClaim("test".to_string()));
+        assert_eq!(www_auth, r#"Bearer error="invalid_token", error_description="Missing required claim""#);
+    }
+
+    #[test]
+    fn it_maps_invalid_issuer_to_www_authenticate() {
+        let www_auth = map_jwt_error_to_www_authenticate(&ErrorKind::InvalidIssuer);
+        assert_eq!(www_auth, r#"Bearer error="invalid_token", error_description="Invalid issuer (iss)""#);
+    }
+
+    #[test]
+    fn it_maps_invalid_audience_to_www_authenticate() {
+        let www_auth = map_jwt_error_to_www_authenticate(&ErrorKind::InvalidAudience);
+        assert_eq!(www_auth, r#"Bearer error="invalid_token", error_description="Invalid audience (aud)""#);
+    }
+
+    #[test]
+    fn it_maps_invalid_subject_to_www_authenticate() {
+        let www_auth = map_jwt_error_to_www_authenticate(&ErrorKind::InvalidSubject);
+        assert_eq!(www_auth, r#"Bearer error="invalid_token", error_description="Invalid subject (sub)""#);
+    }
+
+    #[test]
+    fn it_maps_invalid_algorithm_to_www_authenticate() {
+        let www_auth = map_jwt_error_to_www_authenticate(&ErrorKind::InvalidAlgorithm);
+        assert_eq!(www_auth, r#"Bearer error="invalid_token", error_description="Invalid algorithm""#);
+    }
+
+    #[test]
+    fn it_maps_invalid_algorithm_name_to_www_authenticate() {
+        let www_auth = map_jwt_error_to_www_authenticate(&ErrorKind::InvalidAlgorithmName);
+        assert_eq!(www_auth, r#"Bearer error="invalid_token", error_description="Invalid algorithm""#);
+    }
+
+    #[test]
+    fn it_maps_base64_error_to_www_authenticate() {
+        let www_auth = map_jwt_error_to_www_authenticate(&ErrorKind::Base64(base64::DecodeError::InvalidByte(0, 0)));
+        assert_eq!(www_auth, r#"Bearer error="invalid_request", error_description="Token is not properly base64-encoded""#);
+    }
+
+    #[test]
+    fn it_maps_json_error_to_www_authenticate() {
+        let json_result: Result<serde_json::Value, _> = serde_json::from_str("invalid json");
+        let json_error = json_result.unwrap_err();
+        let www_auth = map_jwt_error_to_www_authenticate(&ErrorKind::Json(Arc::from(json_error)));
+        assert_eq!(www_auth, r#"Bearer error="invalid_request", error_description="Token payload is not valid JSON""#);
+    }
+
+    #[test]
+    fn it_maps_utf8_error_to_www_authenticate() {
+        let invalid_utf8_bytes = vec![0, 159, 146, 150];
+        let utf8_error = String::from_utf8(invalid_utf8_bytes).unwrap_err();
+        let www_auth = map_jwt_error_to_www_authenticate(&ErrorKind::Utf8(utf8_error));
+        assert_eq!(www_auth, r#"Bearer error="invalid_request", error_description="Token contains invalid UTF-8 characters""#);
+    }
+
+    #[test]
+    fn it_maps_invalid_key_format_to_www_authenticate() {
+        let www_auth = map_jwt_error_to_www_authenticate(&ErrorKind::InvalidKeyFormat);
+        assert_eq!(www_auth, r#"Bearer error="invalid_request", error_description="Invalid key format""#);
+    }
+
+    #[test]
+    fn it_converts_jwt_error_to_error_with_expired_signature() {
+        let jwt_error = JwtError::from(ErrorKind::ExpiredSignature);
+        let error: Error = jwt_error.into();
+
+        assert_eq!(error.status, StatusCode::UNAUTHORIZED);
+        assert!(error.instance.is_none());
+    }
+
+    #[test]
+    fn it_converts_jwt_error_to_error_with_invalid_token() {
+        let jwt_error = JwtError::from(ErrorKind::InvalidToken);
+        let error: Error = jwt_error.into();
+
+        assert_eq!(error.status, StatusCode::UNAUTHORIZED);
+        assert!(error.instance.is_none());
+    }
+
+    #[test]
+    fn it_converts_jwt_error_to_error_with_base64_error() {
+        let jwt_error = JwtError::from(ErrorKind::Base64(base64::DecodeError::InvalidByte(0, 0)));
+        let error: Error = jwt_error.into();
+
+        assert_eq!(error.status, StatusCode::BAD_REQUEST);
+        assert!(error.instance.is_none());
+    }
+
+    #[test]
+    fn it_converts_jwt_error_to_error_with_json_error() {
+        let json_result: Result<serde_json::Value, _> = serde_json::from_str("invalid json");
+        let json_error = json_result.unwrap_err();
+        let jwt_error = JwtError::from(ErrorKind::Json(Arc::from(json_error)));
+        let error: Error = jwt_error.into();
+
+        assert_eq!(error.status, StatusCode::BAD_REQUEST);
+        assert!(error.instance.is_none());
+    }
+
+    #[test]
+    fn it_converts_jwt_error_to_error_with_invalid_key_format() {
+        let jwt_error = JwtError::from(ErrorKind::InvalidKeyFormat);
+        let error: Error = jwt_error.into();
+
+        assert_eq!(error.status, StatusCode::BAD_REQUEST);
+        assert!(error.instance.is_none());
+    }
+}
+

--- a/src/auth/authorizer.rs
+++ b/src/auth/authorizer.rs
@@ -2,66 +2,9 @@
 
 use std::collections::HashSet;
 use std::sync::Arc;
-use serde::de::DeserializeOwned;
+use super::AuthClaims;
 
 pub(super) const DEFAULT_ERROR_MSG: &str = "Bearer error=\"insufficient_scope\" error_description=\"User does not have required role or permission\"";
-
-/// Trait representing extractable authorization claims from a JWT payload.
-///
-/// Types implementing this trait allow the framework to access optional authorization
-/// information such as roles or permissions, enabling role-based or permission-based
-/// access control.
-///
-/// This trait is intended to be implemented by your custom claims struct, which is typically
-/// deserialized from the JWT payload. All methods are optional; by default, they return `None`.
-/// You can override only the methods relevant to your use case.
-///
-/// # Example
-///
-/// ```no_run
-/// use serde::Deserialize;
-/// use volga::auth::AuthClaims;
-///
-/// #[derive(Debug, Deserialize)]
-/// struct MyClaims {
-///     sub: String,
-///     role: String,
-/// }
-///
-/// impl AuthClaims for MyClaims {
-///     fn role(&self) -> Option<&str> {
-///         Some(&self.role)
-///     }
-/// }
-/// ```
-pub trait AuthClaims: DeserializeOwned {
-    /// Returns the primary role associated with the claims.
-    ///
-    /// This is useful for role-based access control (RBAC) where only a single role is expected.
-    /// If multiple roles are used, prefer implementing the [`AuthClaims::roles()`] method.
-    ///
-    /// By default, returns `None`.
-    fn role(&self) -> Option<&str> {
-        None
-    }
-
-    /// Returns the list of roles associated with the claims.
-    ///
-    /// Useful when a subject can have multiple roles.
-    /// If a single role is used instead, you may override [`AuthClaims::role()`] instead.
-    ///
-    /// By default, returns `None`.
-    fn roles(&self) -> Option<&[String]> {
-        None
-    }
-
-    /// Returns the list of permissions granted to the subject.
-    ///
-    /// By default, returns `None`.
-    fn permissions(&self) -> Option<&[String]> {
-        None
-    }
-}
 
 /// Creates an [`Authorizer::Role`] authorizer for a single role.
 ///

--- a/src/auth/authorizer.rs
+++ b/src/auth/authorizer.rs
@@ -1,0 +1,335 @@
+//! Generic authorization tools
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use serde::de::DeserializeOwned;
+
+pub(super) const DEFAULT_ERROR_MSG: &str = "Bearer error=\"insufficient_scope\" error_description=\"User does not have required role or permission\"";
+
+/// Trait representing extractable authorization claims from a JWT payload.
+///
+/// Types implementing this trait allow the framework to access optional authorization
+/// information such as roles or permissions, enabling role-based or permission-based
+/// access control.
+///
+/// This trait is intended to be implemented by your custom claims struct, which is typically
+/// deserialized from the JWT payload. All methods are optional; by default, they return `None`.
+/// You can override only the methods relevant to your use case.
+///
+/// # Example
+///
+/// ```no_run
+/// use serde::Deserialize;
+/// use volga::auth::AuthClaims;
+///
+/// #[derive(Debug, Deserialize)]
+/// struct MyClaims {
+///     sub: String,
+///     role: String,
+/// }
+///
+/// impl AuthClaims for MyClaims {
+///     fn role(&self) -> Option<&str> {
+///         Some(&self.role)
+///     }
+/// }
+/// ```
+pub trait AuthClaims: DeserializeOwned {
+    /// Returns the primary role associated with the claims.
+    ///
+    /// This is useful for role-based access control (RBAC) where only a single role is expected.
+    /// If multiple roles are used, prefer implementing the [`AuthClaims::roles()`] method.
+    ///
+    /// By default, returns `None`.
+    fn role(&self) -> Option<&str> {
+        None
+    }
+
+    /// Returns the list of roles associated with the claims.
+    ///
+    /// Useful when a subject can have multiple roles.
+    /// If a single role is used instead, you may override [`AuthClaims::role()`] instead.
+    ///
+    /// By default, returns `None`.
+    fn roles(&self) -> Option<&[String]> {
+        None
+    }
+
+    /// Returns the list of permissions granted to the subject.
+    ///
+    /// By default, returns `None`.
+    fn permissions(&self) -> Option<&[String]> {
+        None
+    }
+}
+
+/// Creates an [`Authorizer::Role`] authorizer for a single role.
+///
+/// Equivalent to: `Authorizer::Role([role.to_string()].into_iter().collect())`
+pub fn role<C>(name: impl Into<String>) -> Authorizer<C>
+where
+    C: AuthClaims,
+{
+    Authorizer::Role(HashSet::from([name.into()]))
+}
+
+/// Creates an [` Authorizer::Role `] authorizer for multiple roles.
+pub fn roles<S, I, C>(roles: I) -> Authorizer<C>
+where
+    C: AuthClaims,
+    S: Into<String>,
+    I: IntoIterator<Item = S>,
+{
+    Authorizer::Role(roles
+        .into_iter()
+        .map(Into::into)
+        .collect())
+}
+
+/// Creates an [`Authorizer::Permission`] authorizer for a single permission.
+pub fn permission<C>(name: impl Into<String>) -> Authorizer<C>
+where
+    C: AuthClaims,
+{
+    Authorizer::Permission(HashSet::from([name.into()]))
+}
+
+/// Creates an [`Authorizer::Permission`] authorizer for multiple permissions.
+pub fn permissions<S, I, C>(permissions: I) -> Authorizer<C>
+where
+    C: AuthClaims,
+    S: Into<String>,
+    I: IntoIterator<Item = S>,
+{
+    Authorizer::Permission(permissions
+        .into_iter()
+        .map(Into::into)
+        .collect())
+}
+
+/// Creates an [`Authorizer::Predicate`] authorizer from a closure or function.
+pub fn predicate<C, F>(f: F) -> Authorizer<C>
+where
+    C: AuthClaims,
+    F: Fn(&C) -> bool + Send + Sync + 'static,
+{
+    Authorizer::Predicate(Arc::new(f))
+}
+
+pub type ClaimsValidator<C> = dyn Fn(&C) -> bool + Send + Sync + 'static;
+
+/// Specifies the validation rules for role-based or permission-based access control.
+///
+/// This enum allows you to define access policies declaratively, based on claims extracted from a JWT.
+/// It supports role matching, permission matching, custom predicates, and logical composition
+/// (`And`/`Or`) of other authorizers.
+///
+/// The `Authorizer` works with any claims type implementing [`AuthClaims`], and can be used
+/// for both simple and complex access control scenarios.
+///
+/// # Examples
+/// ```no_run
+/// use volga::auth::{Authorizer, AuthClaims, role, roles};
+/// use serde::Deserialize;
+/// 
+/// #[derive(Deserialize)]
+/// struct MyClaims {
+///     role: String
+/// }
+/// 
+/// impl AuthClaims for MyClaims {
+///     fn role(&self) -> Option<&str> {
+///         Some(self.role.as_str())
+///     }
+/// }
+/// 
+/// let admin_only = role("admin");
+/// let any_editor = roles(["editor", "contributor"]);
+/// 
+/// let access: Authorizer<MyClaims> = admin_only.or(any_editor);
+/// 
+/// assert!(access.validate(&MyClaims { role: "admin".to_string() }));
+/// assert!(access.validate(&MyClaims { role: "editor".to_string() }));
+/// assert!(access.validate(&MyClaims { role: "contributor".to_string() }));
+/// ```
+pub enum Authorizer<C: AuthClaims> {
+    /// Allows access if the user's role or roles match any of the required roles.
+    ///
+    /// This will check both [`AuthClaims::role()`] and [`AuthClaims::roles()`].
+    Role(HashSet<String>),
+
+    /// Allows access if the user's permissions contain any of the required permissions.
+    ///
+    /// This assumes [`AuthClaims::permissions()`] returns a list of permission strings.
+    Permission(HashSet<String>),
+
+    /// Allows custom validation logic through a user-defined predicate.
+    ///
+    /// This enables flexible access control based on arbitrary logic over the claims.
+    Predicate(Arc<ClaimsValidator<C>>),
+
+    /// Allows access only if **all** inner authorizers return `true`.
+    ///
+    /// Logical **AND** operation.
+    And(Vec<Authorizer<C>>),
+
+    /// Allows access if **any** of the inner authorizers return `true`.
+    ///
+    /// Logical **OR** operation.
+    Or(Vec<Authorizer<C>>),
+}
+
+impl<C: AuthClaims> Authorizer<C> {
+    /// Validates the given claims against this authorizer's rule set.
+    ///
+    /// Returns `true` if access is allowed, `false` otherwise.
+    ///
+    /// This method evaluates role and permission membership or applies custom logic
+    /// as defined in the authorizer.
+    pub fn validate(&self, claims: &C) -> bool {
+        match self {
+            Authorizer::Predicate(pred) => pred(claims),
+            Authorizer::And(auths) => auths
+                .iter()
+                .all(|a| a.validate(claims)),
+            Authorizer::Or(auths) => auths
+                .iter()
+                .any(|a| a.validate(claims)),
+            Authorizer::Role(roles) => {
+                match (claims.role(), claims.roles()) {
+                    (Some(r), None) => roles.contains(r),
+                    (_, Some(rs)) => rs.iter().any(|r| roles.contains(r)),
+                    (None, None) => false,
+                }
+            },
+            Authorizer::Permission(perms) => claims
+                .permissions()
+                .is_some_and(|p| p.iter().any(|perm| perms.contains(perm)))
+        }
+    }
+    
+    /// Combines the current authorizer with another one via logical **AND** (And).
+    ///
+    /// If both operands are already `And`, then their contents are combined into one list.
+    /// This avoids unnecessary nesting: `And([And([a]), And([b])]) → And([a, b])`
+    pub fn and(self, other: Authorizer<C>) -> Self {
+        match (self, other) {
+            (Authorizer::And(mut a), Authorizer::And(mut b)) => {
+                a.append(&mut b);
+                Authorizer::And(a)
+            }
+            (Authorizer::And(mut a), b) => {
+                a.push(b);
+                Authorizer::And(a)
+            }
+            (a, Authorizer::And(mut b)) => {
+                let mut v = vec![a];
+                v.append(&mut b);
+                Authorizer::And(v)
+            }
+            (a, b) => Authorizer::And(vec![a, b]),
+        }
+    }
+
+    /// Combines the current authorizer with another via logical **OR** (Or).
+    ///
+    /// Behavior is similar to [`Authorizer::and()`], but for the `Or` type.
+    pub fn or(self, other: Authorizer<C>) -> Self {
+        match (self, other) {
+            (Authorizer::Or(mut a), Authorizer::Or(mut b)) => {
+                a.append(&mut b);
+                Authorizer::Or(a)
+            }
+            (Authorizer::Or(mut a), b) => {
+                a.push(b);
+                Authorizer::Or(a)
+            }
+            (a, Authorizer::Or(mut b)) => {
+                let mut v = vec![a];
+                v.append(&mut b);
+                Authorizer::Or(v)
+            }
+            (a, b) => Authorizer::Or(vec![a, b]),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Authorizer, AuthClaims, role, roles};
+
+    #[derive(serde::Deserialize)]
+    struct Claims {
+        role: String,
+    }
+
+    impl AuthClaims for Claims {
+        fn role(&self) -> Option<&str> {
+            Some(&self.role)
+        }
+    }
+    
+    #[test]
+    fn it_tests_the_and_flattening() {
+        let a = role::<Claims>("admin");
+        let b = role::<Claims>("editor");
+        let c = role::<Claims>("moderator");
+
+        let ab = a.and(b); // And([admin, editor])
+        let abc = ab.and(c); // And([admin, editor, moderator])
+
+        match abc {
+            Authorizer::And(inner) => {
+                assert_eq!(inner.len(), 3);
+                assert!(matches!(inner[0], Authorizer::Role(ref s) if s.contains(&"admin".to_owned())));
+                assert!(matches!(inner[1], Authorizer::Role(ref s) if s.contains(&"editor".to_owned())));
+                assert!(matches!(inner[2], Authorizer::Role(ref s) if s.contains(&"moderator".to_owned())));
+            }
+            _ => panic!("Expected And variant"),
+        }
+    }
+
+    #[test]
+    fn it_tests_the_or_flattening() {
+        let a = role("admin");
+        let b = role("editor");
+        let c = roles(["viewer"]);
+
+        let ab = a.or(b); // Or([admin, editor])
+        let abc: Authorizer<Claims> = ab.or(c); // Or([admin, editor, viewer])
+
+        match abc {
+            Authorizer::Or(inner) => {
+                assert_eq!(inner.len(), 3);
+                assert!(matches!(inner[0], Authorizer::Role(ref s) if s.contains(&"admin".to_owned())));
+                assert!(matches!(inner[1], Authorizer::Role(ref s) if s.contains(&"editor".to_owned())));
+                assert!(matches!(inner[2], Authorizer::Role(ref s) if s.contains(&"viewer".to_owned())));
+            }
+            _ => panic!("Expected Or variant"),
+        }
+    }
+
+    #[test]
+    fn it_tests_mixed_and_or_structure() {
+        let a = role::<Claims>("admin");
+        let b = role::<Claims>("editor");
+        let c = role::<Claims>("moderator");
+
+        let or_expr = a.or(b); // Or([admin, editor])
+        let combined = or_expr.and(c); // And([Or([...]), moderator])
+
+        match combined {
+            Authorizer::And(inner) => {
+                assert_eq!(inner.len(), 2);
+                match &inner[0] {
+                    Authorizer::Or(or_inner) => {
+                        assert_eq!(or_inner.len(), 2);
+                    }
+                    _ => panic!("Expected Or inside And[0]"),
+                }
+                assert!(matches!(inner[1], Authorizer::Role(ref s) if s.contains(&"moderator".to_owned())));
+            }
+            _ => panic!("Expected And variant"),
+        }
+    }
+}

--- a/src/auth/basic.rs
+++ b/src/auth/basic.rs
@@ -1,0 +1,340 @@
+//! Tools and utils for Basic Authorization
+
+use base64::engine::general_purpose::STANDARD;
+use base64::Engine;
+use std::fmt::{Display, Formatter};
+use futures_util::future::{ready, Ready};
+use hyper::http::request::Parts;
+use crate::{
+    http::{FromRequestParts, FromRequestRef, endpoints::args::{FromPayload, Payload, Source}},
+    headers::{Authorization, Header, HeaderMap, HeaderValue, AUTHORIZATION},
+    error::Error,
+    HttpRequest
+};
+
+const SCHEME: &str = "Basic ";
+
+#[derive(Debug)]
+pub struct Basic(Box<str>);
+
+impl TryFrom<&HeaderValue> for Basic {
+    type Error = Error;
+
+    #[inline]
+    fn try_from(header: &HeaderValue) -> Result<Self, Self::Error> {
+        let token = header
+            .to_str()
+            .map_err(Error::from)?;
+        let token = token.strip_prefix(SCHEME)
+            .map(str::trim)
+            .ok_or_else(|| Error::client_error("Header: Missing Credentials"))?;
+        Ok(Self(token.into()))
+    }
+}
+
+impl TryFrom<Header<Authorization>> for Basic {
+    type Error = Error;
+
+    #[inline]
+    fn try_from(header: Header<Authorization>) -> Result<Self, Self::Error> {
+        let header = header.into_inner();
+        Self::try_from(&header)
+    }
+}
+
+impl TryFrom<&HeaderMap> for Basic {
+    type Error = Error;
+
+    #[inline]
+    fn try_from(headers: &HeaderMap) -> Result<Self, Self::Error> {
+        let header = headers
+            .get(AUTHORIZATION)
+            .ok_or_else(|| Error::client_error("Header: Missing Authorization header"))?;
+        header.try_into()
+    }
+}
+
+impl TryFrom<&Parts> for Basic {
+    type Error = Error;
+
+    #[inline]
+    fn try_from(parts: &Parts) -> Result<Self, Self::Error> {
+        Self::try_from(&parts.headers)
+    }
+}
+
+impl Display for Basic {
+    #[inline]
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl FromRequestParts for Basic {
+    #[inline]
+    fn from_parts(parts: &Parts) -> Result<Self, Error> {
+        Self::try_from(parts)
+    }
+}
+
+impl FromRequestRef for Basic {
+    #[inline]
+    fn from_request(req: &HttpRequest) -> Result<Self, Error> {
+        Self::try_from(req.headers())
+    }
+}
+
+impl FromPayload for Basic {
+    type Future = Ready<Result<Self, Error>>;
+
+    #[inline]
+    fn from_payload(payload: Payload) -> Self::Future {
+        let Payload::Parts(parts) = payload else { unreachable!() };
+        ready(Self::from_parts(parts))
+    }
+
+    #[inline]
+    fn source() -> Source {
+        Source::Parts
+    }
+}
+
+impl Basic {
+    /// Validates username and password
+    pub fn validate(&self, username: &str, password: &str) -> bool {
+        let expected = format!("{username}:{password}");
+        self.validate_base64(&STANDARD.encode(expected))
+    }
+
+    /// Validates credentials encoded in Base64
+    pub fn validate_base64(&self, credentials: &str) -> bool {
+        *credentials == *self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::headers::{HeaderMap, HeaderValue, Header, Authorization, AUTHORIZATION};
+    use base64::engine::general_purpose::STANDARD;
+    use base64::Engine;
+    use hyper::Request;
+
+    fn create_basic_auth_header(username: &str, password: &str) -> HeaderValue {
+        let credentials = format!("{username}:{password}");
+        let encoded = STANDARD.encode(credentials);
+        HeaderValue::from_str(&format!("Basic {encoded}")).unwrap()
+    }
+
+    #[test]
+    fn it_tests_try_from_header_value_success() {
+        let header = create_basic_auth_header("user", "pass");
+        let basic = Basic::try_from(&header).unwrap();
+
+        let expected = STANDARD.encode("user:pass");
+        assert_eq!(basic.to_string(), expected);
+    }
+
+    #[test]
+    fn it_tests_try_from_header_value_missing_scheme() {
+        let header = HeaderValue::from_str("dXNlcjpwYXNz").unwrap(); // "user:pass" without "Basic "
+        let result = Basic::try_from(&header);
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.to_string(), "Header: Missing Credentials");
+    }
+
+    #[test]
+    fn it_tests_try_from_header_value_invalid_utf8() {
+        let mut header_value = Vec::from(b"Basic ");
+        header_value.extend_from_slice(&[0xFF, 0xFE]); // Invalid UTF-8
+
+        // This test would require creating an invalid HeaderValue, which is difficult
+        // Instead, we'll test the trim functionality
+        let header = HeaderValue::from_str("Basic   dXNlcjpwYXNz   ").unwrap(); // With spaces
+        let basic = Basic::try_from(&header).unwrap();
+
+        let expected = STANDARD.encode("user:pass");
+        assert_eq!(basic.to_string(), expected);
+    }
+
+    #[test]
+    fn it_tests_try_from_authorization_header() {
+        let header_value = create_basic_auth_header("testuser", "testpass");
+        let auth_header = Header::<Authorization>::new(&header_value);
+        let basic = Basic::try_from(auth_header).unwrap();
+
+        let expected = STANDARD.encode("testuser:testpass");
+        assert_eq!(basic.to_string(), expected);
+    }
+
+    #[test]
+    fn it_tests_try_from_header_map_success() {
+        let mut headers = HeaderMap::new();
+        let header_value = create_basic_auth_header("admin", "secret");
+        headers.insert(AUTHORIZATION, header_value);
+
+        let basic = Basic::try_from(&headers).unwrap();
+        let expected = STANDARD.encode("admin:secret");
+        assert_eq!(basic.to_string(), expected);
+    }
+
+    #[test]
+    fn it_tests_try_from_header_map_missing_authorization() {
+        let headers = HeaderMap::new();
+        let result = Basic::try_from(&headers);
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.to_string(), "Header: Missing Authorization header");
+    }
+
+    #[test]
+    fn it_tests_try_from_parts() {
+        let req = Request::builder()
+            .header(AUTHORIZATION, create_basic_auth_header("user123", "pass456"))
+            .body(())
+            .unwrap();
+        let (parts, _) = req.into_parts();
+
+        let basic = Basic::try_from(&parts).unwrap();
+        let expected = STANDARD.encode("user123:pass456");
+        assert_eq!(basic.to_string(), expected);
+    }
+
+    #[test]
+    fn it_tests_display() {
+        let encoded = STANDARD.encode("display:test");
+        let basic = Basic(encoded.clone().into_boxed_str());
+
+        assert_eq!(format!("{basic}"), encoded);
+        assert_eq!(basic.to_string(), encoded);
+    }
+
+    #[test]
+    fn it_tests_from_request_parts() {
+        let req = Request::builder()
+            .header(AUTHORIZATION, create_basic_auth_header("parts", "test"))
+            .body(())
+            .unwrap();
+        let (parts, _) = req.into_parts();
+
+        let basic = Basic::from_parts(&parts).unwrap();
+        let expected = STANDARD.encode("parts:test");
+        assert_eq!(basic.to_string(), expected);
+    }
+
+    #[tokio::test]
+    async fn it_tests_from_payload_with_parts() {
+        let req = Request::builder()
+            .header(AUTHORIZATION, create_basic_auth_header("payload", "user"))
+            .body(())
+            .unwrap();
+        let (parts, _) = req.into_parts();
+        let payload = Payload::Parts(&parts);
+
+        let basic = Basic::from_payload(payload).await.unwrap();
+
+        let expected = STANDARD.encode("payload:user");
+        assert_eq!(basic.to_string(), expected);
+    }
+
+    #[test]
+    fn it_tests_source_returns_parts() {
+        assert!(matches!(Basic::source(), Source::Parts));
+    }
+
+    #[test]
+    fn it_tests_validate_with_correct_credentials() {
+        let basic = Basic(STANDARD.encode("testuser:testpass").into_boxed_str());
+
+        assert!(basic.validate("testuser", "testpass"));
+    }
+
+    #[test]
+    fn it_tests_validate_with_incorrect_username() {
+        let basic = Basic(STANDARD.encode("testuser:testpass").into_boxed_str());
+
+        assert!(!basic.validate("wronguser", "testpass"));
+    }
+
+    #[test]
+    fn it_tests_validate_with_incorrect_password() {
+        let basic = Basic(STANDARD.encode("testuser:testpass").into_boxed_str());
+
+        assert!(!basic.validate("testuser", "wrongpass"));
+    }
+
+    #[test]
+    fn it_tests_validate_with_empty_credentials() {
+        let basic = Basic(STANDARD.encode(":").into_boxed_str());
+
+        assert!(basic.validate("", ""));
+    }
+
+    #[test]
+    fn it_tests_validate_with_special_characters() {
+        let username = "user@domain.com";
+        let password = "p@$$w0rd!";
+        let basic = Basic(STANDARD.encode(format!("{username}:{password}")).into_boxed_str());
+
+        assert!(basic.validate(username, password));
+        assert!(!basic.validate("user@domain.com", "wrongpass"));
+    }
+
+    #[test]
+    fn it_tests_validate_base64_with_correct_credentials() {
+        let credentials = "dXNlcjpwYXNz"; // base64 for "user:pass"
+        let basic = Basic(credentials.into());
+
+        assert!(basic.validate_base64(credentials));
+    }
+
+    #[test]
+    fn it_tests_validate_base64_with_incorrect_credentials() {
+        let correct_credentials = "dXNlcjpwYXNz"; // base64 for "user:pass"
+        let wrong_credentials = "YWRtaW46c2VjcmV0"; // base64 for "admin:secret"
+        let basic = Basic(correct_credentials.into());
+
+        assert!(!basic.validate_base64(wrong_credentials));
+    }
+
+    #[test]
+    fn it_tests_validate_base64_with_empty_string() {
+        let basic = Basic("".into());
+
+        assert!(basic.validate_base64(""));
+        assert!(!basic.validate_base64("dXNlcjpwYXNz"));
+    }
+
+    #[test]
+    fn it_tests_case_sensitive_validation() {
+        let basic = Basic(STANDARD.encode("User:Pass").into_boxed_str());
+
+        assert!(basic.validate("User", "Pass"));
+        assert!(!basic.validate("user", "Pass"));
+        assert!(!basic.validate("User", "pass"));
+        assert!(!basic.validate("user", "pass"));
+    }
+
+    #[test]
+    fn it_tests_unicode_credentials() {
+        let username = "użytkownik";
+        let password = "hasło123";
+        let basic = Basic(STANDARD.encode(format!("{username}:{password}")).into_boxed_str());
+
+        assert!(basic.validate(username, password));
+        assert!(!basic.validate("user", password));
+    }
+
+    #[test]
+    fn it_tests_colon_in_password() {
+        let username = "user";
+        let password = "pass:with:colons";
+        let basic = Basic(STANDARD.encode(format!("{username}:{password}")).into_boxed_str());
+
+        assert!(basic.validate(username, password));
+        assert!(!basic.validate(username, "pass"));
+    }
+}

--- a/src/auth/bearer.rs
+++ b/src/auth/bearer.rs
@@ -115,12 +115,12 @@ impl BearerAuthConfig {
     ///     .with_bearer_auth(|auth| auth
     ///         .with_iss(["some issuer"]));
     /// ```
-    pub fn with_iss<I, T>(mut self, aud: I) -> Self
+    pub fn with_iss<I, T>(mut self, iss: I) -> Self
     where
         T: ToString,
         I: AsRef<[T]>
     {
-        self.validation.set_issuer(aud.as_ref());
+        self.validation.set_issuer(iss.as_ref());
         self
     }
 
@@ -666,7 +666,7 @@ mod tests {
         let token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.test";
         let bearer = Bearer(token.into());
 
-        assert_eq!(format!("{}", bearer), token);
+        assert_eq!(format!("{bearer}"), token);
     }
 
     #[tokio::test]

--- a/src/auth/bearer.rs
+++ b/src/auth/bearer.rs
@@ -1,0 +1,374 @@
+//! Tools and utils for Bearer Token Authorization
+
+use std::{fmt::{Display, Formatter}, sync::Arc};
+use futures_util::future::{ready, Ready};
+use hyper::http::request::Parts;
+use serde::{de::DeserializeOwned, Serialize};
+use crate::{
+    http::{Extensions, endpoints::args::{FromPayload, FromRequestParts, FromRequestRef, Payload, Source}}, 
+    headers::{HeaderMap, HeaderValue, Header, Authorization, AUTHORIZATION},
+    error::Error, 
+    HttpRequest,
+};
+use jsonwebtoken::{
+    EncodingKey, DecodingKey,
+    Validation, Algorithm, 
+    Header as JwtHeader
+};
+
+const SCHEME: &str = "Bearer ";
+
+/// Bearer Token Authentication configuration
+#[derive(Default)]
+pub struct BearerAuthConfig {
+    validation: Validation,
+    encoding: Option<EncodingKey>,
+    decoding: Option<DecodingKey>,
+}
+
+impl BearerAuthConfig {
+    /// Specifies a security key to validate a JWT. 
+    /// 
+    /// # Example
+    /// ```no_run
+    /// use volga::{App, auth::DecodingKey};
+    ///
+    /// let secret = std::env::var("JWT_SECRET")
+    ///     .expect("JWT_SECRET must be set");
+    /// 
+    /// let key = DecodingKey::from_secret(secret.as_bytes());
+    /// 
+    /// let app = App::new()
+    ///     .with_bearer_auth(|auth| auth
+    ///         .set_decoding_key(key));
+    /// ```
+    pub fn set_decoding_key(mut self, key: DecodingKey) -> Self {
+        self.decoding = Some(key);
+        self
+    }
+
+    /// Specifies a security key to generate a JWT. 
+    ///
+    /// # Example
+    /// ```no_run
+    /// use volga::{App, auth::EncodingKey};
+    ///
+    /// let secret = std::env::var("JWT_SECRET")
+    ///     .expect("JWT_SECRET must be set");
+    /// 
+    /// let key = EncodingKey::from_secret(secret.as_bytes());
+    /// 
+    /// let app = App::new()
+    ///     .with_bearer_auth(|auth| auth
+    ///         .set_encoding_key(key));
+    /// ```
+    pub fn set_encoding_key(mut self, key: EncodingKey) -> Self {
+        self.encoding = Some(key);
+        self
+    }
+    
+    /// Specifies the algorithm supported for signing/verifying JWTs
+    /// 
+    /// Default: [`Algorithm::HS256`]
+    /// 
+    /// # Example
+    /// ```no_run
+    /// use volga::{App, auth::Algorithm};
+    /// 
+    /// let app = App::new()
+    ///     .with_bearer_auth(|auth| auth
+    ///         .with_alg(Algorithm::RS256));
+    /// ```
+    pub fn with_alg(mut self, alg: Algorithm) -> Self {
+        if !self.validation.algorithms.contains(&alg) { 
+            self.validation.algorithms.push(alg);  
+        }
+        self
+    }
+    
+    /// Sets one or more acceptable audience members
+    ///
+    /// # Example
+    /// ```no_run
+    /// use volga::App;
+    /// 
+    /// let app = App::new()
+    ///     .with_bearer_auth(|auth| auth
+    ///         .with_aud(["some audience"]));
+    /// ```
+    pub fn with_aud<I, T>(mut self, aud: I) -> Self
+    where
+        T: ToString,
+        I: AsRef<[T]>
+    {
+        self.validation.set_audience(aud.as_ref());
+        self
+    }
+
+    /// Sets one or more acceptable issuers
+    ///
+    /// # Example
+    /// ```no_run
+    /// use volga::App;
+    ///
+    /// let app = App::new()
+    ///     .with_bearer_auth(|auth| auth
+    ///         .with_iss(["some issuer"]));
+    /// ```
+    pub fn with_iss<I, T>(mut self, aud: I) -> Self
+    where
+        T: ToString,
+        I: AsRef<[T]>
+    {
+        self.validation.set_issuer(aud.as_ref());
+        self
+    }
+
+    /// Specifies whether to validate the `aud` field or not.
+    ///
+    /// It will return an error if the `aud` field is not a member of the audience provided.
+    /// Validation only happens if the `aud` claim is present in the token.
+    ///
+    /// Default: `true`
+    ///
+    /// # Example
+    /// ```no_run
+    /// use volga::App;
+    ///
+    /// let app = App::new()
+    ///     .with_bearer_auth(|auth| auth
+    ///         .validate_aud(true));
+    /// ```
+    pub fn validate_aud(mut self, validate: bool) -> Self {
+        self.validation.validate_aud = validate;
+        self
+    }
+
+    /// Specifies whether to validate the `exp` field or not.
+    ///
+    /// It will return an error if the time in the exp field is past.
+    ///
+    /// Default: `true`
+    ///
+    /// # Example
+    /// ```no_run
+    /// use volga::App;
+    ///
+    /// let app = App::new()
+    ///     .with_bearer_auth(|auth| auth
+    ///         .validate_exp(true));
+    /// ```
+    pub fn validate_exp(mut self, validate: bool) -> Self {
+        self.validation.validate_exp = validate;
+        self
+    }
+
+    /// Specifies whether to validate the `nbf` field or not.
+    ///
+    /// It will return an error if the current timestamp is before the time in the `nbf` field.
+    /// Validation only happens if the `nbf` claim is present in the token.
+    ///
+    /// Default: `false`
+    ///
+    /// # Example
+    /// ```no_run
+    /// use volga::App;
+    ///
+    /// let app = App::new()
+    ///     .with_bearer_auth(|auth| auth
+    ///         .validate_nbf(true));
+    /// ```
+    pub fn validate_nbf(mut self, validate: bool) -> Self {
+        self.validation.validate_nbf = validate;
+        self
+    }
+
+    pub fn decoding_key(&self) -> Option<&DecodingKey> {
+        self.decoding.as_ref()
+    }
+}
+
+/// Service that handles bearer token generation and validation
+#[derive(Clone)]
+pub struct BearerTokenService {
+    validation: Arc<Validation>,
+    encoding: Option<Arc<EncodingKey>>,
+    decoding: Option<Arc<DecodingKey>>,
+}
+
+impl From<BearerAuthConfig> for BearerTokenService {
+    #[inline]
+    fn from(value: BearerAuthConfig) -> Self {
+        Self {
+            validation: Arc::new(value.validation),
+            encoding: value.encoding.map(Arc::new),
+            decoding: value.decoding.map(Arc::new),
+        }
+    }
+}
+
+impl BearerTokenService {
+    /// Returns validation rules  for JWT
+    pub fn validation(&self) -> &Validation {
+        &self.validation
+    }
+    
+    /// Returns a secret key for decoding JWT
+    pub fn decoding_key(&self) -> Option<Arc<DecodingKey>> {
+        self.decoding.clone()
+    }
+
+    /// Returns a secret key for encoding JWT
+    pub fn encoding_key(&self) -> Option<Arc<EncodingKey>> {
+        self.encoding.clone()
+    }
+
+    /// Encode the header and claims given and sign the payload using the algorithm from the header and the key. 
+    /// If the algorithm given is RSA or EC, the key needs to be in the PEM format.
+    pub fn encode<C: Serialize>(&self, claims: &C) -> Result<Bearer, Error> {
+        let Some(encoding_key) = &self.encoding else {
+            return Err(Error::server_error("Missing security key"));
+        };
+        jsonwebtoken::encode(&JwtHeader::default(), claims, encoding_key)
+            .map_err(Error::from)
+            .map(|s| Bearer(s.into()))
+    }
+
+    /// Decodes and validates a JSON Web Token
+    ///
+    /// If the token or its signature is invalid or the claims fail validation, it will return an error.
+    pub fn decode<C: DeserializeOwned>(&self, bearer: Bearer) -> Result<C, Error> {
+        let Some(decoding_key) = &self.decoding else { 
+            return Err(Error::server_error("Missing security key")); 
+        };
+        jsonwebtoken::decode(&bearer.0, decoding_key, &self.validation)
+            .map_err(Error::from)
+            .map(|t| t.claims)
+    }
+}
+
+/// Wraps a bearer token string
+pub struct Bearer(Box<str>);
+
+impl TryFrom<&HeaderValue> for Bearer {
+    type Error = Error;
+    
+    #[inline]
+    fn try_from(header: &HeaderValue) -> Result<Self, Self::Error> {
+        let token = header
+            .to_str()
+            .map_err(Error::from)?;
+        let token = token.strip_prefix(SCHEME)
+            .map(str::trim)
+            .ok_or_else(|| Error::client_error("Header: Missing Credentials"))?;
+        Ok(Self(token.into()))
+    }
+}
+
+impl TryFrom<Header<Authorization>> for Bearer {
+    type Error = Error;
+    
+    #[inline]
+    fn try_from(header: Header<Authorization>) -> Result<Self, Self::Error> {
+        let header = header.into_inner();
+        Self::try_from(&header)
+    }
+}
+
+impl TryFrom<&HeaderMap> for Bearer {
+    type Error = Error;
+
+    #[inline]
+    fn try_from(headers: &HeaderMap) -> Result<Self, Self::Error> {
+        let header = headers
+            .get(AUTHORIZATION)
+            .ok_or_else(|| Error::client_error("Header: Missing Authorization header"))?;
+        header.try_into()
+    }
+}
+
+impl TryFrom<&Parts> for Bearer {
+    type Error = Error;
+    
+    #[inline]
+    fn try_from(parts: &Parts) -> Result<Self, Self::Error> {
+        Self::try_from(&parts.headers)
+    }
+}
+
+impl Display for Bearer {
+    #[inline]
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl FromRequestParts for Bearer {
+    #[inline]
+    fn from_parts(parts: &Parts) -> Result<Self, Error> {
+        Self::try_from(parts)
+    }
+}
+
+impl FromRequestRef for Bearer {
+    #[inline]
+    fn from_request(req: &HttpRequest) -> Result<Self, Error> {
+        Self::try_from(req.headers())
+    }
+}
+
+impl FromPayload for Bearer {
+    type Future = Ready<Result<Self, Error>>;
+    
+    #[inline]
+    fn from_payload(payload: Payload) -> Self::Future {
+        let Payload::Parts(parts) = payload else { unreachable!() };
+        ready(Self::from_parts(parts))
+    }
+
+    #[inline]
+    fn source() -> Source {
+        Source::Parts
+    }
+}
+
+impl TryFrom<&Extensions> for BearerTokenService {
+    type Error = Error;
+
+    #[inline]
+    fn try_from(extensions: &Extensions) -> Result<Self, Self::Error> {
+        let bts = extensions
+            .get::<BearerTokenService>()
+            .ok_or_else(|| Error::server_error("Bearer Token authorization is not properly configured"))?;
+        Ok(bts.clone())
+    }
+}
+
+impl FromRequestParts for BearerTokenService {
+    #[inline]
+    fn from_parts(parts: &Parts) -> Result<Self, Error> {
+        Self::try_from(&parts.extensions)
+    }
+}
+
+impl FromRequestRef for BearerTokenService {
+    #[inline]
+    fn from_request(req: &HttpRequest) -> Result<Self, Error> {
+        Self::try_from(req.extensions())
+    }
+}
+
+impl FromPayload for BearerTokenService {
+    type Future = Ready<Result<Self, Error>>;
+
+    #[inline]
+    fn from_payload(payload: Payload) -> Self::Future {
+        let Payload::Parts(parts) = payload else { unreachable!() };
+        ready(Self::from_parts(parts))
+    }
+
+    #[inline]
+    fn source() -> Source {
+        Source::Parts
+    }
+}

--- a/src/auth/claims.rs
+++ b/src/auth/claims.rs
@@ -1,0 +1,174 @@
+//! Utilities for custom claims
+
+use serde::de::DeserializeOwned;
+
+/// Trait representing extractable authorization claims from a JWT payload.
+///
+/// Types implementing this trait allow the framework to access optional authorization
+/// information such as roles or permissions, enabling role-based or permission-based
+/// access control.
+///
+/// This trait is intended to be implemented by your custom claims struct, which is typically
+/// deserialized from the JWT payload. All methods are optional; by default, they return `None`.
+/// You can override only the methods relevant to your use case.
+///
+/// # Example
+///
+/// ```no_run
+/// use serde::Deserialize;
+/// use volga::auth::AuthClaims;
+///
+/// #[derive(Debug, Deserialize)]
+/// struct MyClaims {
+///     sub: String,
+///     role: String,
+/// }
+///
+/// impl AuthClaims for MyClaims {
+///     fn role(&self) -> Option<&str> {
+///         Some(&self.role)
+///     }
+/// }
+/// ```
+pub trait AuthClaims: DeserializeOwned {
+    /// Returns the primary role associated with the claims.
+    ///
+    /// This is useful for role-based access control (RBAC) where only a single role is expected.
+    /// If multiple roles are used, prefer implementing the [`AuthClaims::roles()`] method.
+    ///
+    /// By default, returns `None`.
+    fn role(&self) -> Option<&str> {
+        None
+    }
+
+    /// Returns the list of roles associated with the claims.
+    ///
+    /// Useful when a subject can have multiple roles.
+    /// If a single role is used instead, you may override [`AuthClaims::role()`] instead.
+    ///
+    /// By default, returns `None`.
+    fn roles(&self) -> Option<&[String]> {
+        None
+    }
+
+    /// Returns the list of permissions granted to the subject.
+    ///
+    /// By default, returns `None`.
+    fn permissions(&self) -> Option<&[String]> {
+        None
+    }
+}
+
+#[macro_export]
+macro_rules! claims {
+    (
+        $(#[$meta:meta])*
+        $vis:vis struct $name:ident {
+            $(
+                $(#[$field_meta:meta])*
+                $field:ident : $type:ty
+            ),* $(,)?
+        }
+    ) => {
+        $(#[$meta])*
+        $vis struct $name {
+            $(
+                $(#[$field_meta])*
+                pub $field: $type,
+            )*
+        }
+
+        impl $crate::auth::AuthClaims for $name {
+            $(
+                claims!(@gen_impl $field);
+            )*
+        }
+    };
+
+    (@gen_impl role) => {
+        fn role(&self) -> Option<&str> {
+            Some(&self.role)
+        }
+    };
+    (@gen_impl roles) => {
+        fn roles(&self) -> Option<&[String]> {
+            Some(&self.roles)
+        }
+    };
+    (@gen_impl permissions) => {
+        fn permissions(&self) -> Option<&[String]> {
+            Some(&self.permissions)
+        }
+    };
+    
+    (@gen_impl $field:ident) => {};
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{Authorizer, role, roles, permissions, predicate};
+    use serde::{Serialize, Deserialize};
+
+    claims! {
+        #[derive(Debug, Serialize, Deserialize)]
+        struct MyClaims {
+            sub: String,
+            role: String,
+            permissions: Vec<String>,
+        }
+    }
+
+    claims! {
+        #[derive(Debug, Serialize, Deserialize)]
+        struct MyClaims2 {
+            sub: String,
+            roles: Vec<String>,
+        }
+    }
+    
+    #[test]
+    fn it_creates_claims_and_test_role() {
+        let claims = MyClaims {
+            sub: "123".to_string(),
+            role: "admin".to_string(),
+            permissions: vec!["read".to_string(), "write".to_string()],
+        };
+        
+        let validate: Authorizer<MyClaims> = role("admin");
+        assert!(validate.validate(&claims))
+    }
+
+    #[test]
+    fn it_creates_claims_and_test_roles() {
+        let claims = MyClaims2 {
+            sub: "123".to_string(),
+            roles: vec!["admin".to_string(), "user".to_string()],
+        };
+
+        let validate: Authorizer<MyClaims2> = roles(["admin", "user", "editor"]);
+        assert!(validate.validate(&claims))
+    }
+
+    #[test]
+    fn it_creates_claims_and_test_permissions() {
+        let claims = MyClaims {
+            sub: "123".to_string(),
+            role: "user".to_string(),
+            permissions: vec!["read".to_string(), "write".to_string()],
+        };
+
+        let validate: Authorizer<MyClaims> = permissions(["write"]);
+        assert!(validate.validate(&claims))
+    }
+
+    #[test]
+    fn it_creates_claims_and_test_predicate() {
+        let claims = MyClaims {
+            sub: "123".to_string(),
+            role: "user".to_string(),
+            permissions: vec!["read".to_string(), "write".to_string()],
+        };
+        let validate = predicate(|c: &MyClaims| c.sub == "123");
+        assert!(validate.validate(&claims))
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,8 +6,9 @@ use std::{
     io::{ErrorKind, Error as IoError},
     error::Error as StdError
 };
+
 use super::{
-    App, 
+    App,
     http::{
         GenericHandler,
         MapErrHandler,
@@ -42,7 +43,7 @@ pub(crate) type BoxError = Box<
 pub struct Error {
     pub status: StatusCode,
     pub instance: Option<String>,
-    pub(crate) inner: BoxError
+    pub(crate) inner: BoxError,
 }
 
 impl fmt::Display for Error {
@@ -68,7 +69,7 @@ impl From<serde_json::Error> for Error {
         Self {
             status: StatusCode::BAD_REQUEST,
             inner: err.into(),
-            instance: None
+            instance: None,
         }
     }
 }
@@ -95,7 +96,7 @@ impl From<IoError> for Error {
         };
         
         Self { 
-            instance: None, 
+            instance: None,
             inner: err.into(),
             status
         }
@@ -125,7 +126,7 @@ impl Error {
         Self {
             status: StatusCode::INTERNAL_SERVER_ERROR,
             inner: err.into(),
-            instance: None
+            instance: None,
         }
     }
 
@@ -135,7 +136,7 @@ impl Error {
         Self {
             status: StatusCode::BAD_REQUEST,
             inner: err.into(),
-            instance: None
+            instance: None,
         }
     }
     

--- a/src/error.rs
+++ b/src/error.rs
@@ -103,6 +103,17 @@ impl From<IoError> for Error {
     }
 }
 
+impl From<hyper::http::Error> for Error {
+    #[inline]
+    fn from(err: hyper::http::Error) -> Self {
+        Self {
+            instance: None,
+            inner: err.into(),
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+}
+
 impl From<Error> for IoError {
     #[inline]
     fn from(err: Error) -> Self {

--- a/src/error/handler.rs
+++ b/src/error/handler.rs
@@ -93,7 +93,7 @@ pub(crate) type WeakErrorHandler = Weak<
 /// Default error handler that creates a [`HttpResult`] from error
 #[inline]
 pub(crate) async fn default_error_handler(err: Error) -> HttpResult {
-    status!(err.status.as_u16(), "{}", err.to_string())
+    status!(err.status.as_u16(), "{err}")
 }
 
 #[inline]

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -9,6 +9,7 @@ pub use hyper::{
         ACCESS_CONTROL_ALLOW_CREDENTIALS, ACCESS_CONTROL_ALLOW_HEADERS, ACCESS_CONTROL_ALLOW_METHODS,
         ACCESS_CONTROL_ALLOW_ORIGIN, ACCESS_CONTROL_EXPOSE_HEADERS, ACCESS_CONTROL_MAX_AGE,
         ACCESS_CONTROL_REQUEST_HEADERS, ACCESS_CONTROL_REQUEST_METHOD,
+        AUTHORIZATION,
         CACHE_CONTROL,
         CONTENT_DISPOSITION, CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_RANGE, CONTENT_TYPE,
         ETAG,
@@ -23,7 +24,8 @@ pub use hyper::{
         VARY,
         UPGRADE,
         CONNECTION,
-        COOKIE, SET_COOKIE
+        COOKIE, SET_COOKIE,
+        WWW_AUTHENTICATE
     },
     http::{HeaderName, HeaderValue},
     HeaderMap
@@ -77,5 +79,19 @@ impl HeaderError {
     #[inline]
     fn from_to_str_error(error: ToStrError) -> Error {
         Error::client_error(format!("Header: {error}"))
+    }
+}
+
+impl core::convert::From<InvalidHeaderValue> for Error {
+    #[inline]
+    fn from(error: InvalidHeaderValue) -> Self {
+        HeaderError::from_invalid_header_value(error)
+    }
+}
+
+impl core::convert::From<ToStrError> for Error {
+    #[inline]
+    fn from(error: ToStrError) -> Self {
+        HeaderError::from_to_str_error(error)
     }
 }

--- a/src/headers/cache_control.rs
+++ b/src/headers/cache_control.rs
@@ -11,6 +11,16 @@ use std::fs::Metadata;
 #[cfg(feature = "static-files")]
 const DEFAULT_MAX_AGE: u32 = 60 * 60 * 24; // 24 hours
 
+pub const NO_STORE: &str = "no-store";
+pub const NO_CACHE: &str = "no-cache";
+pub const MAX_AGE: &str = "max-age";
+pub const S_MAX_AGE: &str = "s-maxage";
+pub const MUST_REVALIDATE: &str = "must-revalidate";
+pub const PROXY_REVALIDATE: &str = "proxy-revalidate";
+pub const PUBLIC: &str = "public";
+pub const PRIVATE: &str = "private";
+pub const IMMUTABLE: &str = "immutable"; 
+
 /// Represents the HTTP [`Cache-Control`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control)
 /// header holds directives (instructions) in both requests and responses that control caching 
 /// in browsers and shared caches (e.g., Proxies, CDNs).
@@ -69,31 +79,31 @@ impl fmt::Display for CacheControl {
         let mut directives = Vec::new();
 
         if self.no_cache {
-            directives.push("no-cache".to_string());
+            directives.push(NO_CACHE.to_string());
         }
         if self.no_store {
-            directives.push("no-store".to_string());
+            directives.push(NO_STORE.to_string());
         }
         if let Some(max_age) = self.max_age {
-            directives.push(format!("max-age={max_age}"));
+            directives.push(format!("{MAX_AGE}={max_age}"));
         }
         if let Some(s_max_age) = self.s_max_age {
-            directives.push(format!("s-maxage={s_max_age}"));
+            directives.push(format!("{S_MAX_AGE}={s_max_age}"));
         }
         if self.must_revalidate {
-            directives.push("must-revalidate".to_string());
+            directives.push(MUST_REVALIDATE.to_string());
         }
         if self.proxy_revalidate {
-            directives.push("proxy-revalidate".to_string());
+            directives.push(PROXY_REVALIDATE.to_string());
         }
         if self.public {
-            directives.push("public".to_string());
+            directives.push(PUBLIC.to_string());
         }
         if self.private {
-            directives.push("private".to_string());
+            directives.push(PRIVATE.to_string());
         }
         if self.immutable {
-            directives.push("immutable".to_string());
+            directives.push(IMMUTABLE.to_string());
         }
         
         f.write_str(directives.join(", ").as_str())

--- a/src/http/cors.rs
+++ b/src/http/cors.rs
@@ -391,7 +391,7 @@ impl CorsConfig {
 }
 
 impl App {
-    /// Configures web server with specified CORS configuration
+    /// Configures a web server with specified CORS configuration
     ///
     /// Default: `None`
     ///

--- a/src/http/endpoints/route.rs
+++ b/src/http/endpoints/route.rs
@@ -334,6 +334,7 @@ mod tests {
     use crate::ok;
     use crate::http::endpoints::handlers::{Func, RouteHandler};
     use crate::http::endpoints::route::RouteNode;
+    #[cfg(debug_assertions)]
     use super::super::meta::RouteInfo;
     
     #[test]
@@ -371,6 +372,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(debug_assertions)]
     fn it_collects_single_static_route() {
         let handler = || async { ok!() };
         let handler: RouteHandler = Func::new(handler);
@@ -387,6 +389,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(debug_assertions)]
     fn it_collects_multiple_methods_same_route() {
         let handler = || async { ok!() };
         let handler: RouteHandler = Func::new(handler);
@@ -405,6 +408,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(debug_assertions)]
     fn it_collects_nested_static_routes() {
         let handler = || async { ok!() };
         let handler: RouteHandler = Func::new(handler);
@@ -424,6 +428,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(debug_assertions)]
     fn it_collects_dynamic_routes() {
         let handler = || async { ok!() };
         let handler: RouteHandler = Func::new(handler);
@@ -440,6 +445,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(debug_assertions)]
     fn it_collects_mixed_static_and_dynamic_routes() {
         let handler = || async { ok!() };
         let handler: RouteHandler = Func::new(handler);
@@ -462,6 +468,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(debug_assertions)]
     fn it_collects_root_route() {
         let handler = || async { ok!() };
         let handler: RouteHandler = Func::new(handler);
@@ -478,6 +485,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(debug_assertions)]
     fn it_collects_complex_route_tree() {
         let handler = || async { ok!() };
         let handler: RouteHandler = Func::new(handler);
@@ -506,6 +514,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(debug_assertions)]
     fn it_handles_empty_route_tree() {
         let route = RouteNode::Static(HashMap::new());
 
@@ -515,6 +524,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(debug_assertions)]
     fn it_collects_routes_with_multiple_dynamic_segments() {
         let handler = || async { ok!() };
         let handler: RouteHandler = Func::new(handler);
@@ -531,6 +541,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(debug_assertions)]
     fn it_collects_routes_with_different_http_methods() {
         let handler = || async { ok!() };
         let handler: RouteHandler = Func::new(handler);
@@ -559,5 +570,4 @@ mod tests {
             assert_eq!(route.path, "/resource");
         }
     }
-
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,8 @@ pub mod tls;
 pub mod tracing;
 #[cfg(feature = "ws")]
 pub mod ws;
+#[cfg(any(feature = "basic-auth", feature = "jwt-auth"))]
+pub mod auth;
 #[cfg(test)]
 pub mod test_utils;
 

--- a/src/middleware/compress.rs
+++ b/src/middleware/compress.rs
@@ -1,6 +1,6 @@
 ﻿//! Compression middleware
 //! 
-//! Middleware that compress HTTP response body
+//! Middleware that compresses HTTP response body
 
 use std::{
     collections::HashSet,

--- a/src/middleware/decompress.rs
+++ b/src/middleware/decompress.rs
@@ -1,6 +1,6 @@
 ﻿//! Decompression middleware
 //!
-//! Middleware that decompress HTTP request body
+//! Middleware that decompresses the HTTP request body
 
 #[cfg(feature = "decompression-brotli")]
 use async_compression::tokio::bufread::BrotliDecoder;

--- a/tests/jwt.rs
+++ b/tests/jwt.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use jsonwebtoken::{DecodingKey, EncodingKey};
 use serde::{Deserialize, Serialize};
 use volga::{ok, App};
-use volga::headers::AUTHORIZATION;
+use volga::headers::{AUTHORIZATION, CACHE_CONTROL, WWW_AUTHENTICATE};
 use volga::auth::{BearerTokenService, AuthClaims, predicate};
 
 #[derive(Serialize, Deserialize)]
@@ -91,6 +91,7 @@ async fn it_generates_jwt_and_authenticates_it() {
     }).await.unwrap().unwrap();
 
     assert!(response.status().is_success());
+    assert_eq!(response.headers().get(CACHE_CONTROL).unwrap(), "no-store");
     assert_eq!(response.text().await.unwrap(), "Pass!");
 }
 
@@ -153,4 +154,6 @@ async fn it_generates_jwt_and_failed_to_authenticates_it() {
     }).await.unwrap().unwrap();
 
     assert!(!response.status().is_success());
+    assert_eq!(response.headers().get(CACHE_CONTROL).unwrap(), "no-store");
+    assert_eq!(response.headers().get(WWW_AUTHENTICATE).unwrap(), "Bearer error=\"insufficient_scope\" error_description=\"User does not have required role or permission\"");
 }

--- a/tests/jwt.rs
+++ b/tests/jwt.rs
@@ -1,0 +1,156 @@
+use std::ops::Add;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use jsonwebtoken::{DecodingKey, EncodingKey};
+use serde::{Deserialize, Serialize};
+use volga::{ok, App};
+use volga::headers::AUTHORIZATION;
+use volga::auth::{BearerTokenService, AuthClaims, predicate};
+
+#[derive(Serialize, Deserialize)]
+struct AuthData {
+    access_token: String,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Claims {
+    sub: String,
+    iss: String,
+    aud: String,
+    company: String,
+    roles: Vec<String>,
+    permissions: Vec<String>,
+    exp: u64,
+}
+
+impl AuthClaims for Claims {
+    fn roles(&self) -> Option<&[String]> {
+        Some(&self.roles)
+    }
+
+    fn permissions(&self) -> Option<&[String]> {
+        Some(&self.permissions)
+    }
+}
+
+#[tokio::test]
+async fn it_generates_jwt_and_authenticates_it() {
+    tokio::spawn(async {
+        let mut app = App::new()
+            .bind("127.0.0.1:7960")
+            .with_bearer_auth(|auth| auth
+                .set_encoding_key(EncodingKey::from_secret(b"test secret"))
+                .set_decoding_key(DecodingKey::from_secret(b"test secret"))
+                .with_aud(["test"])
+                .with_iss(["test"]));
+
+        app.map_get("/test", || async { "Pass!" })
+            .authorize(predicate(|claims: &Claims| claims.roles.iter().any(|role| role == "admin")));
+
+        app.map_post("/login", |bts: BearerTokenService| async move {
+            let exp = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("Time went backwards")
+                .add(Duration::from_secs(300))
+                .as_secs();
+
+            let claims = Claims {
+                aud: "test".to_owned(),
+                iss: "test".to_owned(),
+                sub: "email.com".to_owned(),
+                company: "Awesome Co.".to_owned(),
+                roles: vec!["admin".to_owned()],
+                permissions: vec![],
+                exp,
+            };
+
+            let access_token = bts.encode(&claims)?
+                .to_string();
+
+            ok!(AuthData { access_token })
+        });
+        
+        app.run().await
+    });
+
+    let token = tokio::spawn(async {
+        let client = if cfg!(all(feature = "http1", not(feature = "http2"))) {
+            reqwest::Client::builder().http1_only().build().unwrap()
+        } else {
+            reqwest::Client::builder().http2_prior_knowledge().build().unwrap()
+        };
+        client.post("http://127.0.0.1:7960/login").send().await
+    }).await.unwrap().unwrap().json::<AuthData>().await.unwrap().access_token;
+    
+    let response = tokio::spawn(async move {
+        let client = if cfg!(all(feature = "http1", not(feature = "http2"))) {
+            reqwest::Client::builder().http1_only().build().unwrap()
+        } else {
+            reqwest::Client::builder().http2_prior_knowledge().build().unwrap()
+        };
+        client.get("http://127.0.0.1:7960/test").header(AUTHORIZATION, format!("Bearer {token}")).send().await
+    }).await.unwrap().unwrap();
+
+    assert!(response.status().is_success());
+    assert_eq!(response.text().await.unwrap(), "Pass!");
+}
+
+#[tokio::test]
+async fn it_generates_jwt_and_failed_to_authenticates_it() {
+    tokio::spawn(async {
+        let mut app = App::new()
+            .bind("127.0.0.1:7961")
+            .with_bearer_auth(|auth| auth
+                .set_encoding_key(EncodingKey::from_secret(b"test secret"))
+                .set_decoding_key(DecodingKey::from_secret(b"test secret"))
+                .with_aud(["test"])
+                .with_iss(["test"]));
+
+        app.map_get("/test", || async { "Pass!" })
+            .authorize(predicate(|claims: &Claims| claims.roles.iter().any(|role| role == "admin")));
+
+        app.map_post("/login", |bts: BearerTokenService| async move {
+            let exp = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("Time went backwards")
+                .add(Duration::from_secs(300))
+                .as_secs();
+
+            let claims = Claims {
+                aud: "test".to_owned(),
+                iss: "test".to_owned(),
+                sub: "email.com".to_owned(),
+                company: "Awesome Co.".to_owned(),
+                roles: vec!["user".to_owned()],
+                permissions: vec![],
+                exp,
+            };
+
+            let access_token = bts.encode(&claims)?
+                .to_string();
+
+            ok!(AuthData { access_token })
+        });
+
+        app.run().await
+    });
+
+    let token = tokio::spawn(async {
+        let client = if cfg!(all(feature = "http1", not(feature = "http2"))) {
+            reqwest::Client::builder().http1_only().build().unwrap()
+        } else {
+            reqwest::Client::builder().http2_prior_knowledge().build().unwrap()
+        };
+        client.post("http://127.0.0.1:7961/login").send().await
+    }).await.unwrap().unwrap().json::<AuthData>().await.unwrap().access_token;
+
+    let response = tokio::spawn(async move {
+        let client = if cfg!(all(feature = "http1", not(feature = "http2"))) {
+            reqwest::Client::builder().http1_only().build().unwrap()
+        } else {
+            reqwest::Client::builder().http2_prior_knowledge().build().unwrap()
+        };
+        client.get("http://127.0.0.1:7961/test").header(AUTHORIZATION, format!("Bearer {token}")).send().await
+    }).await.unwrap().unwrap();
+
+    assert!(!response.status().is_success());
+}


### PR DESCRIPTION
* Added bearer token authentication and authorization
* Added basic authentication

## Generate JWT
```rust
use std::{ops::Add, time::{SystemTime, UNIX_EPOCH, Duration}};
use serde::{Deserialize, Serialize};
use volga::{
    App, Json, HttpResult, 
    auth::{BearerTokenService, EncodingKey}, 
    ok, status, bad_request
};

fn main() {
    let secret = std::env::var("JWT_SECRET")
        .expect("JWT_SECRET must be set");

    let mut app = App::new()
        .with_bearer_auth(|auth| auth
            .set_encoding_key(EncodingKey::from_secret(secret.as_bytes())));
    
    app.map_post("/login", login);
    
    app.run_blocking()
}

async fn login(payload: Json<Payload>, bts: BearerTokenService) -> HttpResult {
    if payload.client_id.is_empty() || payload.client_secret.is_empty() {
        return bad_request!("Missing Credentials");
    }
    if payload.client_id != "foo" || payload.client_secret != "bar" {
        return status!(401, "Invalid Credentials");
    }

    let exp = SystemTime::now()
        .duration_since(UNIX_EPOCH)
        .expect("Time went backwards")
        .add(Duration::from_secs(300))
        .as_secs();
    
    let claims = MyClaims {
        sub: "email.com".to_owned(),
        company: "Awesome Co.".to_owned(),
        role: "admin".to_owned(),
        exp,
    };
    
    let access_token = bts.encode(&claims)?
        .to_string();
    
    ok!(AuthData { access_token })
}

#[derive(Serialize)]
struct MyClaims {
    sub: String,
    company: String,
    role: String,
    exp: u64,
}

#[derive(Serialize)]
struct AuthData {
    access_token: String,
}

#[derive(Deserialize)]
struct Payload {
    client_id: String,
    client_secret: String,
}
```

## Bearer Token Authorization and Authentication
```rust
use serde::Deserialize;
use volga::{App, claims, auth::{DecodingKey, roles}};

fn main() {
    let secret = std::env::var("JWT_SECRET")
        .expect("JWT_SECRET must be set");

    let mut app = App::new()
        .with_bearer_auth(|auth| auth
            .set_decoding_key(DecodingKey::from_secret(secret.as_bytes())));
    
    app.map_get("/me", me)
        .authorize::<MyClaims>(roles(["admin", "user"]));
    
    app.run_blocking()
}

async fn me() -> &'static str {
    "Hello from the protected area"
}

claims! {
    #[derive(Deserialize)]
    struct Claims {
        sub: String,
        company: String,
        role: String,
        exp: u64,
    }
}
```

## Basic Authentication
```rust
use uuid::Uuid;
use volga::{
    App, HttpResult, http::Cookies,
    headers::WWW_AUTHENTICATE,
    auth::Basic,
    error::Error,
    status, ok, see_other
};

fn main() {
    let mut app = App::new();

    app.map_post("/login", login);
    app.map_get("/me", me);

    app.run_blocking()
}

async fn login(cookies: Cookies, auth: Basic) -> Result<(HttpResult, Cookies), Error> {
    let session_id = authorize(auth)?;
    Ok((see_other!("/me"), cookies.add(("session-id", session_id))))
}

async fn me(cookies: Cookies) -> HttpResult {
    cookies
        .get("session-id")
        .map_or_else(
            || status!(401, "Unauthorized", [(WWW_AUTHENTICATE, "Basic realm=\"Restricted area\"")]),
            |_session_id| ok!("Success"))
}

fn authorize(auth: Basic) -> Result<String, Error> {
    if auth.validate("foo", "bar") {
        Ok(Uuid::new_v4().to_string())    
    } else { 
        Err(Error::client_error("Invalid Credentials"))
    } 
}
```