### PR TITLE
Public API stabilization & bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+# 0.9.0
+
+## Added
+* Added `#[non_exhaustive]` for `Authorizer<C>`, `Encoding`, `WsEvent<T>`
+* Added `TracingConfig::without_header()` that disables tracing HTTP header
+
+## Changed
+* `App::with_max_header_list_size(Limit::Unlimited)` now always panics as misconfiguration.
+* Security defaults changed
+
+## Fixed
+* `RouteGroup::cors` now correctly set `CorsOverride::Inherit` instead of disabling it.
+* Updated stale MSRV in lib.rs
+* Updated crate description for `volga-rate-limiter`
+
 # 0.8.9
 
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 * Updated stale MSRV in lib.rs
 * Updated crate description for `volga-rate-limiter`
 
+## Breaking Changes
+* Header mutation methods now return `&mut Self` (was `Header<T>`/`()`).
+* `append_header()` is now infallible and no longer returns Result.
+* Changed visibility of `RESPONSE_ERROR` and `SERVER_NAME` constants.
+* Changed visibility of `Error::status` and `Error::instance` fields, now these data can be fetched by methods: `Error::status()`, `Error::instance()`
+
 # 0.8.9
 
 ## Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.8.9"
+version = "0.9.0"
 license = "MIT"
 edition = "2024"
 rust-version = "1.90.0"
@@ -21,11 +21,11 @@ categories = [
 ]
 
 [workspace.dependencies]
-volga-dev-cert    = { path = "volga-dev-cert",    version = "0.8.9" }
-volga-di          = { path = "volga-di",          version = "0.8.9" }
-volga-macros      = { path = "volga-macros",      version = "0.8.9" }
-volga-open-api    = { path = "volga-open-api",    version = "0.8.9" }
-volga-rate-limiter = { path = "volga-rate-limiter", version = "0.8.9" }
+volga-dev-cert    = { path = "volga-dev-cert",    version = "0.9.0" }
+volga-di          = { path = "volga-di",          version = "0.9.0" }
+volga-macros      = { path = "volga-macros",      version = "0.9.0" }
+volga-open-api    = { path = "volga-open-api",    version = "0.9.0" }
+volga-rate-limiter = { path = "volga-rate-limiter", version = "0.9.0" }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Fast, simple, and high-performance web framework for Rust, built on top of
 Volga is designed to make building HTTP services straightforward and explicit,
 while keeping performance predictable and overhead minimal.
 
-[![latest](https://img.shields.io/badge/latest-0.8.9-blue)](https://crates.io/crates/volga)
+[![latest](https://img.shields.io/badge/latest-0.9.0-blue)](https://crates.io/crates/volga)
 [![latest](https://img.shields.io/badge/rustc-1.90+-964B00)](https://releases.rs/docs/1.90.0/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-violet.svg)](https://github.com/RomanEmreis/volga/blob/main/LICENSE)
 [![Build](https://github.com/RomanEmreis/volga/actions/workflows/rust.yml/badge.svg)](https://github.com/RomanEmreis/volga/actions/workflows/rust.yml)
@@ -46,7 +46,7 @@ Volga is a good fit if you:
 ### Dependencies
 ```toml
 [dependencies]
-volga = "0.8.9"
+volga = "0.9.0"
 tokio = { version = "1", features = ["full"] }
 ```
 ### Simple request handler

--- a/examples/global_error_handler/src/main.rs
+++ b/examples/global_error_handler/src/main.rs
@@ -24,7 +24,7 @@ async fn main() -> std::io::Result<()> {
     // Enabling global error handler
     app.map_err(|error: volga::error::Error| async move {
         tracing::error!("{:?}", error);
-        status!(error.status.as_u16(), "{error}")
+        status!(error.status().as_u16(), "{error}")
     });
 
     app.run().await

--- a/examples/websockets/src/main.rs
+++ b/examples/websockets/src/main.rs
@@ -48,7 +48,7 @@ async fn main() -> std::io::Result<()> {
                 match msg {
                     WsEvent::Data(msg) => tracing::info!("received: {msg}; msg #{value}"),
                     WsEvent::Close(frame) => tracing::info!("close: {frame:?}"),
-                    _ => ()
+                    _ => (),
                 }
             }
         });

--- a/examples/websockets/src/main.rs
+++ b/examples/websockets/src/main.rs
@@ -48,6 +48,7 @@ async fn main() -> std::io::Result<()> {
                 match msg {
                     WsEvent::Data(msg) => tracing::info!("received: {msg}; msg #{value}"),
                     WsEvent::Close(frame) => tracing::info!("close: {frame:?}"),
+                    _ => ()
                 }
             }
         });

--- a/volga-di/src/error.rs
+++ b/volga-di/src/error.rs
@@ -3,6 +3,7 @@
 use std::fmt::{Display, Formatter};
 
 /// Describes dependency injection error
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy)]
 pub enum Error {
     /// Indicates that the DI container is missing or not configured

--- a/volga-rate-limiter/Cargo.toml
+++ b/volga-rate-limiter/Cargo.toml
@@ -2,7 +2,7 @@
 name = "volga-rate-limiter"
 version.workspace = true
 readme = "README.md"
-description = "Macros for Volga Web Framework"
+description = "A lightweight and efficient rate-limiting library for Rust."
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/volga/Cargo.toml
+++ b/volga/Cargo.toml
@@ -100,9 +100,12 @@ http1 = ["dep:hyper", "hyper?/http1", "dep:hyper-util", "hyper-util?/http1", "de
 http2 = ["dep:hyper", "hyper?/http2", "dep:hyper-util", "hyper-util?/http2", "dep:httpdate"]
 
 auth = ["basic-auth", "jwt-auth"]
+auth-full = ["auth", "jwt-derive"]
 basic-auth = ["dep:base64", "dep:subtle", "middleware"]
+jwt-auth-full = ["jwt-auth", "jwt-derive"]
 jwt-auth = ["dep:jsonwebtoken", "middleware"]
-jwt-auth-full = ["jwt-auth", "dep:volga-macros", "volga-macros?/jwt-auth-derive"]
+jwt-derive = ["dep:volga-macros", "volga-macros?/jwt-auth-derive"]
+
 dev-cert = ["dep:volga-dev-cert"]
 di = ["dep:volga-di"]
 macros = ["dep:volga-macros"]
@@ -116,8 +119,9 @@ tls = ["dep:tokio-rustls", "tokio-rustls?/tls12", "tokio-rustls?/aws-lc-rs"]
 tracing = ["dep:tracing"]
 ws = ["dep:sha1", "dep:base64", "dep:tokio-tungstenite"]
 
-cookie-full = ["cookie", "private-cookie", "signed-cookie"]
+cookie-full = ["cookie", "cookie-secure"]
 cookie = ["dep:cookie"]
+cookie-secure = ["private-cookie", "signed-cookie"]
 private-cookie = ["di", "dep:cookie", "cookie?/private"]
 signed-cookie = ["di", "dep:cookie", "cookie?/signed"]
 

--- a/volga/Cargo.toml
+++ b/volga/Cargo.toml
@@ -42,8 +42,9 @@ httpdate = { version = "1.0.3", optional = true }
 hyper = { version = "1.9.0", features = ["server"], optional = true }
 hyper-util = { version = "0.1.20", features = ["server", "server-auto", "server-graceful", "service", "tokio"], optional = true }
 multer = { version = "3.1.0", optional = true }
-sha1 = { version = "0.11.0", optional = true }
 reqwest = { version = "0.13.2", optional = true }
+sha1 = { version = "0.11.0", optional = true }
+subtle = { version = "2.6", default-features = false, optional = true }
 tempfile = { version = "3.27.0", optional = true }
 tokio-rustls = { version = "0.26.4", default-features = false, features = ["tls12", "aws-lc-rs"], optional = true }
 tokio-tungstenite = { version = "0.29.0", optional = true }
@@ -99,7 +100,7 @@ http1 = ["dep:hyper", "hyper?/http1", "dep:hyper-util", "hyper-util?/http1", "de
 http2 = ["dep:hyper", "hyper?/http2", "dep:hyper-util", "hyper-util?/http2", "dep:httpdate"]
 
 auth = ["basic-auth", "jwt-auth"]
-basic-auth = ["dep:base64", "middleware"]
+basic-auth = ["dep:base64", "dep:subtle", "middleware"]
 jwt-auth = ["dep:jsonwebtoken", "middleware"]
 jwt-auth-full = ["jwt-auth", "dep:volga-macros", "volga-macros?/jwt-auth-derive"]
 dev-cert = ["dep:volga-dev-cert"]

--- a/volga/src/app.rs
+++ b/volga/src/app.rs
@@ -353,8 +353,7 @@ impl App {
     /// - `limit` — a [`Limit<u32>`]:
     ///   - `Limit::Default` — uses the framework default (recommended)
     ///   - `Limit::Limited(n)` — enforces an explicit upper bound
-    ///   - `Limit::Unlimited` — treated as `u32::MAX` in production;
-    ///     in debug builds this will **panic** to catch misconfiguration early.
+    ///   - `Limit::Unlimited` — **panics** to catch misconfiguration early.
     pub fn with_max_header_list_size(mut self, size: Limit<usize>) -> Self {
         self.max_header_size = match size {
             Limit::Limited(size) => {
@@ -363,20 +362,9 @@ impl App {
             }
 
             Limit::Unlimited => {
-                #[cfg(debug_assertions)]
                 panic!(
                     "HTTP/2 max_header_list_size cannot be Unlimited; use Limit::Limited(u32) instead"
                 );
-
-                #[cfg(not(debug_assertions))]
-                {
-                    #[cfg(feature = "tracing")]
-                    tracing::warn!(
-                        "max_header_list_size set to Unlimited; using u32::MAX for production"
-                    );
-
-                    Limit::Limited(u32::MAX as usize)
-                }
             }
 
             Limit::Default => Limit::Default,

--- a/volga/src/auth.rs
+++ b/volga/src/auth.rs
@@ -26,7 +26,7 @@ pub use {
     },
 };
 
-#[cfg(feature = "jwt-auth-full")]
+#[cfg(feature = "jwt-derive")]
 pub use volga_macros::Claims;
 
 #[cfg(feature = "basic-auth")]

--- a/volga/src/auth/authenticated.rs
+++ b/volga/src/auth/authenticated.rs
@@ -89,7 +89,7 @@ where
         extensions
             .get()
             .cloned()
-            .ok_or_else(|| Error::server_error("Client IP: missing"))
+            .ok_or_else(|| Error::server_error("Authentication claims: missing"))
     }
 }
 

--- a/volga/src/auth/authorizer.rs
+++ b/volga/src/auth/authorizer.rs
@@ -90,6 +90,7 @@ pub type ClaimsValidator<C> = dyn Fn(&C) -> bool + Send + Sync + 'static;
 /// assert!(access.validate(&MyClaims { role: "editor".to_string() }));
 /// assert!(access.validate(&MyClaims { role: "contributor".to_string() }));
 /// ```
+#[non_exhaustive]
 pub enum Authorizer<C: AuthClaims> {
     /// Allows access if the user's role or roles match any of the required roles.
     ///

--- a/volga/src/auth/basic.rs
+++ b/volga/src/auth/basic.rs
@@ -109,14 +109,17 @@ impl FromPayload for Basic {
 
 impl Basic {
     /// Validates username and password
+    #[inline]
     pub fn validate(&self, username: &str, password: &str) -> bool {
         let expected = format!("{username}:{password}");
         self.validate_base64(&STANDARD.encode(expected))
     }
 
     /// Validates credentials encoded in Base64
+    #[inline]
     pub fn validate_base64(&self, credentials: &str) -> bool {
-        *credentials == *self.0
+        use subtle::ConstantTimeEq;
+        credentials.as_bytes().ct_eq(self.0.as_bytes()).into()
     }
 }
 

--- a/volga/src/error.rs
+++ b/volga/src/error.rs
@@ -33,10 +33,10 @@ pub(crate) type BoxError = Box<dyn StdError + Send + Sync>;
 #[derive(Debug)]
 pub struct Error {
     /// HTTP status code
-    pub status: StatusCode,
+    pub(crate) status: StatusCode,
 
     /// An instance where this error happened
-    pub instance: Option<String>,
+    pub(crate) instance: Option<String>,
 
     /// Inner error object
     pub(crate) inner: BoxError,
@@ -191,6 +191,18 @@ impl Error {
         }
     }
 
+    /// Returns HTTP status code of this error
+    #[inline]
+    pub fn status(&self) -> StatusCode {
+        self.status
+    }
+
+    /// Returns an instance where this error happened
+    #[inline]
+    pub fn instance(&self) -> Option<&str> {
+        self.instance.as_deref()
+    }
+
     /// Unwraps the inner error
     pub fn into_inner(self) -> BoxError {
         self.inner
@@ -309,7 +321,8 @@ mod tests {
         let err = Error::new("/api", "some error");
 
         assert!(err.is_server_error());
-        assert_eq!(err.status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(err.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(err.instance().unwrap(), "/api");
     }
 
     #[test]
@@ -318,7 +331,8 @@ mod tests {
         let err = Error::from(io_error);
 
         assert!(err.is_client_error());
-        assert_eq!(err.status, StatusCode::NOT_FOUND);
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+        assert_eq!(err.instance(), None);
     }
 
     #[test]
@@ -327,7 +341,8 @@ mod tests {
         let err = Error::from(io_error);
 
         assert!(err.is_server_error());
-        assert_eq!(err.status, StatusCode::BAD_GATEWAY);
+        assert_eq!(err.status(), StatusCode::BAD_GATEWAY);
+        assert_eq!(err.instance(), None);
     }
 
     #[test]
@@ -336,7 +351,8 @@ mod tests {
         let err = Error::from(io_error);
 
         assert!(err.is_server_error());
-        assert_eq!(err.status, StatusCode::BAD_GATEWAY);
+        assert_eq!(err.status(), StatusCode::BAD_GATEWAY);
+        assert_eq!(err.instance(), None);
     }
 
     #[test]
@@ -345,7 +361,8 @@ mod tests {
         let err = Error::from(io_error);
 
         assert!(err.is_server_error());
-        assert_eq!(err.status, StatusCode::BAD_GATEWAY);
+        assert_eq!(err.status(), StatusCode::BAD_GATEWAY);
+        assert_eq!(err.instance(), None);
     }
 
     #[test]
@@ -354,7 +371,8 @@ mod tests {
         let err = Error::from(io_error);
 
         assert!(err.is_server_error());
-        assert_eq!(err.status, StatusCode::BAD_GATEWAY);
+        assert_eq!(err.status(), StatusCode::BAD_GATEWAY);
+        assert_eq!(err.instance(), None);
     }
 
     #[test]
@@ -363,7 +381,8 @@ mod tests {
         let err = Error::from(io_error);
 
         assert!(err.is_server_error());
-        assert_eq!(err.status, StatusCode::BAD_GATEWAY);
+        assert_eq!(err.status(), StatusCode::BAD_GATEWAY);
+        assert_eq!(err.instance(), None);
     }
 
     #[test]
@@ -372,7 +391,8 @@ mod tests {
         let err = Error::from(io_error);
 
         assert!(err.is_server_error());
-        assert_eq!(err.status, StatusCode::BAD_GATEWAY);
+        assert_eq!(err.status(), StatusCode::BAD_GATEWAY);
+        assert_eq!(err.instance(), None);
     }
 
     #[test]
@@ -381,7 +401,8 @@ mod tests {
         let err = Error::from(io_error);
 
         assert!(err.is_client_error());
-        assert_eq!(err.status, StatusCode::CONFLICT);
+        assert_eq!(err.status(), StatusCode::CONFLICT);
+        assert_eq!(err.instance(), None);
     }
 
     #[test]
@@ -390,7 +411,8 @@ mod tests {
         let err = Error::from(io_error);
 
         assert!(err.is_client_error());
-        assert_eq!(err.status, StatusCode::BAD_REQUEST);
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(err.instance(), None);
     }
 
     #[test]
@@ -399,7 +421,8 @@ mod tests {
         let err = Error::from(io_error);
 
         assert!(err.is_client_error());
-        assert_eq!(err.status, StatusCode::REQUEST_TIMEOUT);
+        assert_eq!(err.status(), StatusCode::REQUEST_TIMEOUT);
+        assert_eq!(err.instance(), None);
     }
 
     #[test]
@@ -408,7 +431,8 @@ mod tests {
         let err = Error::from(io_error);
 
         assert!(err.is_client_error());
-        assert_eq!(err.status, StatusCode::UNSUPPORTED_MEDIA_TYPE);
+        assert_eq!(err.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+        assert_eq!(err.instance(), None);
     }
 
     #[test]
@@ -417,7 +441,8 @@ mod tests {
         let err = Error::from(io_error);
 
         assert!(err.is_client_error());
-        assert_eq!(err.status, StatusCode::FORBIDDEN);
+        assert_eq!(err.status(), StatusCode::FORBIDDEN);
+        assert_eq!(err.instance(), None);
     }
 
     #[test]
@@ -426,7 +451,8 @@ mod tests {
         let err = Error::from(io_error);
 
         assert!(err.is_server_error());
-        assert_eq!(err.status, StatusCode::BAD_GATEWAY);
+        assert_eq!(err.status(), StatusCode::BAD_GATEWAY);
+        assert_eq!(err.instance(), None);
     }
 
     #[test]
@@ -435,7 +461,8 @@ mod tests {
         let err = Error::from(io_error);
 
         assert!(err.is_server_error());
-        assert_eq!(err.status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(err.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(err.instance(), None);
     }
 
     #[test]
@@ -473,7 +500,8 @@ mod tests {
         let err = Error::from(fmt_error);
 
         assert!(err.is_client_error());
-        assert_eq!(err.status, StatusCode::BAD_REQUEST);
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(err.instance(), None);
     }
 
     #[test]
@@ -482,6 +510,7 @@ mod tests {
         let err = Error::from(io_error);
 
         assert!(err.is_client_error());
-        assert_eq!(err.status, StatusCode::BAD_REQUEST);
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(err.instance(), None);
     }
 }

--- a/volga/src/headers/encoding.rs
+++ b/volga/src/headers/encoding.rs
@@ -5,6 +5,7 @@ use super::{Error, HeaderValue, quality::Ranked};
 use std::{fmt, str::FromStr};
 
 /// Represents encoding formats
+#[non_exhaustive]
 #[derive(Hash, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Encoding {
     /// Wildcard (`*`) encoding

--- a/volga/src/http/cors.rs
+++ b/volga/src/http/cors.rs
@@ -721,6 +721,7 @@ impl App {
     /// let app = App::new()
     ///     .set_cors(CorsConfig::default().with_any_origin())
     ///     .with_cors(|cors| cors
+    ///         .with_name("policy")
     ///         .with_any_method()
     ///         .with_any_header());
     /// ```
@@ -742,7 +743,7 @@ impl App {
     /// let app = App::new().with_default_cors();
     /// ```
     ///
-    /// If CORS was already preconfigured, it does not overwrite it
+    /// If default (unnamed) CORS was already preconfigured, it does overwrite it
     /// ```no_run
     /// use volga::App;
     /// use volga::http::CorsConfig;

--- a/volga/src/http/cors.rs
+++ b/volga/src/http/cors.rs
@@ -751,7 +751,7 @@ impl App {
     ///     .set_cors(CorsConfig::default().with_any_origin())
     ///     .with_default_cors();
     /// ```
-    pub fn with_default_cors<T>(self) -> Self {
+    pub fn with_default_cors(self) -> Self {
         self.set_cors(CorsConfig::default())
     }
 

--- a/volga/src/http/cors.rs
+++ b/volga/src/http/cors.rs
@@ -332,7 +332,7 @@ impl CorsConfig {
     /// use volga::http::CorsConfig;
     ///
     /// let config = CorsConfig::default()
-    ///     .with_any_method();
+    ///     .without_max_age();
     /// ```
     pub fn without_max_age(mut self) -> Self {
         self.max_age = None;

--- a/volga/src/http/cors.rs
+++ b/volga/src/http/cors.rs
@@ -731,6 +731,30 @@ impl App {
         self.set_cors(config(CorsConfig::default()))
     }
 
+    /// Configures a web server with default CORS configuration
+    ///
+    /// Default: `None`
+    ///
+    /// # Example
+    /// ```no_run
+    /// use volga::App;
+    ///
+    /// let app = App::new().with_default_cors();
+    /// ```
+    ///
+    /// If CORS was already preconfigured, it does not overwrite it
+    /// ```no_run
+    /// use volga::App;
+    /// use volga::http::CorsConfig;
+    ///
+    /// let app = App::new()
+    ///     .set_cors(CorsConfig::default().with_any_origin())
+    ///     .with_default_cors();
+    /// ```
+    pub fn with_default_cors<T>(self) -> Self {
+        self.set_cors(CorsConfig::default())
+    }
+
     /// Configures a web server with specified CORS configuration
     ///
     /// Default: `None`
@@ -780,7 +804,7 @@ impl<'a> RouteGroup<'a> {
 
     /// Sets the default CORS policy for this route
     pub fn cors(&mut self) -> &mut Self {
-        self.cors = CorsOverride::Disabled;
+        self.cors = CorsOverride::Inherit;
         self
     }
 

--- a/volga/src/http/request.rs
+++ b/volga/src/http/request.rs
@@ -81,7 +81,7 @@ impl HttpRequest {
         self.inner.headers()
     }
 
-    /// Returns a mutable reference to the associated extensions.
+    /// Returns a mutable reference to the associated HTTP header map.
     #[inline]
     #[allow(unused)]
     pub(crate) fn headers_mut(&mut self) -> &mut HeaderMap {

--- a/volga/src/http/request/request_mut.rs
+++ b/volga/src/http/request/request_mut.rs
@@ -148,11 +148,11 @@ impl HttpRequestMut {
     ///
     /// This method always overwrites previous values.
     #[inline]
-    pub fn insert_header<T: FromHeaders>(&mut self, header: Header<T>) -> Header<T> {
+    pub fn insert_header<T: FromHeaders>(&mut self, header: Header<T>) -> &mut Self {
         self.inner
             .headers_mut()
             .insert(header.name(), header.value().clone());
-        header
+        self
     }
 
     /// Attempts to insert the header into the request, replacing any existing
@@ -163,7 +163,7 @@ impl HttpRequestMut {
     pub fn try_insert_header<T>(
         &mut self,
         header: impl TryInto<Header<T>, Error = Error>,
-    ) -> Result<Header<T>, Error>
+    ) -> Result<&mut Self, Error>
     where
         T: FromHeaders,
     {
@@ -174,19 +174,19 @@ impl HttpRequestMut {
     /// Inserts the raw header into the request, replacing any existing values
     /// with the same header name.
     #[inline]
-    pub fn insert_raw_header(&mut self, name: HeaderName, value: HeaderValue) {
+    pub fn insert_raw_header(&mut self, name: HeaderName, value: HeaderValue) -> &mut Self {
         self.inner.headers_mut().insert(name, value);
+        self
     }
 
     /// Attempts to insert the raw header into the request, replacing any existing values
     /// with the same header name.
     #[inline]
-    pub fn try_insert_raw_header(&mut self, name: &str, value: &str) -> Result<(), Error> {
+    pub fn try_insert_raw_header(&mut self, name: &str, value: &str) -> Result<&mut Self, Error> {
         let name = HeaderName::from_bytes(name.as_bytes()).map_err(Error::from)?;
         let value = HeaderValue::from_str(value).map_err(Error::from)?;
 
-        self.insert_raw_header(name, value);
-        Ok(())
+        Ok(self.insert_raw_header(name, value))
     }
 
     /// Appends a new value for the given header name.
@@ -194,14 +194,14 @@ impl HttpRequestMut {
     /// Existing values with the same name are preserved.
     /// Multiple values for the same header may be present.
     #[inline]
-    pub fn append_header<T>(&mut self, header: Header<T>) -> Result<Header<T>, Error>
+    pub fn append_header<T>(&mut self, header: Header<T>) -> &mut Self
     where
         T: FromHeaders,
     {
         self.inner
             .headers_mut()
             .append(header.name(), header.value().clone());
-        Ok(header)
+        self
     }
 
     /// Attempts to append a new value for the given header name.
@@ -211,28 +211,28 @@ impl HttpRequestMut {
     pub fn try_append_header<T>(
         &mut self,
         header: impl TryInto<Header<T>, Error = Error>,
-    ) -> Result<Header<T>, Error>
+    ) -> Result<&mut Self, Error>
     where
         T: FromHeaders,
     {
         let header = header.try_into()?;
-        self.append_header(header)
+        Ok(self.append_header(header))
     }
 
     /// Appends a new raw value for the given raw header name.
     #[inline]
-    pub fn append_raw_header(&mut self, name: HeaderName, value: HeaderValue) {
+    pub fn append_raw_header(&mut self, name: HeaderName, value: HeaderValue) -> &mut Self {
         self.inner.headers_mut().append(name, value);
+        self
     }
 
     /// Attempts to append a new raw value for the given header name.
     #[inline]
-    pub fn try_append_raw_header(&mut self, name: &str, value: &str) -> Result<(), Error> {
+    pub fn try_append_raw_header(&mut self, name: &str, value: &str) -> Result<&mut Self, Error> {
         let name = HeaderName::from_bytes(name.as_bytes()).map_err(Error::from)?;
         let value = HeaderValue::from_str(value).map_err(Error::from)?;
 
-        self.append_raw_header(name, value);
-        Ok(())
+        Ok(self.append_raw_header(name, value))
     }
 
     /// Removes all values for the given header name.

--- a/volga/src/http/request/request_mut.rs
+++ b/volga/src/http/request/request_mut.rs
@@ -86,7 +86,7 @@ impl HttpRequestMut {
         self.inner.headers()
     }
 
-    /// Returns a mutable reference to the associated extensions.
+    /// Returns a mutable reference to the associated HTTP header map.
     #[inline]
     #[allow(unused)]
     pub(crate) fn headers_mut(&mut self) -> &mut HeaderMap {
@@ -178,7 +178,7 @@ impl HttpRequestMut {
         self.inner.headers_mut().insert(name, value);
     }
 
-    /// Attempts to inserts the raw header into the request, replacing any existing values
+    /// Attempts to insert the raw header into the request, replacing any existing values
     /// with the same header name.
     #[inline]
     pub fn try_insert_raw_header(&mut self, name: &str, value: &str) -> Result<(), Error> {
@@ -225,7 +225,7 @@ impl HttpRequestMut {
         self.inner.headers_mut().append(name, value);
     }
 
-    /// Attempts to append a new raww value for the given header name.
+    /// Attempts to append a new raw value for the given header name.
     #[inline]
     pub fn try_append_raw_header(&mut self, name: &str, value: &str) -> Result<(), Error> {
         let name = HeaderName::from_bytes(name.as_bytes()).map_err(Error::from)?;

--- a/volga/src/http/response.rs
+++ b/volga/src/http/response.rs
@@ -68,12 +68,13 @@ impl HttpResponse {
     ///
     /// # Example
     /// ```no_run
-    /// use volga::{App, HttpRequest};
+    /// use volga::{App, HttpResponse};
     ///
     /// let mut app = App::new();
     ///
-    /// app.map_get("/", |req: HttpRequest| async move {
-    ///     assert!(req.headers().is_empty());
+    /// app.map_ok(|resp: HttpResponse| async move {
+    ///     assert!(resp.headers().is_empty());
+    ///     resp
     /// });
     /// ```
     #[inline]
@@ -81,25 +82,14 @@ impl HttpResponse {
         self.inner.headers()
     }
 
-    /// Returns a mutable reference to the associated extensions.
+    /// Returns a mutable reference to the associated HTTP header map.
     #[inline]
     #[allow(unused)]
     pub(crate) fn headers_mut(&mut self) -> &mut HeaderMap {
         self.inner.headers_mut()
     }
 
-    /// Returns a reference to the associated HTTP method.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use volga::{App, HttpRequest, http::Method};
-    ///
-    /// let mut app = App::new();
-    ///
-    /// app.map_get("/", |req: HttpRequest| async move {
-    ///     assert_eq!(*req.method(), Method::GET);
-    /// });
-    /// ```
+    /// Returns HTTP status code.
     #[inline]
     pub fn status(&self) -> StatusCode {
         self.inner.status()
@@ -190,7 +180,7 @@ impl HttpResponse {
         self.inner.headers_mut().insert(name, value);
     }
 
-    /// Attempts to inserts the raw header into the response, replacing any existing values
+    /// Attempts to insert the raw header into the response, replacing any existing values
     /// with the same header name.
     #[inline]
     pub fn try_insert_raw_header(&mut self, name: &str, value: &str) -> Result<(), Error> {
@@ -237,7 +227,7 @@ impl HttpResponse {
         self.inner.headers_mut().append(name, value);
     }
 
-    /// Attempts to append a new raww value for the given header name.
+    /// Attempts to append a new raw value for the given header name.
     #[inline]
     pub fn try_append_raw_header(&mut self, name: &str, value: &str) -> Result<(), Error> {
         let name = HeaderName::from_bytes(name.as_bytes()).map_err(Error::from)?;
@@ -327,7 +317,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn in_creates_text_response_with_custom_headers() {
+    async fn it_creates_text_response_with_custom_headers() {
         let mut response = HttpResponse::builder()
             .status(400)
             .header_raw("x-api-key", "some api key")
@@ -347,7 +337,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn in_creates_str_text_response_with_custom_headers() {
+    async fn it_creates_str_text_response_with_custom_headers() {
         let mut response = HttpResponse::builder()
             .status(200)
             .header_raw("x-api-key", "some api key")
@@ -367,7 +357,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn in_creates_json_response_with_custom_headers() {
+    async fn it_creates_json_response_with_custom_headers() {
         let content = TestPayload {
             name: "test".into(),
         };

--- a/volga/src/http/response.rs
+++ b/volga/src/http/response.rs
@@ -65,18 +65,6 @@ impl HttpResponse {
     }
 
     /// Returns a reference to the associated HTTP header map.
-    ///
-    /// # Example
-    /// ```no_run
-    /// use volga::{App, HttpResponse};
-    ///
-    /// let mut app = App::new();
-    ///
-    /// app.map_ok(|resp: HttpResponse| async move {
-    ///     assert!(resp.headers().is_empty());
-    ///     resp
-    /// });
-    /// ```
     #[inline]
     pub fn headers(&self) -> &HeaderMap {
         self.inner.headers()

--- a/volga/src/http/response.rs
+++ b/volga/src/http/response.rs
@@ -147,14 +147,14 @@ impl HttpResponse {
     ///
     /// This method always overwrites previous values.
     #[inline]
-    pub fn insert_header<T>(&mut self, header: Header<T>) -> Header<T>
+    pub fn insert_header<T>(&mut self, header: Header<T>) -> &mut Self
     where
         T: FromHeaders,
     {
         self.inner
             .headers_mut()
             .insert(header.name(), header.value().clone());
-        header
+        self
     }
 
     /// Attempts to insert the header into the response, replacing any existing
@@ -165,7 +165,7 @@ impl HttpResponse {
     pub fn try_insert_header<T>(
         &mut self,
         header: impl TryInto<Header<T>, Error = Error>,
-    ) -> Result<Header<T>, Error>
+    ) -> Result<&mut Self, Error>
     where
         T: FromHeaders,
     {
@@ -176,19 +176,19 @@ impl HttpResponse {
     /// Inserts the raw header into the response, replacing any existing values
     /// with the same header name.
     #[inline]
-    pub fn insert_raw_header(&mut self, name: HeaderName, value: HeaderValue) {
+    pub fn insert_raw_header(&mut self, name: HeaderName, value: HeaderValue) -> &mut Self {
         self.inner.headers_mut().insert(name, value);
+        self
     }
 
     /// Attempts to insert the raw header into the response, replacing any existing values
     /// with the same header name.
     #[inline]
-    pub fn try_insert_raw_header(&mut self, name: &str, value: &str) -> Result<(), Error> {
+    pub fn try_insert_raw_header(&mut self, name: &str, value: &str) -> Result<&mut Self, Error> {
         let name = HeaderName::from_bytes(name.as_bytes()).map_err(Error::from)?;
         let value = HeaderValue::from_str(value).map_err(Error::from)?;
 
-        self.insert_raw_header(name, value);
-        Ok(())
+        Ok(self.insert_raw_header(name, value))
     }
 
     /// Appends a new value for the given header name.
@@ -196,14 +196,14 @@ impl HttpResponse {
     /// Existing values with the same name are preserved.
     /// Multiple values for the same header may be present.
     #[inline]
-    pub fn append_header<T>(&mut self, header: Header<T>) -> Result<Header<T>, Error>
+    pub fn append_header<T>(&mut self, header: Header<T>) -> &mut Self
     where
         T: FromHeaders,
     {
         self.inner
             .headers_mut()
             .append(header.name(), header.value().clone());
-        Ok(header)
+        self
     }
 
     /// Attempts to append a new value for the given header name.
@@ -213,28 +213,28 @@ impl HttpResponse {
     pub fn try_append_header<T>(
         &mut self,
         header: impl TryInto<Header<T>, Error = Error>,
-    ) -> Result<Header<T>, Error>
+    ) -> Result<&mut Self, Error>
     where
         T: FromHeaders,
     {
         let header = header.try_into()?;
-        self.append_header(header)
+        Ok(self.append_header(header))
     }
 
     /// Appends a new raw value for the given raw header name.
     #[inline]
-    pub fn append_raw_header(&mut self, name: HeaderName, value: HeaderValue) {
+    pub fn append_raw_header(&mut self, name: HeaderName, value: HeaderValue) -> &mut Self {
         self.inner.headers_mut().append(name, value);
+        self
     }
 
     /// Attempts to append a new raw value for the given header name.
     #[inline]
-    pub fn try_append_raw_header(&mut self, name: &str, value: &str) -> Result<(), Error> {
+    pub fn try_append_raw_header(&mut self, name: &str, value: &str) -> Result<&mut Self, Error> {
         let name = HeaderName::from_bytes(name.as_bytes()).map_err(Error::from)?;
         let value = HeaderValue::from_str(value).map_err(Error::from)?;
 
-        self.append_raw_header(name, value);
-        Ok(())
+        Ok(self.append_raw_header(name, value))
     }
 
     /// Removes all values for the given header name.

--- a/volga/src/http/response/builder.rs
+++ b/volga/src/http/response/builder.rs
@@ -8,9 +8,9 @@ use crate::{
 use std::fmt::{Debug, Formatter};
 
 /// Default server name
-pub const SERVER_NAME: &str = "Volga";
+pub(crate) const SERVER_NAME: &str = "Volga";
 /// Default resource builder error
-pub const RESPONSE_ERROR: &str = "HTTP Response: Unable to create a response";
+pub(crate) const RESPONSE_ERROR: &str = "HTTP Response: Unable to create a response";
 
 /// Builder for [`HttpResponse`].
 ///

--- a/volga/src/http/response/ok.rs
+++ b/volga/src/http/response/ok.rs
@@ -637,7 +637,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn in_creates_text_response_with_custom_headers() {
+    async fn it_creates_text_response_with_custom_headers() {
         let response = ok!("ok"; [
             ("x-api-key", "some api key"),
             ("x-req-id", "some req id"),
@@ -659,7 +659,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn in_creates_text_response_with_empty_custom_headers() {
+    async fn it_creates_text_response_with_empty_custom_headers() {
         #[allow(unused_mut)]
         let response = ok!("ok"; []);
 
@@ -678,7 +678,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn in_creates_json_response_with_custom_headers() {
+    async fn it_creates_json_response_with_custom_headers() {
         let payload = TestPayload {
             name: "test".into(),
         };
@@ -703,7 +703,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn in_creates_anonymous_json_response_with_custom_headers() {
+    async fn it_creates_anonymous_json_response_with_custom_headers() {
         let response = ok!({ "name": "test" }; [
             ("x-api-key", "some api key"),
             ("x-req-id", "some req id"),

--- a/volga/src/lib.rs
+++ b/volga/src/lib.rs
@@ -1,6 +1,6 @@
 //! # Volga
 //!
-//! > Fast, Easy, and very flexible Web Framework for Rust based on [Tokio](https://tokio.rs/) runtime and [hyper](https://hyper.rs/) for fun and painless microservices crafting.
+//! > Fast, simple, and high-performance web framework for Rust, built on top of [Tokio](https://tokio.rs/) and [hyper](https://hyper.rs/).
 //!
 //! ## Features
 //! * Supports HTTP/1 and HTTP/2
@@ -36,9 +36,6 @@ pub mod app;
 pub mod auth;
 #[cfg(feature = "config")]
 pub mod config;
-
-#[cfg(feature = "config")]
-pub use config::{Config, ConfigBuilder};
 
 #[cfg(feature = "di")]
 pub mod di;
@@ -80,8 +77,10 @@ pub use crate::http::{
         path::{NamedPath, Path},
         query::Query,
     },
-    response::builder::{RESPONSE_ERROR, SERVER_NAME},
 };
+
+#[cfg(feature = "config")]
+pub use config::{Config, ConfigBuilder};
 
 #[cfg(feature = "middleware")]
 pub use http::HttpRequestMut;

--- a/volga/src/lib.rs
+++ b/volga/src/lib.rs
@@ -9,7 +9,7 @@
 //! * Dependency Injection
 //! * WebSockets and WebSocket-over-HTTP/2
 //! * Full [Tokio](https://tokio.rs/) compatibility
-//! * Runs on stable Rust 1.80+
+//! * Runs on stable Rust 1.90+
 //!
 //! ## Example
 //! ```no_run

--- a/volga/src/rate_limiting.rs
+++ b/volga/src/rate_limiting.rs
@@ -435,11 +435,46 @@ impl App {
         self
     }
 
-    /// Defines a list of trusted proxies used when extracting client IPs
-    /// for rate limiting. Forwarded headers are honored only if the
-    /// incoming connection is from one of these proxies.
+    /// Configures the list of trusted reverse proxies for client-IP resolution.
     ///
-    /// If an empty list is provided, forwarded headers will be ignored.
+    /// # Security
+    ///
+    /// This setting is **required** for [`by::ip()`] and [`ClientIp`] to honor
+    /// `Forwarded` (RFC 7239) or `X-Forwarded-For` headers. Without it, volga
+    /// uses the direct TCP peer address and ignores forwarded headers entirely —
+    /// this prevents IP-spoofing attacks where an attacker could bypass IP-based
+    /// rate limiting by setting `X-Forwarded-For: <arbitrary>`.
+    ///
+    /// When configured, volga walks the forwarded chain **right-to-left** and
+    /// returns the first hop whose address is **not** in this list. Headers are
+    /// only consulted if the direct peer is itself a trusted proxy — forwarded
+    /// values from untrusted peers are discarded.
+    ///
+    /// # When to set
+    ///
+    /// - Behind a reverse proxy (nginx, Caddy, Cloudflare, ALB) — configure
+    ///   the proxy's internal/egress IPs here.
+    /// - Direct-to-internet deployment — leave unset.
+    ///
+    /// Passing an empty iterator is equivalent to leaving it unset.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use std::net::{IpAddr, Ipv4Addr};
+    /// use volga::App;
+    ///
+    /// let app = App::new()
+    ///     .with_trusted_proxies([
+    ///         IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+    ///         IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+    ///     ]);
+    /// ```
+    ///
+    /// ## See also
+    ///
+    /// - [`by::ip`] — rate-limiting partition by client IP
+    /// - [`ClientIp`] — extractor that uses the same resolution logic
     pub fn with_trusted_proxies<I, T>(mut self, proxies: I) -> Self
     where
         I: IntoIterator<Item = T>,

--- a/volga/src/rate_limiting/by.rs
+++ b/volga/src/rate_limiting/by.rs
@@ -182,10 +182,14 @@ impl RateLimitKeyExt for RateLimitKeySource {
 
 /// Uses the client IP address as a rate limiting partition key.
 ///
-/// The IP address is resolved in the following order:
-/// 1. The `Forwarded` header (RFC 7239)
-/// 2. The `X-Forwarded-For` header
-/// 3. The peer socket address as a fallback
+/// The IP address is resolved as follows:
+/// - If `App::with_trusted_proxies(...)` is configured and the direct peer
+///   is a trusted proxy, the first untrusted hop in `Forwarded` (RFC 7239)
+///   or `X-Forwarded-For` is used.
+/// - Otherwise, the peer socket address is used.
+///
+/// Forwarded headers are **never** trusted from untrusted peers to prevent
+/// IP-spoofing and rate-limit bypass.
 ///
 /// This is the most common strategy for global or unauthenticated rate limiting.
 ///

--- a/volga/src/tls.rs
+++ b/volga/src/tls.rs
@@ -44,8 +44,8 @@ use hyper_util::rt::TokioExecutor;
 use hyper::server::conn::http1;
 
 /// Represents local development certificates mode
-#[cfg(feature = "dev-cert")]
 #[derive(Debug)]
+#[cfg(feature = "dev-cert")]
 pub enum DevCertMode {
     /// Always creates self-signed certificates if they're missing
     Auto,

--- a/volga/src/tls.rs
+++ b/volga/src/tls.rs
@@ -187,8 +187,8 @@ impl Default for RedirectionConfig {
 impl Default for HstsConfig {
     fn default() -> Self {
         Self {
-            preload: true,
-            include_sub_domains: true,
+            preload: false,
+            include_sub_domains: false,
             max_age: Duration::from_secs(DEFAULT_MAX_AGE), // 30 days = 2,592,000 seconds
             exclude_hosts: Vec::new(),
         }
@@ -231,7 +231,7 @@ impl fmt::Display for HstsConfig {
 impl HstsConfig {
     /// Configures whether to set `preload` in HSTS header
     ///
-    /// Default value: `true`
+    /// Default value: `false`
     pub fn with_preload(mut self, preload: bool) -> Self {
         self.preload = preload;
         self
@@ -239,7 +239,7 @@ impl HstsConfig {
 
     /// Configures whether to set `includeSubDomains` in the HSTS header
     ///
-    /// Default: `true`
+    /// Default: `false`
     pub fn with_sub_domains(mut self, include: bool) -> Self {
         self.include_sub_domains = include;
         self
@@ -386,8 +386,8 @@ impl TlsConfig {
     /// If HSTS has already been preconfigured, it does not overwrite it
     ///
     /// Default values:
-    /// - preload: `true`
-    /// - include_sub_domains: `true`
+    /// - preload: `false`
+    /// - include_sub_domains: `false`
     /// - max-age: 30 days (2,592,000 seconds)
     /// - exclude_hosts: empty list
     ///
@@ -550,7 +550,6 @@ impl TlsConfig {
             #[cfg(feature = "http2")]
             b"h2".into(),
             b"http/1.1".into(),
-            b"http/1.0".into(),
         ];
 
         Ok(config)
@@ -654,8 +653,8 @@ impl App {
     /// If HSTS has already been preconfigured, it does not overwrite it
     ///
     /// Default values:
-    /// - preload: `true`
-    /// - include_sub_domains: `true`
+    /// - preload: `false`
+    /// - include_sub_domains: `false`
     /// - max-age: 30 days (2,592,000 seconds)
     /// - exclude_hosts: empty list
     ///
@@ -681,8 +680,8 @@ impl App {
     /// If the [`TlsConfig`] has been specified, it configures HSTS header
     ///
     /// Default values:
-    /// - preload: `true`
-    /// - include_sub_domains: `true`
+    /// - preload: `false`
+    /// - include_sub_domains: `false`
     /// - max-age: 30 days (2,592,000 seconds)
     /// - exclude_hosts: empty list
     ///
@@ -799,8 +798,8 @@ mod tests {
             tls_config.hsts_config.max_age,
             Duration::from_secs(DEFAULT_MAX_AGE)
         );
-        assert!(tls_config.hsts_config.preload);
-        assert!(tls_config.hsts_config.include_sub_domains);
+        assert!(!tls_config.hsts_config.preload);
+        assert!(!tls_config.hsts_config.include_sub_domains);
 
         assert!(!tls_config.https_redirection_config.enabled);
         assert_eq!(tls_config.https_redirection_config.http_port, DEFAULT_PORT);
@@ -821,8 +820,8 @@ mod tests {
             tls_config.hsts_config.max_age,
             Duration::from_secs(DEFAULT_MAX_AGE)
         );
-        assert!(tls_config.hsts_config.preload);
-        assert!(tls_config.hsts_config.include_sub_domains);
+        assert!(!tls_config.hsts_config.preload);
+        assert!(!tls_config.hsts_config.include_sub_domains);
 
         assert!(!tls_config.https_redirection_config.enabled);
         assert_eq!(tls_config.https_redirection_config.http_port, DEFAULT_PORT);
@@ -843,8 +842,8 @@ mod tests {
             tls_config.hsts_config.max_age,
             Duration::from_secs(DEFAULT_MAX_AGE)
         );
-        assert!(tls_config.hsts_config.preload);
-        assert!(tls_config.hsts_config.include_sub_domains);
+        assert!(!tls_config.hsts_config.preload);
+        assert!(!tls_config.hsts_config.include_sub_domains);
 
         assert!(!tls_config.https_redirection_config.enabled);
         assert_eq!(tls_config.https_redirection_config.http_port, DEFAULT_PORT);
@@ -901,29 +900,7 @@ mod tests {
 
     #[test]
     fn it_creates_tls_config_with_hsts_preload() {
-        let tls_config = TlsConfig::from_pem("tls").with_hsts_preload(false);
-
-        let path = PathBuf::from("tls");
-
-        assert_eq!(tls_config.key, path.join(KEY_FILE_NAME));
-        assert_eq!(tls_config.cert, path.join(CERT_FILE_NAME));
-        assert_eq!(tls_config.client_auth, ClientAuth::None);
-
-        assert_eq!(tls_config.hsts_config.exclude_hosts.len(), 0);
-        assert_eq!(
-            tls_config.hsts_config.max_age,
-            Duration::from_secs(DEFAULT_MAX_AGE)
-        );
-        assert!(!tls_config.hsts_config.preload);
-        assert!(tls_config.hsts_config.include_sub_domains);
-
-        assert!(!tls_config.https_redirection_config.enabled);
-        assert_eq!(tls_config.https_redirection_config.http_port, DEFAULT_PORT);
-    }
-
-    #[test]
-    fn it_creates_tls_config_with_hsts_sub_domains() {
-        let tls_config = TlsConfig::from_pem("tls").with_hsts_sub_domains(false);
+        let tls_config = TlsConfig::from_pem("tls").with_hsts_preload(true);
 
         let path = PathBuf::from("tls");
 
@@ -944,6 +921,28 @@ mod tests {
     }
 
     #[test]
+    fn it_creates_tls_config_with_hsts_sub_domains() {
+        let tls_config = TlsConfig::from_pem("tls").with_hsts_sub_domains(true);
+
+        let path = PathBuf::from("tls");
+
+        assert_eq!(tls_config.key, path.join(KEY_FILE_NAME));
+        assert_eq!(tls_config.cert, path.join(CERT_FILE_NAME));
+        assert_eq!(tls_config.client_auth, ClientAuth::None);
+
+        assert_eq!(tls_config.hsts_config.exclude_hosts.len(), 0);
+        assert_eq!(
+            tls_config.hsts_config.max_age,
+            Duration::from_secs(DEFAULT_MAX_AGE)
+        );
+        assert!(!tls_config.hsts_config.preload);
+        assert!(tls_config.hsts_config.include_sub_domains);
+
+        assert!(!tls_config.https_redirection_config.enabled);
+        assert_eq!(tls_config.https_redirection_config.http_port, DEFAULT_PORT);
+    }
+
+    #[test]
     fn it_creates_tls_config_with_hsts_max_age() {
         let tls_config = TlsConfig::from_pem("tls").with_hsts_max_age(Duration::from_secs(5));
 
@@ -955,8 +954,8 @@ mod tests {
 
         assert_eq!(tls_config.hsts_config.exclude_hosts.len(), 0);
         assert_eq!(tls_config.hsts_config.max_age, Duration::from_secs(5));
-        assert!(tls_config.hsts_config.preload);
-        assert!(tls_config.hsts_config.include_sub_domains);
+        assert!(!tls_config.hsts_config.preload);
+        assert!(!tls_config.hsts_config.include_sub_domains);
 
         assert!(!tls_config.https_redirection_config.enabled);
         assert_eq!(tls_config.https_redirection_config.http_port, DEFAULT_PORT);
@@ -977,8 +976,8 @@ mod tests {
             tls_config.hsts_config.max_age,
             Duration::from_secs(DEFAULT_MAX_AGE)
         );
-        assert!(tls_config.hsts_config.preload);
-        assert!(tls_config.hsts_config.include_sub_domains);
+        assert!(!tls_config.hsts_config.preload);
+        assert!(!tls_config.hsts_config.include_sub_domains);
 
         assert!(!tls_config.https_redirection_config.enabled);
         assert_eq!(tls_config.https_redirection_config.http_port, DEFAULT_PORT);
@@ -990,8 +989,8 @@ mod tests {
 
         assert_eq!(hsts_config.exclude_hosts.len(), 0);
         assert_eq!(hsts_config.max_age, Duration::from_secs(DEFAULT_MAX_AGE));
-        assert!(hsts_config.preload);
-        assert!(hsts_config.include_sub_domains);
+        assert!(!hsts_config.preload);
+        assert!(!hsts_config.include_sub_domains);
     }
 
     #[test]
@@ -1008,7 +1007,7 @@ mod tests {
 
         let hsts_string = hsts_config.to_string();
 
-        assert_eq!(hsts_string, "max-age=2592000; includeSubDomains; preload");
+        assert_eq!(hsts_string, "max-age=2592000");
     }
 
     #[test]
@@ -1089,7 +1088,7 @@ mod tests {
         assert_eq!(hsts_header.exclude_hosts, &["www.example.com"]);
         assert_eq!(
             hsts_header.inner,
-            "max-age=2592000; includeSubDomains; preload"
+            "max-age=2592000"
         );
     }
 

--- a/volga/src/tls.rs
+++ b/volga/src/tls.rs
@@ -1086,10 +1086,7 @@ mod tests {
         let hsts_header = HstsHeader::new(hsts_config);
 
         assert_eq!(hsts_header.exclude_hosts, &["www.example.com"]);
-        assert_eq!(
-            hsts_header.inner,
-            "max-age=2592000"
-        );
+        assert_eq!(hsts_header.inner, "max-age=2592000");
     }
 
     #[test]

--- a/volga/src/tracing.rs
+++ b/volga/src/tracing.rs
@@ -58,6 +58,14 @@ impl TracingConfig {
         self
     }
 
+    /// Configures tracing to exclude the span id as an HTTP header
+    ///
+    /// Default: `false`
+    pub fn without_header(mut self) -> Self {
+        self.include_header = false;
+        self
+    }
+
     /// Configures tracing to use a specific HTTP header name if the `include_header` is set to `true`
     ///
     /// Default: `request-id`
@@ -154,6 +162,14 @@ mod tests {
         let tracing_config = TracingConfig::new().with_header();
 
         assert!(tracing_config.include_header);
+        assert_eq!(tracing_config.span_header_name, DEFAULT_SPAN_HEADER_NAME);
+    }
+
+    #[test]
+    fn it_creates_without_include_header() {
+        let tracing_config = TracingConfig::new().with_header().without_header();
+
+        assert!(!tracing_config.include_header);
         assert_eq!(tracing_config.span_header_name, DEFAULT_SPAN_HEADER_NAME);
     }
 

--- a/volga/src/ws/websocket.rs
+++ b/volga/src/ws/websocket.rs
@@ -81,6 +81,7 @@ pub struct WsStream(SplitStream<WebSocketStream<TokioIo<Upgraded>>>);
 /// - [`WsEvent::Close`] indicates that the peer has initiated closing. After this
 ///   event, callers should stop reading and close the corresponding [`WsSink`].
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum WsEvent<T> {
     /// Application-level message deserialized from an incoming data frame.
     Data(T),

--- a/volga/tests/ws.rs
+++ b/volga/tests/ws.rs
@@ -31,6 +31,7 @@ async fn it_works_with_split() {
                 match msg {
                     WsEvent::Data(msg) => write.send(msg).await.unwrap(),
                     WsEvent::Close(_frame) => write.close().await.unwrap(),
+                    _ => unreachable!(),
                 }
             }
         });
@@ -62,6 +63,7 @@ async fn it_works_with_custom_protocol() {
                             write.send(format!("[{protocol}]: {msg}")).await.unwrap()
                         }
                         WsEvent::Close(_frame) => write.close().await.unwrap(),
+                        _ => unreachable!(),
                     }
                 }
             })


### PR DESCRIPTION
## Added
* Added `#[non_exhaustive]` for `Authorizer<C>`, `Encoding`, `WsEvent<T>`
* Added `TracingConfig::without_header()` that disables tracing HTTP header

## Changed
* `App::with_max_header_list_size(Limit::Unlimited)` now always panics as misconfiguration.
* Security defaults changed

## Fixed
* `RouteGroup::cors` now correctly set `CorsOverride::Inherit` instead of disabling it.
* Updated stale MSRV in lib.rs
* Updated crate description for `volga-rate-limiter`

## Breaking Changes
* Header mutation methods now return `&mut Self` (was `Header<T>`/`()`).
* `append_header()` is now infallible and no longer returns Result.
* Changed visibility of `RESPONSE_ERROR` and `SERVER_NAME` constants.
* Changed visibility of `Error::status` and `Error::instance` fields, now these data can be fetched by methods: `Error::status()`, `Error::instance()`

## Type
- [x] Bug fix
- [ ] Feature
- [x] Enhancement
- [ ] Performance
- [x] Documentation
- [x] Refactor
- [x] Security
- [x] Breaking change

## Checklist
- [x] I added/updated tests where it makes sense
- [x] I updated docs/examples if needed
- [x] This change is backwards-compatible (or clearly marked as breaking)
- [x] I ran formatting/lints locally (if applicable)