### PR TITLE
Make auth/config APIs explicit and decouple JWT (breaking)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+# 0.9.1
+
+## Added
+* `EncodingKey::{from_env, try_from_env, from_env_base64, try_from_env_base64, from_file, try_from_file, from_pem_file, try_from_pem_file}` and identical siblings on `DecodingKey` — ergonomic startup-time constructors. Panicking variants expect to be called once at startup; `try_*` variants return `Result<_, volga::Error>`.
+* `BearerAuthConfig::with_resource(uri)` / `with_resources(iter)` — OAuth 2.0 resource indicators (RFC 8707).
+* `BearerAuthConfig::with_resource_metadata_url(url)` — advertises the OAuth 2.0 Protected Resource Metadata URL (RFC 9728) in `WWW-Authenticate` challenges.
+* `BearerAuthConfig::with_strict_aud()` / `BearerAuthConfig::without_strict_aud()` — explicit control over whether `aud` is required when audiences are configured.
+* `BearerAuthConfig::strip_token_from_request(bool)` — controls stripping of the `Authorization` header after successful bearer auth.
+* `BearerAuthConfig::require_https(bool)` — controls HTTPS enforcement (with loopback exception).
+* `CorsConfig::without_credentials()` / `without_vary_header()` — explicit "off" builders paired with the existing `with_*` setters.
+* `HstsConfig::without_preload()` / `without_sub_domains()` — explicit "off" builders paired with the existing `with_*` setters.
+* `WebSocketConnection::without_accept_unmasked_frames()` — explicit opt-out paired with `with_accept_unmasked_frames()`.
+
+## Breaking Changes
+* `volga::auth` no longer re-exports `jsonwebtoken::Algorithm`, `DecodingKey`, `EncodingKey`, `JwtError`, or `ErrorKind`. Replaced by volga-owned `Algorithm`, `DecodingKey`, and `EncodingKey` at the same paths. User code that imports these by name continues to compile; code using `ErrorKind` for pattern-matching JWT errors or calling `EncodingKey::from_rsa_der` / `from_ec_der` / `from_ed_der` / `DecodingKey::from_jwk` / `from_rsa_components` will break. Use the dedicated PEM / base64 / secret / env / file constructors instead.
+* `BearerTokenService::validation()` is removed. Configure via `BearerAuthConfig`; no introspection is exposed.
+* `BearerAuthConfig::with_aud` now automatically adds `aud` to required claims. Tokens missing `aud` are rejected when audiences are configured. Call `without_strict_aud()` to opt out.
+* `require_https` is enabled by default. Non-TLS, non-loopback requests are rejected with `400 Bad Request`. Reverse-proxy deployments must call `require_https(false)`.
+* `strip_token_from_request` is enabled by default. The `Authorization` header is removed after successful bearer auth. Disable via `strip_token_from_request(false)` if downstream handlers need it.
+* `CorsConfig::with_credentials(bool)` and `with_vary_header(bool)` no longer take a `bool`. The no-arg forms enable the feature; use the new `without_credentials()` / `without_vary_header()` to disable.
+* `HstsConfig::with_preload(bool)` and `with_sub_domains(bool)` no longer take a `bool`. The no-arg forms enable the feature; use the new `without_preload()` / `without_sub_domains()` to disable.
+* `WebSocketConnection::with_accept_unmasked_frames(bool)` no longer takes a `bool`. Use the no-arg form to enable and `without_accept_unmasked_frames()` to disable.
+* Removed `App::with_default_cors()`. Use `.set_cors(CorsConfig::default())` instead.
+* Removed `App::with_default_tracing()`. Use `.set_tracing(TracingConfig::default())` instead.
+* Removed `TlsConfig::with_hsts_preload`, `with_hsts_sub_domains`, `with_hsts_max_age`, and `with_hsts_exclude_hosts` shortcuts. Configure through the `with_hsts(|h| h. ...)` closure on `TlsConfig` (e.g. `with_hsts(|h| h.with_preload().with_sub_domains())`).
+
 # 0.9.0
 
 ## Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 license = "MIT"
 edition = "2024"
 rust-version = "1.90.0"
@@ -21,11 +21,11 @@ categories = [
 ]
 
 [workspace.dependencies]
-volga-dev-cert    = { path = "volga-dev-cert",    version = "0.9.0" }
-volga-di          = { path = "volga-di",          version = "0.9.0" }
-volga-macros      = { path = "volga-macros",      version = "0.9.0" }
-volga-open-api    = { path = "volga-open-api",    version = "0.9.0" }
-volga-rate-limiter = { path = "volga-rate-limiter", version = "0.9.0" }
+volga-dev-cert    = { path = "volga-dev-cert",    version = "0.9.1" }
+volga-di          = { path = "volga-di",          version = "0.9.1" }
+volga-macros      = { path = "volga-macros",      version = "0.9.1" }
+volga-open-api    = { path = "volga-open-api",    version = "0.9.1" }
+volga-rate-limiter = { path = "volga-rate-limiter", version = "0.9.1" }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Fast, simple, and high-performance web framework for Rust, built on top of
 Volga is designed to make building HTTP services straightforward and explicit,
 while keeping performance predictable and overhead minimal.
 
-[![latest](https://img.shields.io/badge/latest-0.9.0-blue)](https://crates.io/crates/volga)
+[![latest](https://img.shields.io/badge/latest-0.9.1-blue)](https://crates.io/crates/volga)
 [![latest](https://img.shields.io/badge/rustc-1.90+-964B00)](https://releases.rs/docs/1.90.0/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-violet.svg)](https://github.com/RomanEmreis/volga/blob/main/LICENSE)
 [![Build](https://github.com/RomanEmreis/volga/actions/workflows/rust.yml/badge.svg)](https://github.com/RomanEmreis/volga/actions/workflows/rust.yml)
@@ -46,7 +46,7 @@ Volga is a good fit if you:
 ### Dependencies
 ```toml
 [dependencies]
-volga = "0.9.0"
+volga = "0.9.1"
 tokio = { version = "1", features = ["full"] }
 ```
 ### Simple request handler

--- a/docs/api-design.md
+++ b/docs/api-design.md
@@ -1,0 +1,101 @@
+# API Design: The Five Verbs
+
+Volga's public builder API uses five verbs, each with one job. Follow this convention when adding new builder methods so the surface stays predictable.
+
+## `with_*`
+
+Configures, enriches, or composes behavior using the most natural input for that API. Takes `self` by value.
+
+This is the primary fluent configuration vocabulary.
+
+```rust
+// Closure form — build from default
+let app = App::new().with_cors(|cors| cors.with_any_origin());
+
+// Value form — fluent configuration step
+let config = HstsConfig::default().with_max_age(Duration::from_secs(10));
+```
+
+`with_*` is used for builder-style configuration, including:
+
+- Closures over a default config (`with_cors(|c| ...)`)
+- Enabling flags (`with_preload()`)
+- Attaching behavior or strategies (with_token_bucket(bucket))
+- Setting field-like values that conceptually shape the configuration (with_max_age(...))
+
+Use `with_*` when the operation is part of fluent configuration.
+
+Do not use `with_*(bool)` — split into `with_*` / `without_*` instead.
+
+For installing a pre-built config object directly, use `set_*`.
+
+## `set_*`
+
+Installs a pre-built config object, or sets a single typed field. Takes `self` by value.
+
+```rust
+// Whole-config form — peer to `with_cors`
+let cors = CorsConfig::default().with_any_origin();
+let app = App::new().set_cors(cors);
+
+// Single-field form
+let auth = BearerAuthConfig::new().set_decoding_key(key);
+```
+
+The whole-config form of `set_*` exists alongside `with_*` as a deliberate peer — callers pick the one that matches their authoring style. A single trait-based overload isn't feasible: Rust can't infer closure parameter types when a trait has blanket impls for both `Self` and `FnOnce(Self) -> Self`. Use whichever form reads better at the call site.
+
+## `without_*`
+
+Turns a flag off or clears a field. Zero-argument. Takes `self` by value.
+
+```rust
+let config = HstsConfig::default().with_preload().without_sub_domains();
+```
+
+Use `without_*` as the opposite of a boolean `with_*`. **Do not** write `with_foo(false)` — write `without_foo()`.
+
+## `with_default_*`
+
+Rare. Use **only** when "default" requires non-trivial work beyond `Default::default()` — e.g., file discovery, env reads, convention-over-configuration behavior.
+
+```rust
+// Searches CWD for app_config.toml or .json, loads, panics if missing.
+let app = App::new().with_default_config();
+```
+
+**Do not** add `with_default_cors()` as a shortcut for `set_cors(CorsConfig::default())` — the latter is already explicit. If the only work is `Default::default()`, drop it.
+
+## `use_*`
+
+Enables a feature that registers middleware or special routes. Takes `&mut self`. Zero- or single-argument (for typed keys).
+
+```rust
+let mut app = App::new().with_cors(|c| c.with_any_origin());
+app.use_cors(); // wires up CORS middleware
+```
+
+Use `use_*` when the method makes a visible change to the request pipeline (registers routes, adds middleware, turns on a map-err handler). **Do not** use `use_*` for pure state configuration — that's what `with_*` / `set_*` is for.
+
+## Adding a New Config Subsystem
+
+1. Define the config struct: `pub struct MyConfig { ... }` with `Default`.
+2. Add a pair of `App` builder methods:
+
+```rust
+impl App {
+    pub fn with_my_config<F>(self, f: F) -> Self
+    where
+        F: FnOnce(MyConfig) -> MyConfig,
+    {
+        self.set_my_config(f(MyConfig::default()))
+    }
+
+    pub fn set_my_config(mut self, config: MyConfig) -> Self {
+        self.my_config = Some(config);
+        self
+    }
+}
+```
+
+3. If `MyConfig` has boolean flags, prefer `with_flag` / `without_flag` zero-arg pairs over `with_flag(bool)`.
+4. Add rustdoc examples showing both the closure and value forms of `with_my_config` / `set_my_config`.

--- a/volga/Cargo.toml
+++ b/volga/Cargo.toml
@@ -24,7 +24,7 @@ memchr = "2.8.0"
 mime = "0.3.17"
 mime_guess = "2.0.5"
 pin-project-lite = "0.2.17"
-tokio = { version = "1.51.0", features = ["fs", "io-util", "macros", "net", "rt", "rt-multi-thread", "signal", "sync", "time"] }
+tokio = { version = "1.52.1", features = ["fs", "io-util", "macros", "net", "rt", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-util = "0.7.18"
 serde = "1.0.228"
 serde_json = "1.0.149"

--- a/volga/Cargo.toml
+++ b/volga/Cargo.toml
@@ -155,6 +155,8 @@ test = [
 
 [package.metadata.docs.rs]
 all-features = true
+default-target = "x86_64-unknown-linux-gnu"
+targets = []
 
 [lints]
 workspace = true

--- a/volga/benches/auth.rs
+++ b/volga/benches/auth.rs
@@ -8,10 +8,9 @@ use reqwest::Client;
 use std::hint::black_box;
 use tokio::{runtime::Runtime, time::Instant};
 
-use jsonwebtoken::{DecodingKey, EncodingKey};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
-use volga::auth::roles;
+use volga::auth::{DecodingKey, EncodingKey, roles};
 
 const TEST_TOKEN: &str = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJlbWFpbC5jb20iLCJjb21wYW55IjoiQXdlc29tZSBDby4iLCJyb2xlIjoiYWRtaW4iLCJleHAiOjE3NTMwMDEzODl9.5g6aE4KpRobZqsS8WFJndbHYakG6GydPtIpKt3L1X5o";
 

--- a/volga/src/app/app_env.rs
+++ b/volga/src/app/app_env.rs
@@ -138,6 +138,11 @@ impl TryFrom<App> for AppEnv {
             .as_ref()
             .map(|tls| HstsHeader::new(tls.hsts_config.clone()));
 
+        #[cfg(all(feature = "jwt-auth", feature = "tls"))]
+        let tls_enabled = app.tls_config.is_some();
+        #[cfg(all(feature = "jwt-auth", not(feature = "tls")))]
+        let tls_enabled = false;
+
         #[cfg(feature = "tls")]
         let acceptor = {
             let tls_config = app.tls_config.map(|config| config.build()).transpose()?;
@@ -145,7 +150,9 @@ impl TryFrom<App> for AppEnv {
         };
 
         #[cfg(feature = "jwt-auth")]
-        let bearer_token_service = app.auth_config.map(Into::into);
+        let bearer_token_service = app
+            .auth_config
+            .map(|cfg| crate::auth::BearerTokenService::from_config(cfg, tls_enabled));
 
         let default_cache_control = app.cache_control.map(|c| c.try_into()).transpose()?;
 

--- a/volga/src/app/scope.rs
+++ b/volga/src/app/scope.rs
@@ -193,6 +193,8 @@ async fn handle_impl(
                 error_handler: Arc::clone(error_handler),
                 #[cfg(feature = "jwt-auth")]
                 bearer_token_service: env.bearer_token_service.clone(),
+                #[cfg(feature = "jwt-auth")]
+                bearer: None,
                 #[cfg(any(
                     feature = "decompression-brotli",
                     feature = "decompression-gzip",

--- a/volga/src/auth.rs
+++ b/volga/src/auth.rs
@@ -386,7 +386,10 @@ fn resolve_bearer(ctx: &HttpContext) -> Result<Bearer, Error> {
 #[cfg(feature = "jwt-auth")]
 fn stash_bearer(ctx: &mut HttpContext, bearer: Bearer) {
     use crate::http::request_scope::HttpRequestScope;
-    if let Some(scope) = ctx.request_mut().extensions_mut().get_mut::<HttpRequestScope>()
+    if let Some(scope) = ctx
+        .request_mut()
+        .extensions_mut()
+        .get_mut::<HttpRequestScope>()
         && scope.bearer.is_none()
     {
         scope.bearer = Some(bearer);

--- a/volga/src/auth.rs
+++ b/volga/src/auth.rs
@@ -16,15 +16,17 @@ use {
 
 #[cfg(feature = "jwt-auth")]
 pub use {
+    algorithm::Algorithm,
     authenticated::Authenticated,
     authorizer::{Authorizer, permissions, predicate, role, roles},
     bearer::{Bearer, BearerAuthConfig, BearerTokenService},
     claims::AuthClaims,
-    jsonwebtoken::{
-        Algorithm, DecodingKey, EncodingKey,
-        errors::{Error as JwtError, ErrorKind},
-    },
+    decoding_key::DecodingKey,
+    encoding_key::EncodingKey,
 };
+
+#[cfg(feature = "jwt-auth")]
+use jsonwebtoken::errors::{Error as JwtError, ErrorKind};
 
 #[cfg(feature = "jwt-derive")]
 pub use volga_macros::Claims;
@@ -32,6 +34,8 @@ pub use volga_macros::Claims;
 #[cfg(feature = "basic-auth")]
 pub use basic::Basic;
 
+#[cfg(feature = "jwt-auth")]
+pub mod algorithm;
 #[cfg(feature = "jwt-auth")]
 pub mod authenticated;
 #[cfg(feature = "jwt-auth")]
@@ -42,6 +46,12 @@ pub mod basic;
 pub mod bearer;
 #[cfg(feature = "jwt-auth")]
 pub mod claims;
+#[cfg(feature = "jwt-auth")]
+pub mod decoding_key;
+#[cfg(feature = "jwt-auth")]
+pub mod encoding_key;
+#[cfg(feature = "jwt-auth")]
+pub(crate) mod pem;
 
 #[cfg(feature = "jwt-auth")]
 impl From<JwtError> for Error {
@@ -73,9 +83,9 @@ fn map_jwt_error_to_status(err: &ErrorKind) -> StatusCode {
 }
 
 #[cfg(feature = "jwt-auth")]
-fn map_jwt_error_to_www_authenticate(err: &ErrorKind) -> &'static str {
+fn build_www_authenticate(err: &ErrorKind, resource_metadata_url: Option<&str>) -> String {
     use ErrorKind::*;
-    match err {
+    let base = match err {
         ExpiredSignature => {
             r#"Bearer error="invalid_token", error_description="Token has expired""#
         }
@@ -116,6 +126,10 @@ fn map_jwt_error_to_www_authenticate(err: &ErrorKind) -> &'static str {
             r#"Bearer error="invalid_request", error_description="Invalid key format""#
         }
         _ => r#"Bearer error="server_error", error_description="Internal token processing error""#,
+    };
+    match resource_metadata_url {
+        Some(url) => format!(r#"{base}, resource_metadata="{url}""#),
+        None => base.to_string(),
     }
 }
 
@@ -303,25 +317,39 @@ where
 {
     let authorizer = authorizer.clone();
     async move {
+        if should_reject_for_https(&ctx)? {
+            return status!(400; [
+                (WWW_AUTHENTICATE, r#"Bearer error="invalid_request", error_description="HTTPS required""#)
+            ]);
+        }
         let bearer: Bearer = ctx.extract()?;
         let bts: BearerTokenService = ctx.extract()?;
         let resp = match bts.decode(bearer) {
             Ok(claims) if authorizer.validate(&claims) => {
+                if bts.strip_token_from_request {
+                    ctx.request_mut()
+                        .headers_mut()
+                        .remove(crate::headers::AUTHORIZATION);
+                }
                 ctx.request_mut()
                     .extensions_mut()
                     .insert(Authenticated(claims));
 
                 next(ctx).await
             }
-            Ok(_) => status!(403; [
-                (WWW_AUTHENTICATE, authorizer::DEFAULT_ERROR_MSG)
-            ]),
+            Ok(_) => {
+                let metadata_url = bts.resource_metadata_url.as_deref();
+                status!(403; [
+                    (WWW_AUTHENTICATE, authorizer::default_error_msg(metadata_url))
+                ])
+            }
             Err(err) => {
+                let metadata_url = bts.resource_metadata_url.as_deref();
                 let www_authenticate = err
                     .into_inner()
                     .downcast_ref::<JwtError>()
-                    .map(|e| map_jwt_error_to_www_authenticate(e.kind()))
-                    .unwrap_or(authorizer::DEFAULT_ERROR_MSG);
+                    .map(|e| build_www_authenticate(e.kind(), metadata_url))
+                    .unwrap_or_else(|| authorizer::default_error_msg(metadata_url));
                 status!(403; [
                     (WWW_AUTHENTICATE, www_authenticate)
                 ])
@@ -333,6 +361,19 @@ where
             resp
         })
     }
+}
+
+/// Returns `Ok(true)` when the request should be rejected because
+/// `require_https` is enabled, the server isn't accepting TLS, and the
+/// peer is not a loopback address.
+#[cfg(feature = "jwt-auth")]
+fn should_reject_for_https(ctx: &HttpContext) -> Result<bool, Error> {
+    let bts: BearerTokenService = ctx.extract()?;
+    if !bts.require_https || bts.tls_enabled {
+        return Ok(false);
+    }
+    let client_ip: crate::ClientIp = ctx.extract()?;
+    Ok(!client_ip.into_inner().ip().is_loopback())
 }
 
 #[cfg(all(test, feature = "jwt-auth"))]
@@ -434,7 +475,7 @@ mod tests {
 
     #[test]
     fn it_maps_expired_signature_to_www_authenticate() {
-        let www_auth = map_jwt_error_to_www_authenticate(&ErrorKind::ExpiredSignature);
+        let www_auth = build_www_authenticate(&ErrorKind::ExpiredSignature, None);
         assert_eq!(
             www_auth,
             r#"Bearer error="invalid_token", error_description="Token has expired""#
@@ -443,7 +484,7 @@ mod tests {
 
     #[test]
     fn it_maps_invalid_signature_to_www_authenticate() {
-        let www_auth = map_jwt_error_to_www_authenticate(&ErrorKind::InvalidSignature);
+        let www_auth = build_www_authenticate(&ErrorKind::InvalidSignature, None);
         assert_eq!(
             www_auth,
             r#"Bearer error="invalid_token", error_description="Invalid signature""#
@@ -452,7 +493,7 @@ mod tests {
 
     #[test]
     fn it_maps_invalid_token_to_www_authenticate() {
-        let www_auth = map_jwt_error_to_www_authenticate(&ErrorKind::InvalidToken);
+        let www_auth = build_www_authenticate(&ErrorKind::InvalidToken, None);
         assert_eq!(
             www_auth,
             r#"Bearer error="invalid_token", error_description="Token is malformed or invalid""#
@@ -461,7 +502,7 @@ mod tests {
 
     #[test]
     fn it_maps_immature_signature_to_www_authenticate() {
-        let www_auth = map_jwt_error_to_www_authenticate(&ErrorKind::ImmatureSignature);
+        let www_auth = build_www_authenticate(&ErrorKind::ImmatureSignature, None);
         assert_eq!(
             www_auth,
             r#"Bearer error="invalid_token", error_description="Token is not valid yet (nbf)""#
@@ -471,7 +512,7 @@ mod tests {
     #[test]
     fn it_maps_missing_required_claim_to_www_authenticate() {
         let www_auth =
-            map_jwt_error_to_www_authenticate(&ErrorKind::MissingRequiredClaim("test".to_string()));
+            build_www_authenticate(&ErrorKind::MissingRequiredClaim("test".to_string()), None);
         assert_eq!(
             www_auth,
             r#"Bearer error="invalid_token", error_description="Missing required claim""#
@@ -480,7 +521,7 @@ mod tests {
 
     #[test]
     fn it_maps_invalid_issuer_to_www_authenticate() {
-        let www_auth = map_jwt_error_to_www_authenticate(&ErrorKind::InvalidIssuer);
+        let www_auth = build_www_authenticate(&ErrorKind::InvalidIssuer, None);
         assert_eq!(
             www_auth,
             r#"Bearer error="invalid_token", error_description="Invalid issuer (iss)""#
@@ -489,7 +530,7 @@ mod tests {
 
     #[test]
     fn it_maps_invalid_audience_to_www_authenticate() {
-        let www_auth = map_jwt_error_to_www_authenticate(&ErrorKind::InvalidAudience);
+        let www_auth = build_www_authenticate(&ErrorKind::InvalidAudience, None);
         assert_eq!(
             www_auth,
             r#"Bearer error="invalid_token", error_description="Invalid audience (aud)""#
@@ -498,7 +539,7 @@ mod tests {
 
     #[test]
     fn it_maps_invalid_subject_to_www_authenticate() {
-        let www_auth = map_jwt_error_to_www_authenticate(&ErrorKind::InvalidSubject);
+        let www_auth = build_www_authenticate(&ErrorKind::InvalidSubject, None);
         assert_eq!(
             www_auth,
             r#"Bearer error="invalid_token", error_description="Invalid subject (sub)""#
@@ -507,7 +548,7 @@ mod tests {
 
     #[test]
     fn it_maps_invalid_algorithm_to_www_authenticate() {
-        let www_auth = map_jwt_error_to_www_authenticate(&ErrorKind::InvalidAlgorithm);
+        let www_auth = build_www_authenticate(&ErrorKind::InvalidAlgorithm, None);
         assert_eq!(
             www_auth,
             r#"Bearer error="invalid_token", error_description="Invalid algorithm""#
@@ -516,7 +557,7 @@ mod tests {
 
     #[test]
     fn it_maps_invalid_algorithm_name_to_www_authenticate() {
-        let www_auth = map_jwt_error_to_www_authenticate(&ErrorKind::InvalidAlgorithmName);
+        let www_auth = build_www_authenticate(&ErrorKind::InvalidAlgorithmName, None);
         assert_eq!(
             www_auth,
             r#"Bearer error="invalid_token", error_description="Invalid algorithm""#
@@ -525,9 +566,10 @@ mod tests {
 
     #[test]
     fn it_maps_base64_error_to_www_authenticate() {
-        let www_auth = map_jwt_error_to_www_authenticate(&ErrorKind::Base64(
-            base64::DecodeError::InvalidByte(0, 0),
-        ));
+        let www_auth = build_www_authenticate(
+            &ErrorKind::Base64(base64::DecodeError::InvalidByte(0, 0)),
+            None,
+        );
         assert_eq!(
             www_auth,
             r#"Bearer error="invalid_request", error_description="Token is not properly base64-encoded""#
@@ -538,7 +580,7 @@ mod tests {
     fn it_maps_json_error_to_www_authenticate() {
         let json_result: Result<serde_json::Value, _> = serde_json::from_str("invalid json");
         let json_error = json_result.unwrap_err();
-        let www_auth = map_jwt_error_to_www_authenticate(&ErrorKind::Json(Arc::from(json_error)));
+        let www_auth = build_www_authenticate(&ErrorKind::Json(Arc::from(json_error)), None);
         assert_eq!(
             www_auth,
             r#"Bearer error="invalid_request", error_description="Token payload is not valid JSON""#
@@ -549,7 +591,7 @@ mod tests {
     fn it_maps_utf8_error_to_www_authenticate() {
         let invalid_utf8_bytes = vec![0, 159, 146, 150];
         let utf8_error = String::from_utf8(invalid_utf8_bytes).unwrap_err();
-        let www_auth = map_jwt_error_to_www_authenticate(&ErrorKind::Utf8(utf8_error));
+        let www_auth = build_www_authenticate(&ErrorKind::Utf8(utf8_error), None);
         assert_eq!(
             www_auth,
             r#"Bearer error="invalid_request", error_description="Token contains invalid UTF-8 characters""#
@@ -558,10 +600,42 @@ mod tests {
 
     #[test]
     fn it_maps_invalid_key_format_to_www_authenticate() {
-        let www_auth = map_jwt_error_to_www_authenticate(&ErrorKind::InvalidKeyFormat);
+        let www_auth = build_www_authenticate(&ErrorKind::InvalidKeyFormat, None);
         assert_eq!(
             www_auth,
             r#"Bearer error="invalid_request", error_description="Invalid key format""#
+        );
+    }
+
+    #[test]
+    fn it_appends_resource_metadata_url_to_challenge() {
+        let www_auth = build_www_authenticate(
+            &ErrorKind::ExpiredSignature,
+            Some("https://api.example.com/.well-known/oauth-protected-resource"),
+        );
+        assert_eq!(
+            www_auth,
+            r#"Bearer error="invalid_token", error_description="Token has expired", resource_metadata="https://api.example.com/.well-known/oauth-protected-resource""#
+        );
+    }
+
+    #[test]
+    fn it_default_error_msg_without_metadata_url() {
+        let www_auth = authorizer::default_error_msg(None);
+        assert_eq!(
+            www_auth,
+            r#"Bearer error="insufficient_scope" error_description="User does not have required role or permission""#
+        );
+    }
+
+    #[test]
+    fn it_default_error_msg_appends_metadata_url() {
+        let www_auth = authorizer::default_error_msg(Some(
+            "https://api.example.com/.well-known/oauth-protected-resource",
+        ));
+        assert_eq!(
+            www_auth,
+            r#"Bearer error="insufficient_scope" error_description="User does not have required role or permission", resource_metadata="https://api.example.com/.well-known/oauth-protected-resource""#
         );
     }
 

--- a/volga/src/auth.rs
+++ b/volga/src/auth.rs
@@ -322,11 +322,12 @@ where
                 (WWW_AUTHENTICATE, r#"Bearer error="invalid_request", error_description="HTTPS required""#)
             ]);
         }
-        let bearer: Bearer = ctx.extract()?;
+        let bearer = resolve_bearer(&ctx)?;
         let bts: BearerTokenService = ctx.extract()?;
-        let resp = match bts.decode(bearer) {
+        let resp = match bts.decode(bearer.clone()) {
             Ok(claims) if authorizer.validate(&claims) => {
                 if bts.strip_token_from_request {
+                    stash_bearer(&mut ctx, bearer);
                     ctx.request_mut()
                         .headers_mut()
                         .remove(crate::headers::AUTHORIZATION);
@@ -360,6 +361,35 @@ where
                 .insert(CACHE_CONTROL, HeaderValue::from_static(NO_STORE));
             resp
         })
+    }
+}
+
+/// Returns the bearer token for this request, preferring the value stashed
+/// by an outer `authorize` middleware (when `strip_token_from_request` removed
+/// the `Authorization` header) over the raw header. This keeps stacked
+/// `authorize` chains (e.g. group-level + route-level) working when the outer
+/// step has already stripped the credential.
+#[cfg(feature = "jwt-auth")]
+fn resolve_bearer(ctx: &HttpContext) -> Result<Bearer, Error> {
+    use crate::http::request_scope::HttpRequestScope;
+    if let Some(scope) = ctx.request().extensions().get::<HttpRequestScope>()
+        && let Some(bearer) = scope.bearer.as_ref()
+    {
+        return Ok(bearer.clone());
+    }
+    ctx.extract::<Bearer>()
+}
+
+/// Stashes the bearer token into the request scope so nested `authorize`
+/// middlewares can recover it after the `Authorization` header is removed.
+/// Idempotent: a token already present in the scope is left untouched.
+#[cfg(feature = "jwt-auth")]
+fn stash_bearer(ctx: &mut HttpContext, bearer: Bearer) {
+    use crate::http::request_scope::HttpRequestScope;
+    if let Some(scope) = ctx.request_mut().extensions_mut().get_mut::<HttpRequestScope>()
+        && scope.bearer.is_none()
+    {
+        scope.bearer = Some(bearer);
     }
 }
 

--- a/volga/src/auth/algorithm.rs
+++ b/volga/src/auth/algorithm.rs
@@ -1,0 +1,124 @@
+//! JWT signing/verifying algorithm identifiers.
+
+/// A JWT signing/verifying algorithm.
+///
+/// Mirrors the algorithms defined in [RFC 7518](https://www.rfc-editor.org/rfc/rfc7518).
+/// Use this type with [`BearerAuthConfig::with_alg`](super::bearer::BearerAuthConfig::with_alg).
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+#[non_exhaustive]
+pub enum Algorithm {
+    /// HMAC using SHA-256.
+    HS256,
+    /// HMAC using SHA-384.
+    HS384,
+    /// HMAC using SHA-512.
+    HS512,
+    /// ECDSA using P-256 and SHA-256.
+    ES256,
+    /// ECDSA using P-384 and SHA-384.
+    ES384,
+    /// RSASSA-PKCS1-v1_5 using SHA-256.
+    RS256,
+    /// RSASSA-PKCS1-v1_5 using SHA-384.
+    RS384,
+    /// RSASSA-PKCS1-v1_5 using SHA-512.
+    RS512,
+    /// RSASSA-PSS using SHA-256.
+    PS256,
+    /// RSASSA-PSS using SHA-384.
+    PS384,
+    /// RSASSA-PSS using SHA-512.
+    PS512,
+    /// Edwards-curve Digital Signature Algorithm (EdDSA).
+    EdDSA,
+}
+
+impl Default for Algorithm {
+    #[inline]
+    fn default() -> Self {
+        Algorithm::HS256
+    }
+}
+
+impl From<Algorithm> for jsonwebtoken::Algorithm {
+    #[inline]
+    fn from(value: Algorithm) -> Self {
+        match value {
+            Algorithm::HS256 => jsonwebtoken::Algorithm::HS256,
+            Algorithm::HS384 => jsonwebtoken::Algorithm::HS384,
+            Algorithm::HS512 => jsonwebtoken::Algorithm::HS512,
+            Algorithm::ES256 => jsonwebtoken::Algorithm::ES256,
+            Algorithm::ES384 => jsonwebtoken::Algorithm::ES384,
+            Algorithm::RS256 => jsonwebtoken::Algorithm::RS256,
+            Algorithm::RS384 => jsonwebtoken::Algorithm::RS384,
+            Algorithm::RS512 => jsonwebtoken::Algorithm::RS512,
+            Algorithm::PS256 => jsonwebtoken::Algorithm::PS256,
+            Algorithm::PS384 => jsonwebtoken::Algorithm::PS384,
+            Algorithm::PS512 => jsonwebtoken::Algorithm::PS512,
+            Algorithm::EdDSA => jsonwebtoken::Algorithm::EdDSA,
+        }
+    }
+}
+
+impl From<jsonwebtoken::Algorithm> for Algorithm {
+    #[inline]
+    fn from(value: jsonwebtoken::Algorithm) -> Self {
+        match value {
+            jsonwebtoken::Algorithm::HS256 => Algorithm::HS256,
+            jsonwebtoken::Algorithm::HS384 => Algorithm::HS384,
+            jsonwebtoken::Algorithm::HS512 => Algorithm::HS512,
+            jsonwebtoken::Algorithm::ES256 => Algorithm::ES256,
+            jsonwebtoken::Algorithm::ES384 => Algorithm::ES384,
+            jsonwebtoken::Algorithm::RS256 => Algorithm::RS256,
+            jsonwebtoken::Algorithm::RS384 => Algorithm::RS384,
+            jsonwebtoken::Algorithm::RS512 => Algorithm::RS512,
+            jsonwebtoken::Algorithm::PS256 => Algorithm::PS256,
+            jsonwebtoken::Algorithm::PS384 => Algorithm::PS384,
+            jsonwebtoken::Algorithm::PS512 => Algorithm::PS512,
+            jsonwebtoken::Algorithm::EdDSA => Algorithm::EdDSA,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_defaults_to_hs256() {
+        assert_eq!(Algorithm::default(), Algorithm::HS256);
+    }
+
+    #[test]
+    fn it_converts_every_variant_to_jsonwebtoken() {
+        let pairs: [(Algorithm, jsonwebtoken::Algorithm); 12] = [
+            (Algorithm::HS256, jsonwebtoken::Algorithm::HS256),
+            (Algorithm::HS384, jsonwebtoken::Algorithm::HS384),
+            (Algorithm::HS512, jsonwebtoken::Algorithm::HS512),
+            (Algorithm::ES256, jsonwebtoken::Algorithm::ES256),
+            (Algorithm::ES384, jsonwebtoken::Algorithm::ES384),
+            (Algorithm::RS256, jsonwebtoken::Algorithm::RS256),
+            (Algorithm::RS384, jsonwebtoken::Algorithm::RS384),
+            (Algorithm::RS512, jsonwebtoken::Algorithm::RS512),
+            (Algorithm::PS256, jsonwebtoken::Algorithm::PS256),
+            (Algorithm::PS384, jsonwebtoken::Algorithm::PS384),
+            (Algorithm::PS512, jsonwebtoken::Algorithm::PS512),
+            (Algorithm::EdDSA, jsonwebtoken::Algorithm::EdDSA),
+        ];
+        for (volga, jwt) in pairs {
+            assert_eq!(jsonwebtoken::Algorithm::from(volga), jwt);
+            assert_eq!(Algorithm::from(jwt), volga);
+        }
+    }
+
+    #[test]
+    fn it_debugs_hs256() {
+        assert_eq!(format!("{:?}", Algorithm::HS256), "HS256");
+    }
+
+    #[test]
+    fn it_compares_for_equality() {
+        assert_eq!(Algorithm::RS256, Algorithm::RS256);
+        assert_ne!(Algorithm::RS256, Algorithm::HS256);
+    }
+}

--- a/volga/src/auth/authorizer.rs
+++ b/volga/src/auth/authorizer.rs
@@ -4,7 +4,18 @@ use super::AuthClaims;
 use std::collections::HashSet;
 use std::sync::Arc;
 
-pub(super) const DEFAULT_ERROR_MSG: &str = "Bearer error=\"insufficient_scope\" error_description=\"User does not have required role or permission\"";
+/// Builds the default `WWW-Authenticate` challenge returned when the presented
+/// token is valid, but the caller is missing the required role or permission.
+///
+/// When `resource_metadata_url` is `Some`, an RFC 9728 `resource_metadata`
+/// parameter is appended to the challenge.
+pub(crate) fn default_error_msg(resource_metadata_url: Option<&str>) -> String {
+    let base = r#"Bearer error="insufficient_scope" error_description="User does not have required role or permission""#;
+    match resource_metadata_url {
+        Some(url) => format!(r#"{base}, resource_metadata="{url}""#),
+        None => base.to_string(),
+    }
+}
 
 /// Creates an [`Authorizer::Role`] authorizer for a single role.
 ///

--- a/volga/src/auth/bearer.rs
+++ b/volga/src/auth/bearer.rs
@@ -31,7 +31,7 @@ pub struct BearerAuthConfig {
 
 impl std::fmt::Debug for BearerAuthConfig {
     #[inline]
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("BearerAuthConfig")
             .field("validation", &"[redacted]")
             .field("encoding", &"[redacted]")
@@ -213,7 +213,7 @@ pub struct BearerTokenService {
 
 impl std::fmt::Debug for BearerTokenService {
     #[inline]
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("BearerTokenService")
             .field("validation", &"[redacted]")
             .field("encoding", &"[redacted]")
@@ -234,7 +234,7 @@ impl From<BearerAuthConfig> for BearerTokenService {
 }
 
 impl BearerTokenService {
-    /// Returns validation rules  for JWT
+    /// Returns validation rules for JWT
     pub fn validation(&self) -> &Validation {
         &self.validation
     }
@@ -278,7 +278,7 @@ pub struct Bearer(Box<str>);
 
 impl std::fmt::Debug for Bearer {
     #[inline]
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_tuple("Bearer").field(&"[redacted]").finish()
     }
 }

--- a/volga/src/auth/bearer.rs
+++ b/volga/src/auth/bearer.rs
@@ -445,7 +445,8 @@ impl BearerTokenService {
 }
 
 /// Wraps a bearer token string
-pub struct Bearer(Box<str>);
+#[derive(Clone)]
+pub struct Bearer(Arc<str>);
 
 impl std::fmt::Debug for Bearer {
     #[inline]

--- a/volga/src/auth/bearer.rs
+++ b/volga/src/auth/bearer.rs
@@ -29,6 +29,7 @@ pub struct BearerAuthConfig {
     encoding: Option<EncodingKey>,
     decoding: Option<DecodingKey>,
     strip_token_from_request: bool,
+    strict_aud: Option<bool>,
     resources: Vec<String>,
     resource_metadata_url: Option<String>,
     require_https: bool,
@@ -41,6 +42,7 @@ impl Default for BearerAuthConfig {
             encoding: None,
             decoding: None,
             strip_token_from_request: true,
+            strict_aud: None,
             resources: Vec::new(),
             resource_metadata_url: None,
             require_https: true,
@@ -56,6 +58,7 @@ impl std::fmt::Debug for BearerAuthConfig {
             .field("encoding", &"[redacted]")
             .field("decoding", &"[redacted]")
             .field("strip_token_from_request", &self.strip_token_from_request)
+            .field("strict_aud", &self.strict_aud)
             .field("resources", &self.resources)
             .field("resource_metadata_url", &self.resource_metadata_url)
             .field("require_https", &self.require_https)
@@ -116,6 +119,11 @@ impl BearerAuthConfig {
 
     /// Sets one or more acceptable audience members
     ///
+    /// An empty input is a no-op (no audience constraint or claim
+    /// requirement is applied), so configurations sourced from runtime
+    /// values that resolve to an empty list do not produce an
+    /// unsatisfiable validation setup.
+    ///
     /// # Example
     /// ```no_run
     /// use volga::App;
@@ -129,8 +137,12 @@ impl BearerAuthConfig {
         T: ToString,
         I: AsRef<[T]>,
     {
-        self.validation.set_audience(aud.as_ref());
-        self.validation.required_spec_claims.insert("aud".into());
+        let aud = aud.as_ref();
+        if aud.is_empty() {
+            return self;
+        }
+        self.validation.set_audience(aud);
+        self.apply_aud_required();
         self
     }
 
@@ -240,15 +252,24 @@ impl BearerAuthConfig {
     ///
     /// If no audience is configured, this setting has no effect - `aud`
     /// is not validated at all.
-    pub fn with_strict_aud(self) -> Self {
-        self.strict_audience(true)
+    pub fn with_strict_aud(mut self) -> Self {
+        self.strict_aud = Some(true);
+        self.apply_aud_required();
+        self
     }
 
     /// Allows JWTs without an `aud` (audience) claim.
     ///
+    /// The opt-out persists across builder call order: calling this before
+    /// audiences are configured (e.g. before [`with_aud`](Self::with_aud) or
+    /// [`with_resource`](Self::with_resource)) still suppresses the
+    /// auto-required-`aud` behavior once audiences are added.
+    ///
     /// See [`with_strict_aud`](Self::with_strict_aud) for details.
-    pub fn without_strict_aud(self) -> Self {
-        self.strict_audience(false)
+    pub fn without_strict_aud(mut self) -> Self {
+        self.strict_aud = Some(false);
+        self.apply_aud_required();
+        self
     }
 
     /// Adds a single OAuth 2.0 resource indicator (RFC 8707).
@@ -264,7 +285,7 @@ impl BearerAuthConfig {
             .aud
             .get_or_insert_with(HashSet::new)
             .insert(uri);
-        self.validation.required_spec_claims.insert("aud".into());
+        self.apply_aud_required();
         self
     }
 
@@ -287,7 +308,7 @@ impl BearerAuthConfig {
         for uri in new {
             aud.insert(uri);
         }
-        self.validation.required_spec_claims.insert("aud".into());
+        self.apply_aud_required();
         self
     }
 
@@ -313,17 +334,25 @@ impl BearerAuthConfig {
         self
     }
 
+    /// Synchronizes the `aud` entry in `required_spec_claims` with the
+    /// configured audience set and the user's `strict_aud` preference.
+    ///
+    /// - When no audiences are configured, `aud` is never required: marking
+    ///   it required without any accepted values yields an unsatisfiable
+    ///   validation (every token would fail).
+    /// - Otherwise, `aud` is required iff `strict_aud` is unset (default-on)
+    ///   or explicitly `Some(true)`.
     #[inline]
-    fn strict_audience(mut self, required: bool) -> Self {
+    fn apply_aud_required(&mut self) {
         if self.validation.aud.is_none() {
-            return self;
+            self.validation.required_spec_claims.remove("aud");
+            return;
         }
-        if required {
+        if self.strict_aud.unwrap_or(true) {
             self.validation.required_spec_claims.insert("aud".into());
         } else {
             self.validation.required_spec_claims.remove("aud");
         }
-        self
     }
 }
 
@@ -954,7 +983,7 @@ mod tests {
 
         assert_eq!(
             format!("{config:?}"),
-            r#"BearerAuthConfig { validation: "[redacted]", encoding: "[redacted]", decoding: "[redacted]", strip_token_from_request: true, resources: [], resource_metadata_url: None, require_https: true }"#
+            r#"BearerAuthConfig { validation: "[redacted]", encoding: "[redacted]", decoding: "[redacted]", strip_token_from_request: true, strict_aud: None, resources: [], resource_metadata_url: None, require_https: true }"#
         );
     }
 
@@ -1079,6 +1108,48 @@ mod tests {
         assert!(config.resources.is_empty());
         assert!(config.validation.aud.is_none());
         assert!(!config.validation.required_spec_claims.contains("aud"));
+    }
+
+    #[tokio::test]
+    async fn it_treats_empty_with_aud_as_noop() {
+        let config = BearerAuthConfig::default().with_aud(Vec::<String>::new());
+        assert!(config.validation.aud.is_none());
+        assert!(!config.validation.required_spec_claims.contains("aud"));
+    }
+
+    #[tokio::test]
+    async fn it_persists_strict_aud_optout_before_with_aud() {
+        let config = BearerAuthConfig::default()
+            .without_strict_aud()
+            .with_aud(["test-aud"]);
+        assert!(config.validation.aud.is_some());
+        assert!(!config.validation.required_spec_claims.contains("aud"));
+    }
+
+    #[tokio::test]
+    async fn it_persists_strict_aud_optout_before_with_resource() {
+        let config = BearerAuthConfig::default()
+            .without_strict_aud()
+            .with_resource("https://api.example.com/");
+        assert!(config.validation.aud.is_some());
+        assert!(!config.validation.required_spec_claims.contains("aud"));
+    }
+
+    #[tokio::test]
+    async fn it_persists_strict_aud_optout_before_with_resources() {
+        let config = BearerAuthConfig::default()
+            .without_strict_aud()
+            .with_resources(["https://api.a.example/", "https://api.b.example/"]);
+        assert!(config.validation.aud.is_some());
+        assert!(!config.validation.required_spec_claims.contains("aud"));
+    }
+
+    #[tokio::test]
+    async fn it_persists_strict_aud_optin_across_calls() {
+        let config = BearerAuthConfig::default()
+            .with_strict_aud()
+            .with_aud(["test-aud"]);
+        assert!(config.validation.required_spec_claims.contains("aud"));
     }
 
     #[tokio::test]

--- a/volga/src/auth/bearer.rs
+++ b/volga/src/auth/bearer.rs
@@ -1,5 +1,6 @@
 //! Tools and utils for Bearer Token Authorization
 
+use crate::auth::{Algorithm, DecodingKey, EncodingKey};
 use crate::{
     HttpRequest,
     error::Error,
@@ -12,7 +13,7 @@ use crate::{
 };
 use futures_util::future::{Ready, ready};
 use hyper::http::request::Parts;
-use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header as JwtHeader, Validation};
+use jsonwebtoken::{Header as JwtHeader, Validation};
 use serde::{Serialize, de::DeserializeOwned};
 use std::{
     fmt::{Display, Formatter},
@@ -22,11 +23,28 @@ use std::{
 const SCHEME: &str = "Bearer ";
 
 /// Bearer Token Authentication configuration
-#[derive(Default)]
 pub struct BearerAuthConfig {
     validation: Validation,
     encoding: Option<EncodingKey>,
     decoding: Option<DecodingKey>,
+    strip_token_from_request: bool,
+    resources: Vec<String>,
+    resource_metadata_url: Option<String>,
+    require_https: bool,
+}
+
+impl Default for BearerAuthConfig {
+    fn default() -> Self {
+        Self {
+            validation: Validation::default(),
+            encoding: None,
+            decoding: None,
+            strip_token_from_request: true,
+            resources: Vec::new(),
+            resource_metadata_url: None,
+            require_https: true,
+        }
+    }
 }
 
 impl std::fmt::Debug for BearerAuthConfig {
@@ -36,6 +54,10 @@ impl std::fmt::Debug for BearerAuthConfig {
             .field("validation", &"[redacted]")
             .field("encoding", &"[redacted]")
             .field("decoding", &"[redacted]")
+            .field("strip_token_from_request", &self.strip_token_from_request)
+            .field("resources", &self.resources)
+            .field("resource_metadata_url", &self.resource_metadata_url)
+            .field("require_https", &self.require_https)
             .finish()
     }
 }
@@ -47,14 +69,9 @@ impl BearerAuthConfig {
     /// ```no_run
     /// use volga::{App, auth::DecodingKey};
     ///
-    /// let secret = std::env::var("JWT_SECRET")
-    ///     .expect("JWT_SECRET must be set");
-    ///
-    /// let key = DecodingKey::from_secret(secret.as_bytes());
-    ///
     /// let app = App::new()
     ///     .with_bearer_auth(|auth| auth
-    ///         .set_decoding_key(key));
+    ///         .set_decoding_key(DecodingKey::from_env("JWT_SECRET")));
     /// ```
     pub fn set_decoding_key(mut self, key: DecodingKey) -> Self {
         self.decoding = Some(key);
@@ -67,14 +84,9 @@ impl BearerAuthConfig {
     /// ```no_run
     /// use volga::{App, auth::EncodingKey};
     ///
-    /// let secret = std::env::var("JWT_SECRET")
-    ///     .expect("JWT_SECRET must be set");
-    ///
-    /// let key = EncodingKey::from_secret(secret.as_bytes());
-    ///
     /// let app = App::new()
     ///     .with_bearer_auth(|auth| auth
-    ///         .set_encoding_key(key));
+    ///         .set_encoding_key(EncodingKey::from_env("JWT_SECRET")));
     /// ```
     pub fn set_encoding_key(mut self, key: EncodingKey) -> Self {
         self.encoding = Some(key);
@@ -94,8 +106,9 @@ impl BearerAuthConfig {
     ///         .with_alg(Algorithm::RS256));
     /// ```
     pub fn with_alg(mut self, alg: Algorithm) -> Self {
-        if !self.validation.algorithms.contains(&alg) {
-            self.validation.algorithms.push(alg);
+        let jwt_alg: jsonwebtoken::Algorithm = alg.into();
+        if !self.validation.algorithms.contains(&jwt_alg) {
+            self.validation.algorithms.push(jwt_alg);
         }
         self
     }
@@ -116,6 +129,7 @@ impl BearerAuthConfig {
         I: AsRef<[T]>,
     {
         self.validation.set_audience(aud.as_ref());
+        self.validation.required_spec_claims.insert("aud".into());
         self
     }
 
@@ -197,9 +211,106 @@ impl BearerAuthConfig {
         self
     }
 
-    /// Retuuns a ecret key to decode a JWT
+    /// Returns a secret key to decode a JWT
     pub fn decoding_key(&self) -> Option<&DecodingKey> {
         self.decoding.as_ref()
+    }
+
+    /// Controls whether the `Authorization` header is removed from the request
+    /// after successful bearer-token authentication.
+    ///
+    /// Defaults to `true`. Disable only if downstream handlers legitimately
+    /// need the raw token (e.g., proxying to an upstream service).
+    pub fn strip_token_from_request(mut self, enabled: bool) -> Self {
+        self.strip_token_from_request = enabled;
+        self
+    }
+
+    /// Requires the JWT to include an `aud` (audience) claim.
+    ///
+    /// When any audience is configured via [`with_aud`](Self::with_aud),
+    /// [`with_resource`](Self::with_resource), or
+    /// [`with_resources`](Self::with_resources), the `aud` claim is
+    /// automatically required.
+    ///
+    /// Calling [`without_strict_aud`](Self::without_strict_aud)
+    /// relaxes this requirement: tokens without an `aud` claim are accepted,
+    /// but if the claim is present, its value is still validated.
+    ///
+    /// If no audience is configured, this setting has no effect - `aud`
+    /// is not validated at all.
+    pub fn with_strict_aud(self) -> Self {
+        self.strict_audience(true)
+    }
+
+    /// Allows JWTs without an `aud` (audience) claim.
+    ///
+    /// See [`with_strict_aud`](Self::with_strict_aud) for details.
+    pub fn without_strict_aud(self) -> Self {
+        self.strict_audience(false)
+    }
+
+    /// Adds a single OAuth 2.0 resource indicator (RFC 8707).
+    ///
+    /// The URI is added to the audience set and `aud` is required in tokens.
+    /// This is a semantic alias for [`with_aud`](Self::with_aud) that also
+    /// records the URI as a resource for metadata/diagnostic purposes.
+    pub fn with_resource<U: Into<String>>(mut self, uri: U) -> Self {
+        let uri = uri.into();
+        self.resources.push(uri.clone());
+        self.validation.set_audience(&[uri]);
+        self.validation.required_spec_claims.insert("aud".into());
+        self
+    }
+
+    /// Adds multiple OAuth 2.0 resource indicators (RFC 8707).
+    ///
+    /// All URIs are added to the audience set and `aud` is required in tokens.
+    pub fn with_resources<I, U>(mut self, uris: I) -> Self
+    where
+        I: IntoIterator<Item = U>,
+        U: Into<String>,
+    {
+        let new: Vec<String> = uris.into_iter().map(Into::into).collect();
+        self.resources.extend(new.iter().cloned());
+        self.validation.set_audience(&new);
+        self.validation.required_spec_claims.insert("aud".into());
+        self
+    }
+
+    /// Sets the URL advertised as `resource_metadata` in the `WWW-Authenticate`
+    /// challenge per RFC 9728 (OAuth 2.0 Protected Resource Metadata).
+    ///
+    /// volga does **not** serve the metadata document at this URL — that is
+    /// the application's responsibility. This setting only controls the
+    /// challenge-header hint sent to clients.
+    pub fn with_resource_metadata_url<U: Into<String>>(mut self, url: U) -> Self {
+        self.resource_metadata_url = Some(url.into());
+        self
+    }
+
+    /// Requires the request to be received over TLS (HTTPS).
+    ///
+    /// When `true` (default), non-TLS requests are rejected with `400 Bad Request`
+    /// unless the peer address is a loopback address (`127.0.0.0/8` or `::1`).
+    /// Reverse-proxy deployments that terminate TLS upstream must disable this
+    /// check; volga does not inspect `X-Forwarded-Proto`.
+    pub fn require_https(mut self, enabled: bool) -> Self {
+        self.require_https = enabled;
+        self
+    }
+
+    #[inline]
+    fn strict_audience(mut self, required: bool) -> Self {
+        if self.validation.aud.is_none() {
+            return self;
+        }
+        if required {
+            self.validation.required_spec_claims.insert("aud".into());
+        } else {
+            self.validation.required_spec_claims.remove("aud");
+        }
+        self
     }
 }
 
@@ -209,6 +320,10 @@ pub struct BearerTokenService {
     validation: Arc<Validation>,
     encoding: Option<Arc<EncodingKey>>,
     decoding: Option<Arc<DecodingKey>>,
+    pub(crate) strip_token_from_request: bool,
+    pub(crate) resource_metadata_url: Option<Arc<str>>,
+    pub(crate) require_https: bool,
+    pub(crate) tls_enabled: bool,
 }
 
 impl std::fmt::Debug for BearerTokenService {
@@ -218,6 +333,10 @@ impl std::fmt::Debug for BearerTokenService {
             .field("validation", &"[redacted]")
             .field("encoding", &"[redacted]")
             .field("decoding", &"[redacted]")
+            .field("strip_token_from_request", &self.strip_token_from_request)
+            .field("resource_metadata_url", &self.resource_metadata_url)
+            .field("require_https", &self.require_https)
+            .field("tls_enabled", &self.tls_enabled)
             .finish()
     }
 }
@@ -225,18 +344,28 @@ impl std::fmt::Debug for BearerTokenService {
 impl From<BearerAuthConfig> for BearerTokenService {
     #[inline]
     fn from(value: BearerAuthConfig) -> Self {
-        Self {
-            validation: Arc::new(value.validation),
-            encoding: value.encoding.map(Arc::new),
-            decoding: value.decoding.map(Arc::new),
-        }
+        Self::from_config(value, false)
     }
 }
 
 impl BearerTokenService {
-    /// Returns validation rules for JWT
-    pub fn validation(&self) -> &Validation {
-        &self.validation
+    /// Builds a [`BearerTokenService`] from a [`BearerAuthConfig`], recording
+    /// whether the outer server accepts TLS traffic.
+    ///
+    /// `tls_enabled` is consulted together with `require_https` to decide
+    /// whether to reject plaintext requests. Applications should prefer the
+    /// [`From<BearerAuthConfig>`] impl in tests and when TLS status is irrelevant.
+    #[inline]
+    pub(crate) fn from_config(cfg: BearerAuthConfig, tls_enabled: bool) -> Self {
+        Self {
+            validation: Arc::new(cfg.validation),
+            encoding: cfg.encoding.map(Arc::new),
+            decoding: cfg.decoding.map(Arc::new),
+            strip_token_from_request: cfg.strip_token_from_request,
+            resource_metadata_url: cfg.resource_metadata_url.map(Into::into),
+            require_https: cfg.require_https,
+            tls_enabled,
+        }
     }
 
     /// Returns a secret key for decoding JWT
@@ -255,7 +384,7 @@ impl BearerTokenService {
         let Some(encoding_key) = &self.encoding else {
             return Err(Error::server_error("Missing security key"));
         };
-        jsonwebtoken::encode(&JwtHeader::default(), claims, encoding_key)
+        jsonwebtoken::encode(&JwtHeader::default(), claims, &encoding_key.0)
             .map_err(Error::from)
             .map(|s| Bearer(s.into()))
     }
@@ -267,7 +396,7 @@ impl BearerTokenService {
         let Some(decoding_key) = &self.decoding else {
             return Err(Error::server_error("Missing security key"));
         };
-        jsonwebtoken::decode(&*bearer.0, decoding_key, &self.validation)
+        jsonwebtoken::decode(&*bearer.0, &decoding_key.0, &self.validation)
             .map_err(Error::from)
             .map(|t| t.claims)
     }
@@ -408,10 +537,10 @@ impl FromPayload for BearerTokenService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::auth::{Algorithm, DecodingKey, EncodingKey};
     use crate::headers::{HeaderMap, HeaderValue};
     use crate::http::Extensions;
     use hyper::Request;
-    use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey};
     use serde::{Deserialize, Serialize};
     use std::collections::HashSet;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -430,7 +559,12 @@ mod tests {
     async fn it_tests_bearer_auth_config_default() {
         let config = BearerAuthConfig::default();
 
-        assert!(config.validation.algorithms.contains(&Algorithm::HS256));
+        assert!(
+            config
+                .validation
+                .algorithms
+                .contains(&jsonwebtoken::Algorithm::HS256)
+        );
         assert!(config.encoding.is_none());
         assert!(config.decoding.is_none());
     }
@@ -458,9 +592,24 @@ mod tests {
             .with_alg(Algorithm::HS512)
             .with_alg(Algorithm::RS256);
 
-        assert!(config.validation.algorithms.contains(&Algorithm::HS256));
-        assert!(config.validation.algorithms.contains(&Algorithm::HS512));
-        assert!(config.validation.algorithms.contains(&Algorithm::RS256));
+        assert!(
+            config
+                .validation
+                .algorithms
+                .contains(&jsonwebtoken::Algorithm::HS256)
+        );
+        assert!(
+            config
+                .validation
+                .algorithms
+                .contains(&jsonwebtoken::Algorithm::HS512)
+        );
+        assert!(
+            config
+                .validation
+                .algorithms
+                .contains(&jsonwebtoken::Algorithm::RS256)
+        );
     }
 
     #[tokio::test]
@@ -518,7 +667,6 @@ mod tests {
 
         assert!(service.encoding_key().is_some());
         assert!(service.decoding_key().is_some());
-        assert!(service.validation().algorithms.contains(&Algorithm::HS256));
     }
 
     #[tokio::test]
@@ -737,18 +885,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn it_tests_service_validation_getter() {
-        let config = BearerAuthConfig::default()
-            .validate_exp(false)
-            .validate_aud(false);
-        let service: BearerTokenService = config.into();
-
-        let validation = service.validation();
-        assert!(!validation.validate_exp);
-        assert!(!validation.validate_aud);
-    }
-
-    #[tokio::test]
     async fn it_tests_encode_decode_round_trip_with_validation() {
         let encoding_key = EncodingKey::from_secret(SECRET);
         let decoding_key = DecodingKey::from_secret(SECRET);
@@ -805,7 +941,7 @@ mod tests {
 
         assert_eq!(
             format!("{config:?}"),
-            r#"BearerAuthConfig { validation: "[redacted]", encoding: "[redacted]", decoding: "[redacted]" }"#
+            r#"BearerAuthConfig { validation: "[redacted]", encoding: "[redacted]", decoding: "[redacted]", strip_token_from_request: true, resources: [], resource_metadata_url: None, require_https: true }"#
         );
     }
 
@@ -825,7 +961,112 @@ mod tests {
 
         assert_eq!(
             format!("{service:?}"),
-            r#"BearerTokenService { validation: "[redacted]", encoding: "[redacted]", decoding: "[redacted]" }"#
+            r#"BearerTokenService { validation: "[redacted]", encoding: "[redacted]", decoding: "[redacted]", strip_token_from_request: true, resource_metadata_url: None, require_https: true, tls_enabled: false }"#
         );
+    }
+
+    #[tokio::test]
+    async fn it_defaults_strip_token_true() {
+        let config = BearerAuthConfig::default();
+        assert!(config.strip_token_from_request);
+    }
+
+    #[tokio::test]
+    async fn it_allows_disabling_strip_token() {
+        let config = BearerAuthConfig::default().strip_token_from_request(false);
+        assert!(!config.strip_token_from_request);
+    }
+
+    #[tokio::test]
+    async fn it_propagates_strip_token_to_service() {
+        let service: BearerTokenService = BearerAuthConfig::default()
+            .strip_token_from_request(false)
+            .into();
+        assert!(!service.strip_token_from_request);
+    }
+
+    #[tokio::test]
+    async fn it_does_not_require_aud_by_default() {
+        let config = BearerAuthConfig::default();
+        assert!(!config.validation.required_spec_claims.contains("aud"));
+    }
+
+    #[tokio::test]
+    async fn it_auto_enables_strict_aud_when_with_aud_called() {
+        let config = BearerAuthConfig::default().with_aud(["test-aud"]);
+        assert!(config.validation.required_spec_claims.contains("aud"));
+    }
+
+    #[tokio::test]
+    async fn it_respects_explicit_strict_aud_disabling() {
+        let config = BearerAuthConfig::default()
+            .with_aud(["test-aud"])
+            .without_strict_aud();
+        assert!(!config.validation.required_spec_claims.contains("aud"));
+    }
+
+    #[tokio::test]
+    async fn it_strict_aud_noop_without_audiences() {
+        let config = BearerAuthConfig::default().with_strict_aud();
+        assert!(!config.validation.required_spec_claims.contains("aud"));
+    }
+
+    #[tokio::test]
+    async fn it_stores_single_resource() {
+        let config = BearerAuthConfig::default().with_resource("https://api.example.com/");
+        assert_eq!(
+            config.resources,
+            vec!["https://api.example.com/".to_string()]
+        );
+        assert!(config.validation.required_spec_claims.contains("aud"));
+    }
+
+    #[tokio::test]
+    async fn it_stores_multiple_resources() {
+        let config = BearerAuthConfig::default()
+            .with_resources(["https://api.a.example/", "https://api.b.example/"]);
+        assert_eq!(config.resources.len(), 2);
+        assert!(config.validation.required_spec_claims.contains("aud"));
+    }
+
+    #[tokio::test]
+    async fn it_stores_resource_metadata_url() {
+        let config = BearerAuthConfig::default().with_resource_metadata_url(
+            "https://api.example.com/.well-known/oauth-protected-resource",
+        );
+        assert_eq!(
+            config.resource_metadata_url.as_deref(),
+            Some("https://api.example.com/.well-known/oauth-protected-resource")
+        );
+    }
+
+    #[tokio::test]
+    async fn it_defaults_require_https_true() {
+        let config = BearerAuthConfig::default();
+        assert!(config.require_https);
+    }
+
+    #[tokio::test]
+    async fn it_allows_disabling_require_https() {
+        let config = BearerAuthConfig::default().require_https(false);
+        assert!(!config.require_https);
+    }
+
+    #[tokio::test]
+    async fn it_propagates_require_https_to_service() {
+        let service: BearerTokenService = BearerAuthConfig::default().require_https(false).into();
+        assert!(!service.require_https);
+    }
+
+    #[tokio::test]
+    async fn it_from_config_records_tls_enabled() {
+        let service = BearerTokenService::from_config(BearerAuthConfig::default(), true);
+        assert!(service.tls_enabled);
+    }
+
+    #[tokio::test]
+    async fn it_from_impl_defaults_tls_disabled() {
+        let service: BearerTokenService = BearerAuthConfig::default().into();
+        assert!(!service.tls_enabled);
     }
 }

--- a/volga/src/auth/bearer.rs
+++ b/volga/src/auth/bearer.rs
@@ -16,6 +16,7 @@ use hyper::http::request::Parts;
 use jsonwebtoken::{Header as JwtHeader, Validation};
 use serde::{Serialize, de::DeserializeOwned};
 use std::{
+    collections::HashSet,
     fmt::{Display, Formatter},
     sync::Arc,
 };
@@ -252,28 +253,40 @@ impl BearerAuthConfig {
 
     /// Adds a single OAuth 2.0 resource indicator (RFC 8707).
     ///
-    /// The URI is added to the audience set and `aud` is required in tokens.
-    /// This is a semantic alias for [`with_aud`](Self::with_aud) that also
-    /// records the URI as a resource for metadata/diagnostic purposes.
+    /// The URI is appended to the existing audience set (preserving any
+    /// previously configured audiences) and `aud` is required in tokens.
+    /// This is a semantic companion to [`with_aud`](Self::with_aud) that
+    /// also records the URI as a resource for metadata/diagnostic purposes.
     pub fn with_resource<U: Into<String>>(mut self, uri: U) -> Self {
         let uri = uri.into();
         self.resources.push(uri.clone());
-        self.validation.set_audience(&[uri]);
+        self.validation
+            .aud
+            .get_or_insert_with(HashSet::new)
+            .insert(uri);
         self.validation.required_spec_claims.insert("aud".into());
         self
     }
 
     /// Adds multiple OAuth 2.0 resource indicators (RFC 8707).
     ///
-    /// All URIs are added to the audience set and `aud` is required in tokens.
+    /// All URIs are appended to the existing audience set and `aud` is
+    /// required in tokens. An empty iterator is a no-op (no audience
+    /// constraint or claim requirement is applied).
     pub fn with_resources<I, U>(mut self, uris: I) -> Self
     where
         I: IntoIterator<Item = U>,
         U: Into<String>,
     {
         let new: Vec<String> = uris.into_iter().map(Into::into).collect();
+        if new.is_empty() {
+            return self;
+        }
         self.resources.extend(new.iter().cloned());
-        self.validation.set_audience(&new);
+        let aud = self.validation.aud.get_or_insert_with(HashSet::new);
+        for uri in new {
+            aud.insert(uri);
+        }
         self.validation.required_spec_claims.insert("aud".into());
         self
     }
@@ -1027,6 +1040,45 @@ mod tests {
             .with_resources(["https://api.a.example/", "https://api.b.example/"]);
         assert_eq!(config.resources.len(), 2);
         assert!(config.validation.required_spec_claims.contains("aud"));
+    }
+
+    #[tokio::test]
+    async fn it_preserves_existing_audiences_when_adding_resource() {
+        let config = BearerAuthConfig::default()
+            .with_aud(["existing-aud"])
+            .with_resource("https://api.example.com/");
+        let aud = config.validation.aud.expect("aud should be set");
+        assert!(aud.contains("existing-aud"));
+        assert!(aud.contains("https://api.example.com/"));
+    }
+
+    #[tokio::test]
+    async fn it_preserves_existing_audiences_when_adding_resources() {
+        let config = BearerAuthConfig::default()
+            .with_aud(["existing-aud"])
+            .with_resources(["https://api.a.example/", "https://api.b.example/"]);
+        let aud = config.validation.aud.expect("aud should be set");
+        assert!(aud.contains("existing-aud"));
+        assert!(aud.contains("https://api.a.example/"));
+        assert!(aud.contains("https://api.b.example/"));
+    }
+
+    #[tokio::test]
+    async fn it_accumulates_resources_across_calls() {
+        let config = BearerAuthConfig::default()
+            .with_resource("https://api.a.example/")
+            .with_resource("https://api.b.example/");
+        let aud = config.validation.aud.expect("aud should be set");
+        assert!(aud.contains("https://api.a.example/"));
+        assert!(aud.contains("https://api.b.example/"));
+    }
+
+    #[tokio::test]
+    async fn it_treats_empty_resources_iter_as_noop() {
+        let config = BearerAuthConfig::default().with_resources(Vec::<String>::new());
+        assert!(config.resources.is_empty());
+        assert!(config.validation.aud.is_none());
+        assert!(!config.validation.required_spec_claims.contains("aud"));
     }
 
     #[tokio::test]

--- a/volga/src/auth/decoding_key.rs
+++ b/volga/src/auth/decoding_key.rs
@@ -1,0 +1,314 @@
+//! Owned wrapper around `jsonwebtoken::DecodingKey`.
+
+use crate::auth::encoding_key::{read_env_var, read_key_file};
+use crate::error::Error;
+
+/// A key used to verify JWTs.
+///
+/// Wraps an internal verification key. Use one of the `from_*` or `try_from_*`
+/// constructors to build an instance, then pass it to
+/// [`BearerAuthConfig::set_decoding_key`](super::bearer::BearerAuthConfig::set_decoding_key).
+pub struct DecodingKey(pub(crate) jsonwebtoken::DecodingKey);
+
+impl std::fmt::Debug for DecodingKey {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("DecodingKey([redacted])")
+    }
+}
+
+impl DecodingKey {
+    /// Builds an HMAC key from a raw byte slice.
+    #[inline]
+    pub fn from_secret(secret: &[u8]) -> Self {
+        Self(jsonwebtoken::DecodingKey::from_secret(secret))
+    }
+
+    /// Builds an HMAC key by base64-decoding a string.
+    #[inline]
+    pub fn from_base64_secret(secret: &str) -> Result<Self, Error> {
+        jsonwebtoken::DecodingKey::from_base64_secret(secret)
+            .map(Self)
+            .map_err(Error::from)
+    }
+
+    /// Builds an RSA verification key from a PEM-encoded public key.
+    #[inline]
+    pub fn from_rsa_pem(pem: &[u8]) -> Result<Self, Error> {
+        jsonwebtoken::DecodingKey::from_rsa_pem(pem)
+            .map(Self)
+            .map_err(Error::from)
+    }
+
+    /// Builds an ECDSA verification key from a PEM-encoded public key.
+    #[inline]
+    pub fn from_ec_pem(pem: &[u8]) -> Result<Self, Error> {
+        jsonwebtoken::DecodingKey::from_ec_pem(pem)
+            .map(Self)
+            .map_err(Error::from)
+    }
+
+    /// Builds an EdDSA verification key from a PEM-encoded public key.
+    #[inline]
+    pub fn from_ed_pem(pem: &[u8]) -> Result<Self, Error> {
+        jsonwebtoken::DecodingKey::from_ed_pem(pem)
+            .map(Self)
+            .map_err(Error::from)
+    }
+
+    /// Reads the env var `name` and builds an HMAC key from its bytes.
+    ///
+    /// Panics on missing/invalid env var. Intended for startup configuration.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use volga::auth::DecodingKey;
+    ///
+    /// let key = DecodingKey::from_env("JWT_SECRET");
+    /// ```
+    #[inline]
+    pub fn from_env(name: &str) -> Self {
+        Self::try_from_env(name).unwrap_or_else(|e| panic!("{e}"))
+    }
+
+    /// Reads the env var `name` and builds an HMAC key from its bytes.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use volga::auth::DecodingKey;
+    ///
+    /// let key = DecodingKey::try_from_env("JWT_SECRET")?;
+    /// # Ok::<(), volga::error::Error>(())
+    /// ```
+    #[inline]
+    pub fn try_from_env(name: &str) -> Result<Self, Error> {
+        let value = read_env_var(name)?;
+        Ok(Self::from_secret(value.as_bytes()))
+    }
+
+    /// Reads the env var `name` and base64-decodes it into an HMAC key.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use volga::auth::DecodingKey;
+    ///
+    /// let key = DecodingKey::from_env_base64("JWT_SECRET_B64");
+    /// ```
+    #[inline]
+    pub fn from_env_base64(name: &str) -> Self {
+        Self::try_from_env_base64(name).unwrap_or_else(|e| panic!("{e}"))
+    }
+
+    /// Reads the env var `name` and base64-decodes it into an HMAC key.
+    #[inline]
+    pub fn try_from_env_base64(name: &str) -> Result<Self, Error> {
+        let value = read_env_var(name)?;
+        Self::from_base64_secret(&value)
+    }
+
+    /// Reads the file at `path` and builds an HMAC key from its raw bytes.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use volga::auth::DecodingKey;
+    ///
+    /// let key = DecodingKey::from_file("/etc/volga/jwt.key");
+    /// ```
+    #[inline]
+    pub fn from_file<P: AsRef<std::path::Path>>(path: P) -> Self {
+        Self::try_from_file(path).unwrap_or_else(|e| panic!("{e}"))
+    }
+
+    /// Reads the file at `path` and builds an HMAC key from its raw bytes.
+    #[inline]
+    pub fn try_from_file<P: AsRef<std::path::Path>>(path: P) -> Result<Self, Error> {
+        let bytes = read_key_file(path.as_ref())?;
+        Ok(Self::from_secret(&bytes))
+    }
+
+    /// Reads the PEM file at `path` and auto-detects the key format
+    /// (RSA / EC / Ed) from the header line.
+    ///
+    /// Panics if the file cannot be read, the header is unrecognized, or
+    /// the PEM body cannot be parsed.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use volga::auth::DecodingKey;
+    ///
+    /// let key = DecodingKey::from_pem_file("/etc/volga/rs256.pub");
+    /// ```
+    #[inline]
+    pub fn from_pem_file<P: AsRef<std::path::Path>>(path: P) -> Self {
+        Self::try_from_pem_file(path).unwrap_or_else(|e| panic!("{e}"))
+    }
+
+    /// Reads the PEM file at `path` and auto-detects the key format.
+    pub fn try_from_pem_file<P: AsRef<std::path::Path>>(path: P) -> Result<Self, Error> {
+        let bytes = read_key_file(path.as_ref())?;
+        match super::pem::detect(&bytes) {
+            super::pem::PemKind::Rsa => Self::from_rsa_pem(&bytes),
+            super::pem::PemKind::Ec => Self::from_ec_pem(&bytes),
+            super::pem::PemKind::Ambiguous => Self::from_rsa_pem(&bytes)
+                .or_else(|_| Self::from_ec_pem(&bytes))
+                .or_else(|_| Self::from_ed_pem(&bytes)),
+            super::pem::PemKind::Unknown => Err(Error::server_error(format!(
+                "Unrecognized PEM header in {}; use from_rsa_pem / from_ec_pem / from_ed_pem explicitly",
+                path.as_ref().display()
+            ))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SECRET: &[u8] = b"test-secret-bytes";
+    const SECRET_B64: &str = "dGVzdC1zZWNyZXQtYnl0ZXM=";
+
+    // SPKI-format RSA public key matching the private key used in EncodingKey tests.
+    const RSA_PUBLIC_PEM: &[u8] = b"-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAq1ma/MoK5uWwsPxUNsVH
+1e+ybz/TzUGiFqUKbYkLTpXr9kpXi0i5SZOkGXHnLz1ch4gmOMuvvoLNwRyBzZGk
+OOd8IoLZAe4OAdmpQ2T0pY6szvUCK3WpIa06P7n20msOuc8bzm6CFM9fJU5/vHze
+LGAj4Vi2GoFz4Lm3zUlZcY2zQWu2kdJZt6HbAM4s+nv1m3gqX+m5gTOjBP7oxEdN
+sOGZnl5v8h8uZ/U+CP2emvr67HW+Pph8OjVvXbyhBNGAbEljoXjJMLcqB5ULxXC4
+AspE+EfAZD5pCQO2ssUVPjw07qLNFd6gTJ7q41k2bNrS/SmYqWMeWttwEGS5Tjm3
+XwIDAQAB
+-----END PUBLIC KEY-----
+";
+
+    #[test]
+    fn it_creates_from_secret() {
+        let _ = DecodingKey::from_secret(SECRET);
+    }
+
+    #[test]
+    fn it_creates_from_base64_secret() {
+        assert!(DecodingKey::from_base64_secret(SECRET_B64).is_ok());
+    }
+
+    #[test]
+    fn it_rejects_invalid_base64_secret() {
+        let key = DecodingKey::from_base64_secret("not valid base64!!!");
+        assert!(key.is_err());
+    }
+
+    #[test]
+    fn it_creates_from_rsa_pem() {
+        let key = DecodingKey::from_rsa_pem(RSA_PUBLIC_PEM);
+        assert!(key.is_ok());
+    }
+
+    #[test]
+    fn it_rejects_malformed_rsa_pem() {
+        let key = DecodingKey::from_rsa_pem(b"not a pem");
+        assert!(key.is_err());
+    }
+
+    #[test]
+    fn it_rejects_malformed_ec_pem() {
+        let key = DecodingKey::from_ec_pem(b"not a pem");
+        assert!(key.is_err());
+    }
+
+    #[test]
+    fn it_rejects_malformed_ed_pem() {
+        let key = DecodingKey::from_ed_pem(b"not a pem");
+        assert!(key.is_err());
+    }
+
+    #[test]
+    fn it_loads_from_env_var() {
+        // CARGO_PKG_NAME is always set by cargo during tests.
+        let key = DecodingKey::try_from_env("CARGO_PKG_NAME");
+        assert!(key.is_ok());
+    }
+
+    #[test]
+    fn it_fails_when_env_missing() {
+        let key = DecodingKey::try_from_env("VOLGA_TEST_DECODING_KEY_NOT_SET_XYZ");
+        assert!(key.is_err());
+    }
+
+    #[test]
+    #[should_panic(expected = "NOT_SET_PANIC_DECODING_SECRET_XYZABC")]
+    fn it_panics_when_from_env_var_missing() {
+        let _ = DecodingKey::from_env("NOT_SET_PANIC_DECODING_SECRET_XYZABC");
+    }
+
+    #[test]
+    fn it_fails_env_base64_when_var_invalid_base64() {
+        // CARGO_PKG_NAME is always set by cargo during tests and is not valid base64.
+        let key = DecodingKey::try_from_env_base64("CARGO_PKG_NAME");
+        assert!(key.is_err());
+    }
+
+    #[test]
+    fn it_fails_env_base64_when_var_missing() {
+        let key = DecodingKey::try_from_env_base64("VOLGA_TEST_DECODING_ENV_B64_MISSING_XYZ");
+        assert!(key.is_err());
+    }
+
+    #[test]
+    fn it_loads_from_file() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("volga-test-decoding-{}.key", std::process::id()));
+        std::fs::write(&path, SECRET).unwrap();
+        let key = DecodingKey::try_from_file(&path);
+        let _ = std::fs::remove_file(&path);
+        assert!(key.is_ok());
+    }
+
+    #[test]
+    fn it_fails_when_file_missing() {
+        let path = std::path::Path::new("/nonexistent/volga/test/decoding-key.txt");
+        let key = DecodingKey::try_from_file(path);
+        assert!(key.is_err());
+    }
+
+    #[test]
+    fn it_loads_rsa_pem_file_with_autodetect() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!(
+            "volga-test-decoding-rsa-{}.pem",
+            std::process::id()
+        ));
+        std::fs::write(&path, RSA_PUBLIC_PEM).unwrap();
+        let key = DecodingKey::try_from_pem_file(&path);
+        let _ = std::fs::remove_file(&path);
+        assert!(key.is_ok(), "got: {key:?}");
+    }
+
+    #[test]
+    fn it_fails_when_pem_file_missing() {
+        let path = std::path::Path::new("/nonexistent/volga/test/decoding-key.pem");
+        let key = DecodingKey::try_from_pem_file(path);
+        assert!(key.is_err());
+    }
+
+    #[test]
+    fn it_fails_when_pem_header_unknown() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!(
+            "volga-test-decoding-unknown-{}.pem",
+            std::process::id()
+        ));
+        std::fs::write(
+            &path,
+            b"-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----\n",
+        )
+        .unwrap();
+        let key = DecodingKey::try_from_pem_file(&path);
+        let _ = std::fs::remove_file(&path);
+        assert!(key.is_err());
+        assert!(key.unwrap_err().to_string().to_lowercase().contains("pem"));
+    }
+
+    #[test]
+    fn it_debugs_as_redacted() {
+        let key = DecodingKey::from_secret(SECRET);
+        assert_eq!(format!("{key:?}"), "DecodingKey([redacted])");
+    }
+}

--- a/volga/src/auth/encoding_key.rs
+++ b/volga/src/auth/encoding_key.rs
@@ -1,0 +1,357 @@
+//! Owned wrapper around `jsonwebtoken::EncodingKey`.
+
+use crate::error::Error;
+
+pub(crate) fn read_env_var(name: &str) -> Result<String, Error> {
+    match std::env::var(name) {
+        Ok(value) => Ok(value),
+        Err(std::env::VarError::NotPresent) => {
+            Err(Error::server_error(format!("{name} env var is not set")))
+        }
+        Err(std::env::VarError::NotUnicode(_)) => Err(Error::server_error(format!(
+            "{name} env var is not valid UTF-8"
+        ))),
+    }
+}
+
+pub(crate) fn read_key_file(path: &std::path::Path) -> Result<Vec<u8>, Error> {
+    std::fs::read(path).map_err(|e| {
+        Error::server_error(format!("Failed to read key file {}: {e}", path.display()))
+    })
+}
+
+/// A key used to sign JWTs.
+///
+/// Wraps an internal signing key. Use one of the `from_*` or `try_from_*`
+/// constructors to build an instance, then pass it to
+/// [`BearerAuthConfig::set_encoding_key`](super::bearer::BearerAuthConfig::set_encoding_key).
+pub struct EncodingKey(pub(crate) jsonwebtoken::EncodingKey);
+
+impl std::fmt::Debug for EncodingKey {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("EncodingKey([redacted])")
+    }
+}
+
+impl EncodingKey {
+    /// Builds an HMAC key from a raw byte slice.
+    ///
+    /// Use with `HS256`, `HS384`, or `HS512`.
+    #[inline]
+    pub fn from_secret(secret: &[u8]) -> Self {
+        Self(jsonwebtoken::EncodingKey::from_secret(secret))
+    }
+
+    /// Builds an HMAC key by base64-decoding a string.
+    ///
+    /// Returns an error if the input is not valid base64.
+    #[inline]
+    pub fn from_base64_secret(secret: &str) -> Result<Self, Error> {
+        jsonwebtoken::EncodingKey::from_base64_secret(secret)
+            .map(Self)
+            .map_err(Error::from)
+    }
+
+    /// Builds an RSA signing key from a PEM-encoded private key.
+    #[inline]
+    pub fn from_rsa_pem(pem: &[u8]) -> Result<Self, Error> {
+        jsonwebtoken::EncodingKey::from_rsa_pem(pem)
+            .map(Self)
+            .map_err(Error::from)
+    }
+
+    /// Builds an ECDSA signing key from a PEM-encoded private key.
+    #[inline]
+    pub fn from_ec_pem(pem: &[u8]) -> Result<Self, Error> {
+        jsonwebtoken::EncodingKey::from_ec_pem(pem)
+            .map(Self)
+            .map_err(Error::from)
+    }
+
+    /// Builds an EdDSA signing key from a PEM-encoded private key.
+    #[inline]
+    pub fn from_ed_pem(pem: &[u8]) -> Result<Self, Error> {
+        jsonwebtoken::EncodingKey::from_ed_pem(pem)
+            .map(Self)
+            .map_err(Error::from)
+    }
+
+    /// Reads the env var `name` and builds an HMAC key from its bytes.
+    ///
+    /// Equivalent to `try_from_env(name).expect(...)`. Panics if the variable
+    /// is missing or not valid UTF-8. Intended for startup configuration where
+    /// failing fast is preferred.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use volga::auth::EncodingKey;
+    ///
+    /// let key = EncodingKey::from_env("JWT_SECRET");
+    /// ```
+    #[inline]
+    pub fn from_env(name: &str) -> Self {
+        Self::try_from_env(name).unwrap_or_else(|e| panic!("{e}"))
+    }
+
+    /// Reads the env var `name` and builds an HMAC key from its bytes.
+    ///
+    /// Returns an error with a message that includes the variable name if the
+    /// variable is missing or not valid UTF-8.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use volga::auth::EncodingKey;
+    ///
+    /// let key = EncodingKey::try_from_env("JWT_SECRET")?;
+    /// # Ok::<(), volga::error::Error>(())
+    /// ```
+    #[inline]
+    pub fn try_from_env(name: &str) -> Result<Self, Error> {
+        let value = read_env_var(name)?;
+        Ok(Self::from_secret(value.as_bytes()))
+    }
+
+    /// Reads the env var `name` and base64-decodes it into an HMAC key.
+    ///
+    /// Panics if the variable is missing, not UTF-8, or not valid base64.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use volga::auth::EncodingKey;
+    ///
+    /// let key = EncodingKey::from_env_base64("JWT_SECRET_B64");
+    /// ```
+    #[inline]
+    pub fn from_env_base64(name: &str) -> Self {
+        Self::try_from_env_base64(name).unwrap_or_else(|e| panic!("{e}"))
+    }
+
+    /// Reads the env var `name` and base64-decodes it into an HMAC key.
+    #[inline]
+    pub fn try_from_env_base64(name: &str) -> Result<Self, Error> {
+        let value = read_env_var(name)?;
+        Self::from_base64_secret(&value)
+    }
+
+    /// Reads the file at `path` and builds an HMAC key from its raw bytes.
+    ///
+    /// Panics on I/O errors. Intended for startup configuration.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use volga::auth::EncodingKey;
+    ///
+    /// let key = EncodingKey::from_file("/etc/volga/jwt.key");
+    /// ```
+    #[inline]
+    pub fn from_file<P: AsRef<std::path::Path>>(path: P) -> Self {
+        Self::try_from_file(path).unwrap_or_else(|e| panic!("{e}"))
+    }
+
+    /// Reads the file at `path` and builds an HMAC key from its raw bytes.
+    #[inline]
+    pub fn try_from_file<P: AsRef<std::path::Path>>(path: P) -> Result<Self, Error> {
+        let bytes = read_key_file(path.as_ref())?;
+        Ok(Self::from_secret(&bytes))
+    }
+
+    /// Reads the PEM file at `path` and auto-detects the key format
+    /// (RSA / EC / Ed) from the header line.
+    ///
+    /// Panics if the file cannot be read, the header is unrecognized, or
+    /// the PEM body cannot be parsed by any candidate algorithm.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use volga::auth::EncodingKey;
+    ///
+    /// let key = EncodingKey::from_pem_file("/etc/volga/rs256.pem");
+    /// ```
+    #[inline]
+    pub fn from_pem_file<P: AsRef<std::path::Path>>(path: P) -> Self {
+        Self::try_from_pem_file(path).unwrap_or_else(|e| panic!("{e}"))
+    }
+
+    /// Reads the PEM file at `path` and auto-detects the key format.
+    pub fn try_from_pem_file<P: AsRef<std::path::Path>>(path: P) -> Result<Self, Error> {
+        let bytes = read_key_file(path.as_ref())?;
+        match super::pem::detect(&bytes) {
+            super::pem::PemKind::Rsa => Self::from_rsa_pem(&bytes),
+            super::pem::PemKind::Ec => Self::from_ec_pem(&bytes),
+            super::pem::PemKind::Ambiguous => Self::from_rsa_pem(&bytes)
+                .or_else(|_| Self::from_ec_pem(&bytes))
+                .or_else(|_| Self::from_ed_pem(&bytes)),
+            super::pem::PemKind::Unknown => Err(Error::server_error(format!(
+                "Unrecognized PEM header in {}; use from_rsa_pem / from_ec_pem / from_ed_pem explicitly",
+                path.as_ref().display()
+            ))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SECRET: &[u8] = b"test-secret-bytes";
+    // echo -n "test-secret-bytes" | base64 -> dGVzdC1zZWNyZXQtYnl0ZXM=
+    const SECRET_B64: &str = "dGVzdC1zZWNyZXQtYnl0ZXM=";
+
+    #[test]
+    fn it_creates_from_secret() {
+        let _key = EncodingKey::from_secret(SECRET);
+    }
+
+    #[test]
+    fn it_creates_from_base64_secret() {
+        let key = EncodingKey::from_base64_secret(SECRET_B64);
+        assert!(key.is_ok());
+    }
+
+    #[test]
+    fn it_rejects_invalid_base64_secret() {
+        let key = EncodingKey::from_base64_secret("not valid base64!!!");
+        assert!(key.is_err());
+    }
+
+    #[test]
+    fn it_debugs_as_redacted() {
+        let key = EncodingKey::from_secret(SECRET);
+        assert_eq!(format!("{key:?}"), "EncodingKey([redacted])");
+    }
+
+    // Sample RSA private key in PEM format, generated for tests only.
+    const RSA_PRIVATE_PEM: &[u8] = b"-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAq1ma/MoK5uWwsPxUNsVH1e+ybz/TzUGiFqUKbYkLTpXr9kpX
+i0i5SZOkGXHnLz1ch4gmOMuvvoLNwRyBzZGkOOd8IoLZAe4OAdmpQ2T0pY6szvUC
+K3WpIa06P7n20msOuc8bzm6CFM9fJU5/vHzeLGAj4Vi2GoFz4Lm3zUlZcY2zQWu2
+kdJZt6HbAM4s+nv1m3gqX+m5gTOjBP7oxEdNsOGZnl5v8h8uZ/U+CP2emvr67HW+
+Pph8OjVvXbyhBNGAbEljoXjJMLcqB5ULxXC4AspE+EfAZD5pCQO2ssUVPjw07qLN
+Fd6gTJ7q41k2bNrS/SmYqWMeWttwEGS5Tjm3XwIDAQABAoIBABhmQZmjnCtmoO9B
+IaR5sstJvAoLIbVnJ0QjSvfMdtpzKdk5lwD9KjZnbbFgWqZphRSXVnzKMEHh/9/E
+8qPf78ToNx21FrcwHsTkXmjjAKFjbL+oRFfDRkZZZAY+CxpvBQ4LGJWyBvXwz6jb
+BVyppnmpZ8L+LCY5fwaYMQ8I0ExD7akqjEgMo9QTNpGeHl1hIVlbn93c/8MQyLpk
+OxHcq8DhRCTYQsEc7D8z7wU7QhKw0Wf1FjUDkSC4LVIVFEbKp8EqOKJpoPJsfj1r
+CiF8Vy8AUBIN1pC5nOsu3L6l1aONmDlq7ufVg2M2odZzOXvUQlzQGP3b10f1JRck
+O+lCqeECgYEA3TgcuopwW9DYYlHhjaSDRy7EZ5xD50fWyHCH9SL2H1qwz8Jsf9u8
+rFT/L5aEWW2xoBN7YLXHnALxFgZtEcqW9NEpkU8Uii7ZYO1NU+HhbeNE27a2jZzg
+DI4HfDckajKNmn/y+2JGsmvCqwAPmYj5qvCBfZZmxBc6Zeq6cFaZJ/8CgYEAxeDl
+ItlCmHVGsW94Kcm3f1FTaGvVptHB9xftxiGm/Xdkw70dRuZPsprBE8A7MwhZ8afk
+FVxLoTGEk7wuuwSpYyngJ4/+SdlH4xXz5Bgr07dqKwXAS9AWUhNU9YYMmbkI5Rjk
+MuAeBF7XS8nzrlXvHrfnajn9Pq3UeL8AUv7jhuECgYB6e4uqMpDnfh8NuPNwZ4/H
+FkRZUHMnjUPQb4TGCjVSbIJmAcRBPHqsfBeqH0qrfA05Ua+tcRSKPPcOtU1zDAW9
+uTJj2P0pDkF6bl2ZxiPcQt3IwF8CcAlqhFSVb+nZ/CokcnBA5vVJLSJv5FyKbAOb
+dlGANmy5ZzE5NobWwkuCkwKBgExZLlkx24dOdfyaXBWK3Osc+Wy4BQLH9VcWZrlC
+Xfxu7ajTS31O4yojk+XuPCu95ouMLNbJfEWDLpu8MGmYG1EhI6pn7UGFJ4MCFQHV
+5VhcImpMFB6hw00FRWhJ7Bt5pvM3bTGfe6Ue0AFBzcM+KSz9yIDiDoXLRT9jmP1v
+dL3hAoGBAJrnfhTQ6tSUmdBkgk6SfNx+RgPRj/7IbHlP1UYNS1i2OmhH+5T8qVZx
+DdAfI6OjB86GKnRAtfRfPxJqT7vV6m6pGXyGcJyPdFINbENx31LXV6E7aXJEJbQX
+JUI7cp++yw7jYS/V9fAJTMjs/uk1dRuXRoWbwc4o+PlhcBtU2VAp
+-----END RSA PRIVATE KEY-----
+";
+
+    #[test]
+    fn it_creates_from_rsa_pem() {
+        let key = EncodingKey::from_rsa_pem(RSA_PRIVATE_PEM);
+        assert!(key.is_ok());
+    }
+
+    #[test]
+    fn it_rejects_malformed_rsa_pem() {
+        let key = EncodingKey::from_rsa_pem(b"not a pem");
+        assert!(key.is_err());
+    }
+
+    #[test]
+    fn it_loads_from_env_var() {
+        // CARGO_PKG_NAME is always set by cargo during tests; use as known-present var.
+        let key = EncodingKey::try_from_env("CARGO_PKG_NAME");
+        assert!(key.is_ok(), "got: {key:?}");
+    }
+
+    #[test]
+    fn it_fails_when_env_var_missing() {
+        let key = EncodingKey::try_from_env("DEFINITELY_NOT_SET_VAR_XYZABC_123456");
+        assert!(key.is_err());
+        let err_msg = key.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("DEFINITELY_NOT_SET_VAR_XYZABC_123456"),
+            "error should mention var name, got: {err_msg}"
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "NOT_SET_PANIC_ENCODING_SECRET_XYZABC")]
+    fn it_panics_when_from_env_var_missing() {
+        let _ = EncodingKey::from_env("NOT_SET_PANIC_ENCODING_SECRET_XYZABC");
+    }
+
+    #[test]
+    fn it_fails_env_base64_when_var_invalid_base64() {
+        // CARGO_PKG_NAME is always set by cargo during tests and is not valid base64.
+        let key = EncodingKey::try_from_env_base64("CARGO_PKG_NAME");
+        assert!(key.is_err());
+    }
+
+    #[test]
+    fn it_fails_env_base64_when_var_missing() {
+        let key = EncodingKey::try_from_env_base64("VOLGA_TEST_ENV_B64_MISSING_XYZ");
+        assert!(key.is_err());
+    }
+
+    #[test]
+    fn it_loads_from_file() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("volga-test-encoding-{}.key", std::process::id()));
+        std::fs::write(&path, SECRET).unwrap();
+        let key = EncodingKey::try_from_file(&path);
+        let _ = std::fs::remove_file(&path);
+        assert!(key.is_ok());
+    }
+
+    #[test]
+    fn it_fails_when_file_missing() {
+        let path = std::path::Path::new("/nonexistent/volga/test/key.txt");
+        let key = EncodingKey::try_from_file(path);
+        assert!(key.is_err());
+    }
+
+    #[test]
+    fn it_loads_rsa_pem_file_with_autodetect() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!(
+            "volga-test-encoding-rsa-{}.pem",
+            std::process::id()
+        ));
+        std::fs::write(&path, RSA_PRIVATE_PEM).unwrap();
+        let key = EncodingKey::try_from_pem_file(&path);
+        let _ = std::fs::remove_file(&path);
+        assert!(key.is_ok(), "got: {key:?}");
+    }
+
+    #[test]
+    fn it_fails_when_pem_file_missing() {
+        let path = std::path::Path::new("/nonexistent/volga/test/key.pem");
+        let key = EncodingKey::try_from_pem_file(path);
+        assert!(key.is_err());
+    }
+
+    #[test]
+    fn it_fails_when_pem_header_unknown() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!(
+            "volga-test-encoding-unknown-{}.pem",
+            std::process::id()
+        ));
+        std::fs::write(
+            &path,
+            b"-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----\n",
+        )
+        .unwrap();
+        let key = EncodingKey::try_from_pem_file(&path);
+        let _ = std::fs::remove_file(&path);
+        assert!(key.is_err());
+        assert!(key.unwrap_err().to_string().to_lowercase().contains("pem"));
+    }
+}

--- a/volga/src/auth/pem.rs
+++ b/volga/src/auth/pem.rs
@@ -1,0 +1,169 @@
+//! PEM header detection for auto-selecting the right JWT key constructor.
+
+/// The key format inferred from a PEM header.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[allow(dead_code)]
+pub(crate) enum PemKind {
+    /// `-----BEGIN RSA PRIVATE KEY-----` or `-----BEGIN RSA PUBLIC KEY-----`.
+    Rsa,
+    /// `-----BEGIN EC PRIVATE KEY-----`.
+    Ec,
+    /// `-----BEGIN PRIVATE KEY-----` or `-----BEGIN PUBLIC KEY-----` — ambiguous
+    /// between RSA, EC, and Ed. Caller should try each constructor in order.
+    Ambiguous,
+    /// Header was not recognized.
+    Unknown,
+}
+
+/// Inspects the first recognizable PEM header line in `bytes` and returns the
+/// inferred key kind. Leading whitespace / blank lines are skipped.
+#[allow(dead_code)]
+pub(crate) fn detect(bytes: &[u8]) -> PemKind {
+    for line in bytes.split(|&b| b == b'\n') {
+        let trimmed = trim_ascii(line);
+        if trimmed.is_empty() {
+            continue;
+        }
+        return match trimmed {
+            b"-----BEGIN RSA PRIVATE KEY-----" | b"-----BEGIN RSA PUBLIC KEY-----" => PemKind::Rsa,
+            b"-----BEGIN EC PRIVATE KEY-----" => PemKind::Ec,
+            b"-----BEGIN PRIVATE KEY-----" | b"-----BEGIN PUBLIC KEY-----" => PemKind::Ambiguous,
+            _ => PemKind::Unknown,
+        };
+    }
+    PemKind::Unknown
+}
+
+#[allow(dead_code)]
+fn trim_ascii(mut bytes: &[u8]) -> &[u8] {
+    while let [first, rest @ ..] = bytes {
+        if first.is_ascii_whitespace() {
+            bytes = rest;
+        } else {
+            break;
+        }
+    }
+    while let [rest @ .., last] = bytes {
+        if last.is_ascii_whitespace() {
+            bytes = rest;
+        } else {
+            break;
+        }
+    }
+    bytes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_detects_rsa_private() {
+        assert_eq!(
+            detect(b"-----BEGIN RSA PRIVATE KEY-----\nabc\n"),
+            PemKind::Rsa
+        );
+    }
+
+    #[test]
+    fn it_detects_rsa_public() {
+        assert_eq!(
+            detect(b"-----BEGIN RSA PUBLIC KEY-----\nabc\n"),
+            PemKind::Rsa
+        );
+    }
+
+    #[test]
+    fn it_detects_ec_private() {
+        assert_eq!(
+            detect(b"-----BEGIN EC PRIVATE KEY-----\nabc\n"),
+            PemKind::Ec
+        );
+    }
+
+    #[test]
+    fn it_detects_pkcs8_as_ambiguous() {
+        assert_eq!(
+            detect(b"-----BEGIN PRIVATE KEY-----\nabc\n"),
+            PemKind::Ambiguous
+        );
+    }
+
+    #[test]
+    fn it_detects_spki_as_ambiguous() {
+        assert_eq!(
+            detect(b"-----BEGIN PUBLIC KEY-----\nabc\n"),
+            PemKind::Ambiguous
+        );
+    }
+
+    #[test]
+    fn it_returns_unknown_for_no_header() {
+        assert_eq!(detect(b"no header here"), PemKind::Unknown);
+    }
+
+    #[test]
+    fn it_returns_unknown_for_unfamiliar_header() {
+        assert_eq!(
+            detect(b"-----BEGIN CERTIFICATE-----\nabc\n"),
+            PemKind::Unknown
+        );
+    }
+
+    #[test]
+    fn it_handles_leading_whitespace() {
+        assert_eq!(
+            detect(b"\n\n-----BEGIN EC PRIVATE KEY-----\nabc\n"),
+            PemKind::Ec
+        );
+    }
+
+    #[test]
+    fn it_returns_unknown_for_empty_input() {
+        assert_eq!(detect(b""), PemKind::Unknown);
+    }
+
+    #[test]
+    fn it_returns_unknown_for_only_whitespace() {
+        assert_eq!(detect(b"   \n\t\n   \n"), PemKind::Unknown);
+    }
+
+    #[test]
+    fn it_handles_crlf_line_endings() {
+        assert_eq!(
+            detect(b"-----BEGIN RSA PRIVATE KEY-----\r\nabc\r\n"),
+            PemKind::Rsa
+        );
+    }
+
+    #[test]
+    fn it_handles_trailing_whitespace_on_header_line() {
+        assert_eq!(
+            detect(b"-----BEGIN EC PRIVATE KEY-----   \nabc\n"),
+            PemKind::Ec
+        );
+    }
+
+    #[test]
+    fn it_detects_header_without_trailing_newline() {
+        assert_eq!(detect(b"-----BEGIN RSA PRIVATE KEY-----"), PemKind::Rsa);
+    }
+
+    #[test]
+    fn it_skips_leading_blank_lines_with_mixed_whitespace() {
+        assert_eq!(
+            detect(b"\r\n  \t\n-----BEGIN PUBLIC KEY-----\n"),
+            PemKind::Ambiguous
+        );
+    }
+
+    #[test]
+    fn it_stops_at_first_non_empty_line() {
+        // A garbage first line should yield Unknown even if a valid header
+        // appears later — we only inspect the first non-blank line.
+        assert_eq!(
+            detect(b"garbage\n-----BEGIN RSA PRIVATE KEY-----\n"),
+            PemKind::Unknown
+        );
+    }
+}

--- a/volga/src/http/cors.rs
+++ b/volga/src/http/cors.rs
@@ -348,10 +348,18 @@ impl CorsConfig {
     /// use volga::http::CorsConfig;
     ///
     /// let config = CorsConfig::default()
-    ///     .with_credentials(true);
+    ///     .with_credentials();
     /// ```
-    pub fn with_credentials(mut self, allow: bool) -> Self {
-        self.allow_credentials = allow;
+    pub fn with_credentials(mut self) -> Self {
+        self.allow_credentials = true;
+        self
+    }
+
+    /// Disallows credentials in CORS requests.
+    ///
+    /// Default: disallowed.
+    pub fn without_credentials(mut self) -> Self {
+        self.allow_credentials = false;
         self
     }
 
@@ -364,10 +372,18 @@ impl CorsConfig {
     /// use volga::http::CorsConfig;
     ///
     /// let config = CorsConfig::default()
-    ///     .with_vary_header(false);
+    ///     .without_vary_header();
     /// ```
-    pub fn with_vary_header(mut self, include_vary: bool) -> Self {
-        self.include_vary = include_vary;
+    pub fn with_vary_header(mut self) -> Self {
+        self.include_vary = true;
+        self
+    }
+
+    /// Omits the `Vary` header from CORS responses.
+    ///
+    /// Default: included.
+    pub fn without_vary_header(mut self) -> Self {
+        self.include_vary = false;
         self
     }
 
@@ -732,30 +748,6 @@ impl App {
         self.set_cors(config(CorsConfig::default()))
     }
 
-    /// Configures a web server with default CORS configuration
-    ///
-    /// Default: `None`
-    ///
-    /// # Example
-    /// ```no_run
-    /// use volga::App;
-    ///
-    /// let app = App::new().with_default_cors();
-    /// ```
-    ///
-    /// If default (unnamed) CORS was already preconfigured, it does overwrite it
-    /// ```no_run
-    /// use volga::App;
-    /// use volga::http::CorsConfig;
-    ///
-    /// let app = App::new()
-    ///     .set_cors(CorsConfig::default().with_any_origin())
-    ///     .with_default_cors();
-    /// ```
-    pub fn with_default_cors(self) -> Self {
-        self.set_cors(CorsConfig::default())
-    }
-
     /// Configures a web server with specified CORS configuration
     ///
     /// Default: `None`
@@ -930,14 +922,14 @@ mod tests {
 
     #[test]
     fn it_creates_cors_config_without_vary_header() {
-        let config = CorsConfig::default().with_vary_header(false);
+        let config = CorsConfig::default().without_vary_header();
 
         assert!(!config.include_vary);
     }
 
     #[test]
     fn it_creates_cors_config_with_include_credentials() {
-        let config = CorsConfig::default().with_credentials(true);
+        let config = CorsConfig::default().with_credentials();
 
         assert!(config.allow_credentials);
     }
@@ -960,8 +952,8 @@ mod tests {
             cors.with_origins(["https://example.com"])
                 .with_headers(["Content-Type"])
                 .with_methods([Method::GET, Method::POST])
-                .with_credentials(true)
-                .with_vary_header(false)
+                .with_credentials()
+                .without_vary_header()
         });
 
         let config = app.cors.default.unwrap();
@@ -1010,8 +1002,8 @@ mod tests {
             .with_origins(["https://example.com"])
             .with_headers(["Content-Type"])
             .with_methods([Method::GET, Method::POST])
-            .with_credentials(true)
-            .with_vary_header(false);
+            .with_credentials()
+            .without_vary_header();
 
         let app = App::new().set_cors(config);
 
@@ -1085,7 +1077,7 @@ mod tests {
     fn it_does_not_return_access_control_allow_origin_header_with_credentials() {
         let config = CorsConfig::default()
             .with_any_origin()
-            .with_credentials(true)
+            .with_credentials()
             .precompute();
 
         let origin = Some(HeaderValue::from_static("https://example.com"));
@@ -1253,7 +1245,7 @@ mod tests {
 
     #[test]
     fn it_does_not_return_vary_preflight_header() {
-        let config = CorsConfig::default().with_vary_header(false);
+        let config = CorsConfig::default().without_vary_header();
 
         let header = config.vary_preflight();
 
@@ -1262,7 +1254,7 @@ mod tests {
 
     #[test]
     fn it_does_not_return_vary_normal_header() {
-        let config = CorsConfig::default().with_vary_header(false);
+        let config = CorsConfig::default().without_vary_header();
 
         let header = config.vary_normal();
 
@@ -1273,7 +1265,7 @@ mod tests {
     fn it_doesnt_needs_vary_when_any_origin_and_allow_any_credentials_false() {
         let config = CorsConfig::default()
             .with_any_origin()
-            .with_vary_header(true);
+            .with_vary_header();
 
         assert!(!config.needs_vary());
     }
@@ -1281,7 +1273,7 @@ mod tests {
     #[test]
     fn it_needs_vary_with_origin() {
         let config = CorsConfig::default()
-            .with_vary_header(true)
+            .with_vary_header()
             .with_origins(["http://localhost:7878/"]);
 
         assert!(config.needs_vary());
@@ -1298,7 +1290,7 @@ mod tests {
 
     #[test]
     fn it_returns_access_control_allow_credentials_header() {
-        let config = CorsConfig::default().with_credentials(true);
+        let config = CorsConfig::default().with_credentials();
 
         let header = config.allow_credentials();
 
@@ -1318,7 +1310,7 @@ mod tests {
     fn it_panics_due_combining_any_origin_with_allow_credentials() {
         let config = CorsConfig::default()
             .with_any_origin()
-            .with_credentials(true);
+            .with_credentials();
         config.validate();
     }
 
@@ -1328,7 +1320,7 @@ mod tests {
         let config = CorsConfig::default()
             .with_origins(["http://localhost:7878/"])
             .with_any_header()
-            .with_credentials(true);
+            .with_credentials();
         config.validate();
     }
 
@@ -1339,7 +1331,7 @@ mod tests {
             .with_origins(["http://localhost:7878/"])
             .with_headers(["Content-Type"])
             .with_any_method()
-            .with_credentials(true);
+            .with_credentials();
         config.validate();
     }
 
@@ -1351,7 +1343,7 @@ mod tests {
             .with_headers(["Content-Type"])
             .with_methods([Method::GET, Method::POST])
             .with_expose_any_header()
-            .with_credentials(true);
+            .with_credentials();
         config.validate();
     }
 }

--- a/volga/src/http/cors.rs
+++ b/volga/src/http/cors.rs
@@ -1263,9 +1263,7 @@ mod tests {
 
     #[test]
     fn it_doesnt_needs_vary_when_any_origin_and_allow_any_credentials_false() {
-        let config = CorsConfig::default()
-            .with_any_origin()
-            .with_vary_header();
+        let config = CorsConfig::default().with_any_origin().with_vary_header();
 
         assert!(!config.needs_vary());
     }
@@ -1308,9 +1306,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn it_panics_due_combining_any_origin_with_allow_credentials() {
-        let config = CorsConfig::default()
-            .with_any_origin()
-            .with_credentials();
+        let config = CorsConfig::default().with_any_origin().with_credentials();
         config.validate();
     }
 

--- a/volga/src/http/endpoints/args/option.rs
+++ b/volga/src/http/endpoints/args/option.rs
@@ -1,4 +1,4 @@
-//! Extractor for Option<T>
+//! Extractor for `Option<T>`
 
 use crate::{
     HttpRequest,

--- a/volga/src/http/endpoints/args/vec.rs
+++ b/volga/src/http/endpoints/args/vec.rs
@@ -1,4 +1,4 @@
-//! Extractor for [Vec<T>] that is basically [`Json<Vec<T>>`] and deserialized from JSON array
+//! Extractor for [`Vec<T>`] that is basically [`Json<Vec<T>>`] and deserialized from JSON array
 
 use pin_project_lite::pin_project;
 use serde::de::DeserializeOwned;

--- a/volga/src/http/request_scope.rs
+++ b/volga/src/http/request_scope.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use crate::error::handler::PipelineErrorHandler;
 
 #[cfg(feature = "jwt-auth")]
-use crate::auth::bearer::BearerTokenService;
+use crate::auth::bearer::{Bearer, BearerTokenService};
 
 #[cfg(any(
     feature = "decompression-brotli",
@@ -68,6 +68,14 @@ pub(crate) struct HttpRequestScope {
     #[cfg(feature = "jwt-auth")]
     pub(crate) bearer_token_service: Option<BearerTokenService>,
 
+    /// Stashed bearer token captured by the first `authorize` middleware on
+    /// the chain when `strip_token_from_request` is enabled. Allows nested
+    /// `authorize` middlewares (e.g. group-level + route-level) to recover
+    /// the credential after the outer call has removed the `Authorization`
+    /// header from the request.
+    #[cfg(feature = "jwt-auth")]
+    pub(crate) bearer: Option<Bearer>,
+
     /// Resolved limits for the decompression middleware.
     #[cfg(any(
         feature = "decompression-brotli",
@@ -113,6 +121,8 @@ impl Default for HttpRequestScope {
             },
             #[cfg(feature = "jwt-auth")]
             bearer_token_service: None,
+            #[cfg(feature = "jwt-auth")]
+            bearer: None,
             #[cfg(any(
                 feature = "decompression-brotli",
                 feature = "decompression-gzip",

--- a/volga/src/middleware/cors.rs
+++ b/volga/src/middleware/cors.rs
@@ -107,7 +107,7 @@ mod tests {
 
     #[test]
     fn it_validates_cors_config() {
-        let mut app = App::new().with_cors(|cors| cors.with_credentials(false));
+        let mut app = App::new().with_cors(|cors| cors.without_credentials());
         app.use_cors();
     }
 }

--- a/volga/src/tls.rs
+++ b/volga/src/tls.rs
@@ -229,19 +229,35 @@ impl fmt::Display for HstsConfig {
 }
 
 impl HstsConfig {
-    /// Configures whether to set `preload` in HSTS header
+    /// Enables `preload` in the HSTS header.
     ///
-    /// Default value: `false`
-    pub fn with_preload(mut self, preload: bool) -> Self {
-        self.preload = preload;
+    /// Default: disabled.
+    pub fn with_preload(mut self) -> Self {
+        self.preload = true;
         self
     }
 
-    /// Configures whether to set `includeSubDomains` in the HSTS header
+    /// Disables `preload` in the HSTS header.
     ///
-    /// Default: `false`
-    pub fn with_sub_domains(mut self, include: bool) -> Self {
-        self.include_sub_domains = include;
+    /// Default: disabled.
+    pub fn without_preload(mut self) -> Self {
+        self.preload = false;
+        self
+    }
+
+    /// Enables `includeSubDomains` in the HSTS header.
+    ///
+    /// Default: disabled.
+    pub fn with_sub_domains(mut self) -> Self {
+        self.include_sub_domains = true;
+        self
+    }
+
+    /// Disables `includeSubDomains` in the HSTS header.
+    ///
+    /// Default: disabled.
+    pub fn without_sub_domains(mut self) -> Self {
+        self.include_sub_domains = false;
         self
     }
 
@@ -396,7 +412,7 @@ impl TlsConfig {
     /// use volga::tls::TlsConfig;
     ///
     /// let tls = TlsConfig::new()
-    ///     .with_hsts(|hsts| hsts.with_preload(false));
+    ///     .with_hsts(|hsts| hsts.without_preload());
     /// ```
     pub fn with_hsts<T>(mut self, config: T) -> Self
     where
@@ -415,42 +431,6 @@ impl TlsConfig {
     /// - exclude_hosts: empty list
     pub fn set_hsts(mut self, hsts_config: HstsConfig) -> Self {
         self.hsts_config = hsts_config;
-        self
-    }
-
-    /// Configures whether to set `preload` in HSTS header
-    ///
-    /// Default value: `true`
-    pub fn with_hsts_preload(mut self, preload: bool) -> Self {
-        self.hsts_config = self.hsts_config.with_preload(preload);
-        self
-    }
-
-    /// Configures whether to set `includeSubDomains` in the HSTS header
-    ///
-    /// Default: `true`
-    pub fn with_hsts_sub_domains(mut self, include: bool) -> Self {
-        self.hsts_config = self.hsts_config.with_sub_domains(include);
-        self
-    }
-
-    /// Configures `max_age` for HSTS header
-    ///
-    /// Default: 30 days (2,592,000 seconds)
-    pub fn with_hsts_max_age(mut self, max_age: Duration) -> Self {
-        self.hsts_config = self.hsts_config.with_max_age(max_age);
-        self
-    }
-
-    /// Configures a list of host names that will not add the HSTS header.
-    ///
-    /// Default: empty list
-    pub fn with_hsts_exclude_hosts<I, S>(mut self, exclude_hosts: I) -> Self
-    where
-        I: IntoIterator<Item = S>,
-        S: AsRef<str>,
-    {
-        self.hsts_config = self.hsts_config.with_exclude_hosts(exclude_hosts);
         self
     }
 
@@ -661,11 +641,11 @@ impl App {
     /// # Example
     /// ```no_run
     /// use volga::App;
-    /// use volga::tls::{TlsConfig, HstsConfig};
+    /// use volga::tls::TlsConfig;
     ///
     /// let app = App::new()
-    ///     .set_tls(TlsConfig::new().with_hsts_sub_domains(false)) // sets include_sub_domains to true
-    ///     .with_hsts(|hsts| hsts.with_preload(true));             // sets preload to true, include_sub_domains remains true
+    ///     .set_tls(TlsConfig::new())
+    ///     .with_hsts(|hsts| hsts.with_preload().with_sub_domains());
     /// ```
     pub fn with_hsts<T>(mut self, config: T) -> Self
     where
@@ -875,13 +855,12 @@ mod tests {
 
     #[test]
     fn it_creates_tls_config_with_hsts() {
-        let tls_config = TlsConfig::from_pem("tls")
-            .with_hsts_exclude_hosts(["example.com"])
-            .with_hsts(|hsts| {
-                hsts.with_preload(false)
-                    .with_sub_domains(false)
-                    .with_max_age(Duration::from_secs(1))
-            });
+        let tls_config = TlsConfig::from_pem("tls").with_hsts(|hsts| {
+            hsts.with_exclude_hosts(["example.com"])
+                .without_preload()
+                .without_sub_domains()
+                .with_max_age(Duration::from_secs(1))
+        });
 
         let path = PathBuf::from("tls");
 
@@ -900,7 +879,7 @@ mod tests {
 
     #[test]
     fn it_creates_tls_config_with_hsts_preload() {
-        let tls_config = TlsConfig::from_pem("tls").with_hsts_preload(true);
+        let tls_config = TlsConfig::from_pem("tls").with_hsts(|h| h.with_preload());
 
         let path = PathBuf::from("tls");
 
@@ -922,7 +901,7 @@ mod tests {
 
     #[test]
     fn it_creates_tls_config_with_hsts_sub_domains() {
-        let tls_config = TlsConfig::from_pem("tls").with_hsts_sub_domains(true);
+        let tls_config = TlsConfig::from_pem("tls").with_hsts(|h| h.with_sub_domains());
 
         let path = PathBuf::from("tls");
 
@@ -944,7 +923,8 @@ mod tests {
 
     #[test]
     fn it_creates_tls_config_with_hsts_max_age() {
-        let tls_config = TlsConfig::from_pem("tls").with_hsts_max_age(Duration::from_secs(5));
+        let tls_config =
+            TlsConfig::from_pem("tls").with_hsts(|h| h.with_max_age(Duration::from_secs(5)));
 
         let path = PathBuf::from("tls");
 
@@ -963,7 +943,8 @@ mod tests {
 
     #[test]
     fn it_creates_tls_config_with_hsts_exclude_hosts() {
-        let tls_config = TlsConfig::from_pem("tls").with_hsts_exclude_hosts(["example.com"]);
+        let tls_config =
+            TlsConfig::from_pem("tls").with_hsts(|h| h.with_exclude_hosts(["example.com"]));
 
         let path = PathBuf::from("tls");
 
@@ -1016,8 +997,8 @@ mod tests {
             .with_tls(|tls| tls.with_https_redirection())
             .with_hsts(|hsts| {
                 hsts.with_max_age(Duration::from_secs(1))
-                    .with_preload(false)
-                    .with_sub_domains(false)
+                    .without_preload()
+                    .without_sub_domains()
                     .with_exclude_hosts(["example.com"])
             });
 
@@ -1036,8 +1017,8 @@ mod tests {
     fn it_creates_app_with_tls_config_and_sets_hsts_custom_config() {
         let hsts = HstsConfig::default()
             .with_max_age(Duration::from_secs(1))
-            .with_preload(false)
-            .with_sub_domains(false)
+            .without_preload()
+            .without_sub_domains()
             .with_exclude_hosts(["example.com"]);
 
         let app = App::new()

--- a/volga/src/tracing.rs
+++ b/volga/src/tracing.rs
@@ -81,16 +81,6 @@ impl TracingConfig {
 }
 
 impl App {
-    /// Configures web server with the default Tracing configurations
-    ///
-    /// Defaults:
-    /// - include_header: `false`
-    /// - span_header_name: `request-id`
-    pub fn with_default_tracing(mut self) -> Self {
-        self.tracing_config = Some(TracingConfig::default());
-        self
-    }
-
     /// Configures web server with specific Tracing configurations.
     ///
     /// Defaults:
@@ -185,7 +175,7 @@ mod tests {
 
     #[test]
     fn it_creates_app_with_default_tracing() {
-        let app = App::new().with_default_tracing();
+        let app = App::new().set_tracing(TracingConfig::default());
         let tracing_config = app.tracing_config.unwrap();
 
         assert!(!tracing_config.include_header);

--- a/volga/src/ws/connection.rs
+++ b/volga/src/ws/connection.rs
@@ -107,11 +107,19 @@ impl WebSocketConnection {
         self
     }
 
-    /// Sets/unsets a web-server to accept unmasked frames
+    /// Accepts unmasked frames from the peer.
     ///
-    /// Default: `false`
-    pub fn with_accept_unmasked_frames(mut self, accept: bool) -> Self {
-        self.config.accept_unmasked_frames = accept;
+    /// Default: rejected.
+    pub fn with_accept_unmasked_frames(mut self) -> Self {
+        self.config.accept_unmasked_frames = true;
+        self
+    }
+
+    /// Rejects unmasked frames from the peer.
+    ///
+    /// Default: rejected.
+    pub fn without_accept_unmasked_frames(mut self) -> Self {
+        self.config.accept_unmasked_frames = false;
         self
     }
 
@@ -545,7 +553,7 @@ mod tests {
 
         let conn = conn
             .with_max_frame_size(1024)
-            .with_accept_unmasked_frames(true)
+            .with_accept_unmasked_frames()
             .with_protocols(["foo-ws"])
             .with_max_message_size(1024)
             .with_read_buffer_size(1024)

--- a/volga/tests/auth_require_https_tests.rs
+++ b/volga/tests/auth_require_https_tests.rs
@@ -1,0 +1,96 @@
+//! Verifies `require_https` behavior: loopback exception and opt-out.
+
+#![cfg(all(feature = "jwt-auth", feature = "test"))]
+
+use serde::{Deserialize, Serialize};
+use std::time::{SystemTime, UNIX_EPOCH};
+use volga::{
+    App,
+    auth::{AuthClaims, BearerAuthConfig, BearerTokenService, DecodingKey, EncodingKey, roles},
+    ok,
+    test::TestServer,
+};
+
+const SECRET: &[u8] = b"test-require-https-secret-0123456";
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct Claims {
+    sub: String,
+    role: String,
+    exp: u64,
+}
+
+impl AuthClaims for Claims {
+    fn role(&self) -> Option<&str> {
+        Some(&self.role)
+    }
+}
+
+fn make_token() -> String {
+    let claims = Claims {
+        sub: "alice".to_string(),
+        role: "admin".to_string(),
+        exp: SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            + 3600,
+    };
+    let service: BearerTokenService = BearerAuthConfig::default()
+        .set_encoding_key(EncodingKey::from_secret(SECRET))
+        .into();
+    service.encode(&claims).unwrap().to_string()
+}
+
+#[tokio::test]
+async fn it_allows_loopback_without_tls() {
+    let server = TestServer::builder()
+        .configure(|app| {
+            app.with_bearer_auth(|auth| auth.set_decoding_key(DecodingKey::from_secret(SECRET)))
+        })
+        .setup(|app: &mut App| {
+            app.map_get("/ok", || async { ok!("ok") })
+                .authorize::<Claims>(roles(["admin"]));
+        })
+        .build()
+        .await;
+
+    let token = make_token();
+    let res = server
+        .client()
+        .get(server.url("/ok"))
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200, "loopback should bypass require_https");
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn it_respects_require_https_disabled() {
+    let server = TestServer::builder()
+        .configure(|app| {
+            app.with_bearer_auth(|auth| {
+                auth.set_decoding_key(DecodingKey::from_secret(SECRET))
+                    .require_https(false)
+            })
+        })
+        .setup(|app: &mut App| {
+            app.map_get("/ok", || async { ok!("ok") })
+                .authorize::<Claims>(roles(["admin"]));
+        })
+        .build()
+        .await;
+
+    let token = make_token();
+    let res = server
+        .client()
+        .get(server.url("/ok"))
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    server.shutdown().await;
+}

--- a/volga/tests/auth_strip_token_tests.rs
+++ b/volga/tests/auth_strip_token_tests.rs
@@ -83,6 +83,42 @@ async fn it_strips_authorization_header_after_auth() {
 }
 
 #[tokio::test]
+async fn it_supports_layered_authorize_with_strip_enabled() {
+    // Group-level + route-level authorize must both succeed when
+    // strip_token_from_request is enabled (default). The outer call strips
+    // the header, but the inner call must recover the token from the
+    // request scope rather than failing with "Missing Authorization header".
+    let server = TestServer::builder()
+        .configure(|app| {
+            app.with_bearer_auth(|auth| {
+                auth.set_decoding_key(DecodingKey::from_secret(SECRET))
+                    .validate_exp(false)
+            })
+        })
+        .setup(|app| {
+            app.group("/api", |api| {
+                api.authorize::<Claims>(roles(["admin"]));
+                api.map_get("/echo", echo_auth_header)
+                    .authorize::<Claims>(roles(["admin"]));
+            });
+        })
+        .build()
+        .await;
+
+    let token = make_token();
+    let res = server
+        .client()
+        .get(server.url("/api/echo"))
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    assert_eq!(res.text().await.unwrap(), "absent");
+    server.shutdown().await;
+}
+
+#[tokio::test]
 async fn it_preserves_authorization_header_when_disabled() {
     let server = TestServer::builder()
         .configure(|app| {

--- a/volga/tests/auth_strip_token_tests.rs
+++ b/volga/tests/auth_strip_token_tests.rs
@@ -1,0 +1,113 @@
+//! Verifies that the Authorization header is removed from the request after
+//! successful bearer-token auth, unless disabled.
+
+#![cfg(all(feature = "jwt-auth", feature = "test"))]
+
+use serde::{Deserialize, Serialize};
+use std::time::{SystemTime, UNIX_EPOCH};
+use volga::{
+    HttpRequest,
+    auth::{AuthClaims, DecodingKey, EncodingKey, roles},
+    ok,
+    test::TestServer,
+};
+
+const SECRET: &[u8] = b"test-strip-token-secret-0123456789";
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct Claims {
+    sub: String,
+    role: String,
+    exp: u64,
+}
+
+impl AuthClaims for Claims {
+    fn role(&self) -> Option<&str> {
+        Some(&self.role)
+    }
+}
+
+fn make_token() -> String {
+    let claims = Claims {
+        sub: "alice".to_string(),
+        role: "admin".to_string(),
+        exp: SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            + 3600,
+    };
+    let key = EncodingKey::from_secret(SECRET);
+    let service: volga::auth::BearerTokenService = volga::auth::BearerAuthConfig::default()
+        .set_encoding_key(key)
+        .validate_exp(false)
+        .into();
+    service.encode(&claims).unwrap().to_string()
+}
+
+async fn echo_auth_header(req: HttpRequest) -> volga::HttpResult {
+    if req.headers().get(hyper::header::AUTHORIZATION).is_some() {
+        ok!("present")
+    } else {
+        ok!("absent")
+    }
+}
+
+#[tokio::test]
+async fn it_strips_authorization_header_after_auth() {
+    let server = TestServer::builder()
+        .configure(|app| {
+            app.with_bearer_auth(|auth| {
+                auth.set_decoding_key(DecodingKey::from_secret(SECRET))
+                    .validate_exp(false)
+            })
+        })
+        .setup(|app| {
+            app.map_get("/echo", echo_auth_header)
+                .authorize::<Claims>(roles(["admin"]));
+        })
+        .build()
+        .await;
+
+    let token = make_token();
+    let res = server
+        .client()
+        .get(server.url("/echo"))
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    assert_eq!(res.text().await.unwrap(), "absent");
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn it_preserves_authorization_header_when_disabled() {
+    let server = TestServer::builder()
+        .configure(|app| {
+            app.with_bearer_auth(|auth| {
+                auth.set_decoding_key(DecodingKey::from_secret(SECRET))
+                    .validate_exp(false)
+                    .strip_token_from_request(false)
+            })
+        })
+        .setup(|app| {
+            app.map_get("/echo", echo_auth_header)
+                .authorize::<Claims>(roles(["admin"]));
+        })
+        .build()
+        .await;
+
+    let token = make_token();
+    let res = server
+        .client()
+        .get(server.url("/echo"))
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    assert_eq!(res.text().await.unwrap(), "present");
+    server.shutdown().await;
+}

--- a/volga/tests/auth_www_authenticate_tests.rs
+++ b/volga/tests/auth_www_authenticate_tests.rs
@@ -1,0 +1,62 @@
+//! Verifies that WWW-Authenticate responses include `resource_metadata` when
+//! configured.
+
+#![cfg(all(feature = "jwt-auth", feature = "test"))]
+
+use serde::{Deserialize, Serialize};
+use volga::{
+    App,
+    auth::{AuthClaims, DecodingKey, roles},
+    test::TestServer,
+};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct Claims {
+    sub: String,
+    role: String,
+    exp: u64,
+}
+
+impl AuthClaims for Claims {
+    fn role(&self) -> Option<&str> {
+        Some(&self.role)
+    }
+}
+
+#[tokio::test]
+async fn it_includes_resource_metadata_in_challenge() {
+    let server = TestServer::builder()
+        .configure(|app| {
+            app.with_bearer_auth(|auth| {
+                auth.set_decoding_key(DecodingKey::from_secret(b"wrong-secret"))
+                    .with_resource_metadata_url(
+                        "https://api.example.com/.well-known/oauth-protected-resource",
+                    )
+            })
+        })
+        .setup(|app: &mut App| {
+            app.map_get("/x", || async { volga::ok!("x") })
+                .authorize::<Claims>(roles(["admin"]));
+        })
+        .build()
+        .await;
+
+    let res = server
+        .client()
+        .get(server.url("/x"))
+        .header("Authorization", "Bearer bad-token")
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 403);
+    let www_auth = res.headers().get("www-authenticate").unwrap();
+    let www_auth = www_auth.to_str().unwrap();
+    assert!(
+        www_auth.contains(
+            r#"resource_metadata="https://api.example.com/.well-known/oauth-protected-resource""#
+        ),
+        "header was: {www_auth}"
+    );
+    server.shutdown().await;
+}

--- a/volga/tests/cors.rs
+++ b/volga/tests/cors.rs
@@ -262,7 +262,7 @@ async fn it_applies_named_cors_for_route() {
             .with_cors(|cors| {
                 cors.with_origins(["http://192.168.1.1"])
                     .with_methods([Method::GET])
-                    .with_vary_header(false)
+                    .without_vary_header()
                     .with_any_header()
             })
         })
@@ -307,7 +307,7 @@ async fn it_applies_named_cors_for_route_group() {
             .with_cors(|cors| {
                 cors.with_origins(["http://192.168.1.1"])
                     .with_methods([Method::GET])
-                    .with_vary_header(false)
+                    .without_vary_header()
                     .with_any_header()
             })
         })
@@ -355,7 +355,7 @@ async fn it_prefers_route_cors_policy_over_the_route_group() {
             .with_cors(|cors| {
                 cors.with_origins(["http://127.0.0.1"])
                     .with_methods([Method::GET])
-                    .with_vary_header(false)
+                    .without_vary_header()
                     .with_any_header()
             })
         })

--- a/volga/tests/jwt.rs
+++ b/volga/tests/jwt.rs
@@ -1,11 +1,10 @@
 #![allow(missing_docs)]
 #![cfg(all(feature = "test", feature = "middleware", feature = "jwt-auth-full"))]
 
-use jsonwebtoken::{DecodingKey, EncodingKey};
 use serde::{Deserialize, Serialize};
 use std::ops::Add;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use volga::auth::{BearerTokenService, Claims, predicate};
+use volga::auth::{BearerTokenService, Claims, DecodingKey, EncodingKey, predicate};
 use volga::test::TestServer;
 use volga::{
     headers::{CACHE_CONTROL, WWW_AUTHENTICATE},

--- a/volga/tests/tls.rs
+++ b/volga/tests/tls.rs
@@ -232,8 +232,8 @@ async fn it_works_with_tls_with_required_auth_authenticated_and_https_redirectio
                     .with_http_port(http_port)
             })
             .with_hsts(|hsts| {
-                hsts.with_preload(false)
-                    .with_sub_domains(true)
+                hsts.without_preload()
+                    .with_sub_domains()
                     .with_max_age(Duration::from_secs(60))
                     .with_exclude_hosts(["example.com", "example.net"])
             })
@@ -287,8 +287,8 @@ async fn it_works_with_tls_with_https_redirection() {
             ))
             .with_tls(|tls| tls.with_https_redirection().with_http_port(http_port))
             .with_hsts(|hsts| {
-                hsts.with_preload(false)
-                    .with_sub_domains(true)
+                hsts.without_preload()
+                    .with_sub_domains()
                     .with_max_age(Duration::from_secs(60))
                     .with_exclude_hosts(["example.com", "example.net"])
             })
@@ -336,8 +336,8 @@ async fn it_returns_404_if_no_host() {
             ))
             .with_tls(|tls| tls.with_https_redirection().with_http_port(http_port))
             .with_hsts(|hsts| {
-                hsts.with_preload(false)
-                    .with_sub_domains(true)
+                hsts.without_preload()
+                    .with_sub_domains()
                     .with_max_age(Duration::from_secs(60))
                     .with_exclude_hosts(["example.com", "example.net"])
             })


### PR DESCRIPTION
## Added

* **Startup constructors for JWT keys**
  `EncodingKey` / `DecodingKey` gained env / base64 / file / PEM constructors (`from_*` and `try_from_*`).
  Panicking variants are intended for one-time startup; `try_*` return `Result<_, volga::Error>`.

* **Bearer auth enhancements**

  * `with_resource(s)` — OAuth 2.0 Resource Indicators (RFC 8707)
  * `with_resource_metadata_url` — Protected Resource Metadata (RFC 9728)
  * `with_strict_aud` / `without_strict_aud` — control `aud` requirement
  * `strip_token_from_request(bool)` — remove `Authorization` after auth
  * `require_https(bool)` — enforce HTTPS (loopback allowed)

* **Explicit “disable” builders (paired with `with_*`)**

  * CORS: `without_credentials`, `without_vary_header`
  * HSTS: `without_preload`, `without_sub_domains`
  * WebSocket: `without_accept_unmasked_frames`

## Breaking Changes

* **JWT API decoupled from `jsonwebtoken`**

  * Removed re-exports (`Algorithm`, `EncodingKey`, `DecodingKey`, `JwtError`, `ErrorKind`)
  * Replaced with volga-owned types at the same paths
  * Code using `ErrorKind` or low-level constructors (`*_der`, `from_jwk`, `from_rsa_components`) will break
  * Use PEM / base64 / secret / env / file constructors instead

* **Bearer auth behavior**

  * `validation()` removed → configure via `BearerAuthConfig`
  * `with_aud` now **implicitly requires `aud`**

    * opt-out via `without_strict_aud()`
  * `require_https` **enabled by default**
  * `strip_token_from_request` **enabled by default**

* **Boolean builder APIs removed (fluent style enforced)**

  * `with_* (bool)` → split into:

    * `with_*()` (enable)
    * `without_*()` (disable)
  * Affects:

    * `CorsConfig`
    * `HstsConfig`
    * `WebSocketConnection`

* **Removed convenience APIs**

  * `App::with_default_cors` → `set_cors(CorsConfig::default())`
  * `App::with_default_tracing` → `set_tracing(TracingConfig::default())`
  * HSTS shortcuts in `TlsConfig` → use `with_hsts(|h| ...)`

## Type
- [ ] Bug fix
- [ ] Feature
- [x] Enhancement
- [ ] Performance
- [x] Documentation
- [x] Refactor
- [x] Security
- [x] Breaking change

## Checklist
- [x] I added/updated tests where it makes sense
- [x] I updated docs/examples if needed
- [x] This change is backwards-compatible (or clearly marked as breaking)
- [x] I ran formatting/lints locally (if applicable)
