### PR TITLE
multipart response

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -8,6 +8,7 @@ on:
   workflow_dispatch:
 
 env:
+  RUST_NIGHTLY: nightly-2026-05-03
   CARGO_TERM_COLOR: always
   ASAN_OPTIONS: quarantine_size_mb=1:malloc_context_size=0
 
@@ -18,11 +19,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
         with: 
-          toolchain: nightly-2026-05-03
+          toolchain: ${{ env.RUST_NIGHTLY }}
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz --locked
       - name: Build fuzz targets
-        run: cargo +nightly fuzz build
+        run: cargo +${{ env.RUST_NIGHTLY }} fuzz build
 
   fuzz_smoke:
     if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
@@ -32,13 +33,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly-2026-05-03
+          toolchain: ${{ env.RUST_NIGHTLY }}
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz --locked
       - name: Smoke run router
-        run: cargo +nightly fuzz run fuzz_router_match -- -max_len=512 -max_total_time=45 -rss_limit_mb=512
+        run: cargo +${{ env.RUST_NIGHTLY }} fuzz run fuzz_router_match -- -max_len=512 -max_total_time=45 -rss_limit_mb=512
       - name: Smoke run query
-        run: cargo +nightly fuzz run fuzz_query_decode -- -max_len=1024 -max_total_time=45 -rss_limit_mb=512
+        run: cargo +${{ env.RUST_NIGHTLY }} fuzz run fuzz_query_decode -- -max_len=1024 -max_total_time=45 -rss_limit_mb=512
 
   fuzz_nightly:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
@@ -60,8 +61,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly-2026-05-03
+          toolchain: ${{ env.RUST_NIGHTLY }}
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz --locked
       - name: Nightly fuzz run
-        run: cargo +nightly fuzz run ${{ matrix.target }} -- -max_len=${{ matrix.max_len }} -max_total_time=300 -rss_limit_mb=512
+        run: cargo +${{ env.RUST_NIGHTLY }} fuzz run ${{ matrix.target }} -- -max_len=${{ matrix.max_len }} -max_total_time=300 -rss_limit_mb=512

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -16,7 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly-2026-05-03
+      - uses: dtolnay/rust-toolchain@nightly
+        with: 
+          toolchain: nightly-2026-05-03
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz --locked
       - name: Build fuzz targets
@@ -28,7 +30,9 @@ jobs:
     needs: fuzz_build
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly-2026-05-03
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: nightly-2026-05-03
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz --locked
       - name: Smoke run router
@@ -54,7 +58,9 @@ jobs:
             max_len: 256
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly-2026-05-03
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: nightly-2026-05-03
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz --locked
       - name: Nightly fuzz run

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@nightly-2026-05-03
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz --locked
       - name: Build fuzz targets
@@ -28,7 +28,7 @@ jobs:
     needs: fuzz_build
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@nightly-2026-05-03
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz --locked
       - name: Smoke run router
@@ -54,7 +54,7 @@ jobs:
             max_len: 256
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@nightly-2026-05-03
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz --locked
       - name: Nightly fuzz run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+# 0.9.2
+
+## Added
+* `Multipart` is now bidirectional — in addition to acting as a request extractor, it implements `IntoResponse` and can be returned from handlers to produce a `multipart/*` response.
+* `Multipart::from_parts(iter)` / `Multipart::from_stream(stream)` — build an outgoing multipart from any `IntoIterator<Item = Part>` or `Stream<Item = Part>`.
+* `Multipart::with_subtype(MultipartSubtype)` — switch between `form-data`, `mixed`, `byteranges`, or a `Custom(...)` subtype on outgoing responses.
+* `Multipart::with_boundary(...)` — override the auto-generated boundary; validated per RFC 2046 §5.1.1.
+* `Multipart::into_outgoing()` — re-encode an incoming multipart as a streaming outgoing one for proxy / forwarding scenarios.
+* `Part` builder API: `Part::text`, `Part::bytes`, `Part::file`, `Part::stream`, `Part::new`, plus `with_content_type`, `with_disposition`, `with_header_raw`. `Content-Type` is auto-inferred from filename via `mime_guess`. The static-input constructors panic on invalid header bytes; fallible `try_text` / `try_bytes` / `try_file` / `try_stream` / `try_with_disposition` counterparts are provided for untrusted input.
+* `OpenApiRouteConfig::produces_multipart(status)` — describe `multipart/form-data` responses in OpenAPI specs.
+
+## Changed
+* HSTS default `max_age` is now 1 year (31,536,000 s); previously 30 days. Aligns with the [HSTS preload list](https://hstspreload.org/) requirement (#190).
+
+## Breaking Changes
+* `HstsConfig::with_preload()` panics if `max_age < 1 year`; `HstsConfig::with_max_age(...)` panics if called when `preload` is enabled and the new value is below 1 year (#190).
+* `TlsConfig`, `RedirectionConfig`, and `Problem` are now `#[non_exhaustive]`. External code can no longer construct them with struct literals or exhaustively pattern-match (#190, #191).
+* Removed the deprecated `problem!` macro. Use `volga::error::Problem` instead (#191).
+* `From<Algorithm> for jsonwebtoken::Algorithm` and the reverse impl are removed. `jsonwebtoken::Algorithm` is no longer reachable through volga's public API; conversion is crate-internal via `Algorithm::to_jwt()` (#191).
+* `Problem` responses now use the correct `application/problem+json` content type (#191).
+
 # 0.9.1
 
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Changed
 * HSTS default `max_age` is now 1 year (31,536,000 s); previously 30 days. Aligns with the [HSTS preload list](https://hstspreload.org/) requirement (#190).
+* `Multipart` request parsing accepts any `multipart/*` subtype (previously only `multipart/form-data`). Required for forwarding `multipart/byteranges`, `multipart/mixed`, etc.
 
 ## Breaking Changes
 * `HstsConfig::with_preload()` panics if `max_age < 1 year`; `HstsConfig::with_max_age(...)` panics if called when `preload` is enabled and the new value is below 1 year (#190).

--- a/examples/multipart/src/main.rs
+++ b/examples/multipart/src/main.rs
@@ -37,10 +37,7 @@ async fn main() -> std::io::Result<()> {
     });
 
     app.map_post("/outbound", || async move {
-        Multipart::from_parts([
-            Part::text("greeting", "hello"),
-            Part::text("name", "world"),
-        ])
+        Multipart::from_parts([Part::text("greeting", "hello"), Part::text("name", "world")])
     });
 
     app.run().await

--- a/examples/multipart/src/main.rs
+++ b/examples/multipart/src/main.rs
@@ -5,7 +5,7 @@
 //! ```
 
 use std::path::Path;
-use volga::{App, Multipart, ok};
+use volga::{App, Multipart, multipart::Part, ok};
 
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
@@ -30,6 +30,14 @@ async fn main() -> std::io::Result<()> {
             results.push(text);
         }
         ok!(results)
+    });
+
+    app.map_post("/trace", |multipart: Multipart| async move {
+        multipart.into_outgoing()
+    });
+
+    app.map_post("/outbound", || async move {
+        Multipart::from_parts([Part::text("greeting", "hello"), Part::text("name", "world")])
     });
 
     app.run().await

--- a/examples/multipart/src/main.rs
+++ b/examples/multipart/src/main.rs
@@ -37,7 +37,10 @@ async fn main() -> std::io::Result<()> {
     });
 
     app.map_post("/outbound", || async move {
-        Multipart::from_parts([Part::text("greeting", "hello"), Part::text("name", "world")])
+        Multipart::from_parts([
+            Part::text("greeting", "hello"),
+            Part::text("name", "world"),
+        ])
     });
 
     app.run().await

--- a/volga-open-api/src/route.rs
+++ b/volga-open-api/src/route.rs
@@ -246,6 +246,20 @@ impl OpenApiRouteConfig {
         self
     }
 
+    /// Generates default `multipart/form-data` response schema.
+    pub fn produces_multipart(mut self, status: impl IntoStatusCode) -> Self {
+        let status = status.into_status_code();
+        self.responses.insert(
+            status,
+            ResponseBody::Content {
+                schema: Box::new(OpenApiSchema::multipart()),
+                example: None,
+                content_type: MULTIPART_FORM_DATA.to_string(),
+            },
+        );
+        self
+    }
+
     /// Generates stream response schema.
     pub fn produces_stream(mut self, status: impl IntoStatusCode) -> Self {
         let status = status.into_status_code();
@@ -607,7 +621,7 @@ fn type_display_name<T>() -> String {
 #[cfg(test)]
 #[allow(unused)]
 mod tests {
-    use super::{IntoStatusCode, OpenApiRouteConfig};
+    use super::{IntoStatusCode, OpenApiRouteConfig, ResponseBody};
     use crate::{op::OpenApiOperation, schema::OpenApiSchema};
     use serde::{Deserialize, Serialize};
     use serde_json::json;
@@ -1115,6 +1129,18 @@ mod tests {
                     .is_some()
             );
             assert_eq!(op_json["responses"].as_object().unwrap().len(), 3);
+        }
+    }
+
+    #[test]
+    fn produces_multipart_sets_response_content_type() {
+        let cfg = OpenApiRouteConfig::default().produces_multipart(200u16);
+        let resp = cfg.responses.get(&200u16).expect("200 response defined");
+        match resp {
+            ResponseBody::Content { content_type, .. } => {
+                assert_eq!(content_type, "multipart/form-data");
+            }
+            _ => panic!("expected Content variant"),
         }
     }
 }

--- a/volga/Cargo.toml
+++ b/volga/Cargo.toml
@@ -42,6 +42,7 @@ httpdate = { version = "1.0.3", optional = true }
 hyper = { version = "1.9.0", features = ["server"], optional = true }
 hyper-util = { version = "0.1.20", features = ["server", "server-auto", "server-graceful", "service", "tokio"], optional = true }
 multer = { version = "3.1.0", optional = true }
+rand = { version = "0.10.1", optional = true }
 reqwest = { version = "0.13.3", optional = true }
 sha1 = { version = "0.11.0", optional = true }
 subtle = { version = "2.6.1", default-features = false, optional = true }
@@ -110,7 +111,7 @@ dev-cert = ["dep:volga-dev-cert"]
 di = ["dep:volga-di"]
 macros = ["dep:volga-macros"]
 middleware = []
-multipart = ["dep:multer"]
+multipart = ["dep:multer", "dep:rand"]
 openapi = ["dep:sha1", "dep:volga-open-api"]
 problem-details = ["serde/derive", "volga-open-api?/problem-details"]
 rate-limiting = ["dep:twox-hash", "dep:volga-rate-limiter", "middleware"]

--- a/volga/src/headers/known_headers.rs
+++ b/volga/src/headers/known_headers.rs
@@ -63,32 +63,38 @@ impl ContentType {
     #[inline]
     pub fn multipart_form_data(boundary: &str) -> Header<Self> {
         Self::multipart_custom("form-data", boundary)
+            .expect("`form-data` is a static, valid subtype")
     }
 
     /// Creates a `multipart/mixed; boundary=...` [`Header<ContentType>`].
     #[inline]
     pub fn multipart_mixed(boundary: &str) -> Header<Self> {
-        Self::multipart_custom("mixed", boundary)
+        Self::multipart_custom("mixed", boundary).expect("`mixed` is a static, valid subtype")
     }
 
     /// Creates a `multipart/byteranges; boundary=...` [`Header<ContentType>`].
     #[inline]
-    pub fn multipart_byteranges(boundary: &str) -> Header<Self> {
+    pub fn multipart_byte_ranges(boundary: &str) -> Header<Self> {
         Self::multipart_custom("byteranges", boundary)
+            .expect("`byteranges` is a static, valid subtype")
     }
 
     /// Creates a `multipart/<subtype>; boundary=...` [`Header<ContentType>`].
     /// Boundary must already be RFC 2046 §5.1.1 compliant; use `Multipart::with_boundary`
     /// for validation. RFC 2045 tspecials in the boundary (e.g. `:` or space) trigger
     /// quoting of the parameter value so downstream parsers can extract it.
-    pub fn multipart_custom(subtype: &str, boundary: &str) -> Header<Self> {
+    /// Returns `Err` if `subtype` contains bytes that are invalid in an HTTP header
+    /// value (e.g. CR/LF) — the `subtype` is generally caller-controlled runtime input.
+    pub fn multipart_custom(
+        subtype: &str,
+        boundary: &str,
+    ) -> Result<Header<Self>, crate::error::Error> {
         let value = if boundary_needs_quoting(boundary) {
             format!("multipart/{subtype}; boundary=\"{boundary}\"")
         } else {
             format!("multipart/{subtype}; boundary={boundary}")
         };
         Self::from_bytes(value.as_bytes())
-            .expect("boundary should produce a valid Content-Type header value")
     }
 }
 
@@ -256,14 +262,21 @@ mod multipart_content_type_tests {
 
     #[test]
     fn byteranges_with_boundary() {
-        let h = ContentType::multipart_byteranges("abc");
+        let h = ContentType::multipart_byte_ranges("abc");
         assert_eq!(h.as_ref(), "multipart/byteranges; boundary=abc");
     }
 
     #[test]
     fn custom_subtype() {
-        let h = ContentType::multipart_custom("alternative", "abc");
+        let h = ContentType::multipart_custom("alternative", "abc").unwrap();
         assert_eq!(h.as_ref(), "multipart/alternative; boundary=abc");
+    }
+
+    #[test]
+    fn custom_subtype_rejects_invalid_header_bytes() {
+        // CR/LF in the subtype must surface as an error, not panic.
+        let err = ContentType::multipart_custom("evil\r\ninjected", "abc").unwrap_err();
+        assert!(!format!("{err}").is_empty());
     }
 
     #[test]

--- a/volga/src/headers/known_headers.rs
+++ b/volga/src/headers/known_headers.rs
@@ -58,6 +58,33 @@ impl ContentType {
     pub fn stream() -> Header<Self> {
         Self::from_static(APPLICATION_OCTET_STREAM.as_ref())
     }
+
+    /// Creates a `multipart/form-data; boundary=...` [`Header<ContentType>`].
+    #[inline]
+    pub fn multipart_form_data(boundary: &str) -> Header<Self> {
+        Self::multipart_custom("form-data", boundary)
+    }
+
+    /// Creates a `multipart/mixed; boundary=...` [`Header<ContentType>`].
+    #[inline]
+    pub fn multipart_mixed(boundary: &str) -> Header<Self> {
+        Self::multipart_custom("mixed", boundary)
+    }
+
+    /// Creates a `multipart/byteranges; boundary=...` [`Header<ContentType>`].
+    #[inline]
+    pub fn multipart_byteranges(boundary: &str) -> Header<Self> {
+        Self::multipart_custom("byteranges", boundary)
+    }
+
+    /// Creates a `multipart/<subtype>; boundary=...` [`Header<ContentType>`].
+    /// Boundary must already be RFC 2046 §5.1.1 compliant; use `Multipart::with_boundary`
+    /// for validation.
+    pub fn multipart_custom(subtype: &str, boundary: &str) -> Header<Self> {
+        let value = format!("multipart/{subtype}; boundary={boundary}");
+        Self::from_bytes(value.as_bytes())
+            .expect("boundary should produce a valid Content-Type header value")
+    }
 }
 
 impl CacheControl {
@@ -175,5 +202,34 @@ mod tests {
     #[test]
     fn it_creates_cache_control_private() {
         assert_header_value(CacheControl::private(), "private");
+    }
+}
+
+#[cfg(test)]
+mod multipart_content_type_tests {
+    use super::ContentType;
+
+    #[test]
+    fn form_data_with_boundary() {
+        let h = ContentType::multipart_form_data("X-BOUNDARY");
+        assert_eq!(h.as_ref(), "multipart/form-data; boundary=X-BOUNDARY");
+    }
+
+    #[test]
+    fn mixed_with_boundary() {
+        let h = ContentType::multipart_mixed("XYZ");
+        assert_eq!(h.as_ref(), "multipart/mixed; boundary=XYZ");
+    }
+
+    #[test]
+    fn byteranges_with_boundary() {
+        let h = ContentType::multipart_byteranges("abc");
+        assert_eq!(h.as_ref(), "multipart/byteranges; boundary=abc");
+    }
+
+    #[test]
+    fn custom_subtype() {
+        let h = ContentType::multipart_custom("alternative", "abc");
+        assert_eq!(h.as_ref(), "multipart/alternative; boundary=abc");
     }
 }

--- a/volga/src/headers/known_headers.rs
+++ b/volga/src/headers/known_headers.rs
@@ -79,12 +79,45 @@ impl ContentType {
 
     /// Creates a `multipart/<subtype>; boundary=...` [`Header<ContentType>`].
     /// Boundary must already be RFC 2046 §5.1.1 compliant; use `Multipart::with_boundary`
-    /// for validation.
+    /// for validation. RFC 2045 tspecials in the boundary (e.g. `:` or space) trigger
+    /// quoting of the parameter value so downstream parsers can extract it.
     pub fn multipart_custom(subtype: &str, boundary: &str) -> Header<Self> {
-        let value = format!("multipart/{subtype}; boundary={boundary}");
+        let value = if boundary_needs_quoting(boundary) {
+            format!("multipart/{subtype}; boundary=\"{boundary}\"")
+        } else {
+            format!("multipart/{subtype}; boundary={boundary}")
+        };
         Self::from_bytes(value.as_bytes())
             .expect("boundary should produce a valid Content-Type header value")
     }
+}
+
+/// Returns `true` if `value` contains any RFC 2045 tspecial or whitespace and must
+/// therefore be wrapped in `"..."` when used as a Content-Type parameter value.
+/// The validated boundary alphabet excludes `"` and `\`, so simple wrapping is safe.
+#[inline]
+fn boundary_needs_quoting(value: &str) -> bool {
+    value.bytes().any(|b| {
+        matches!(
+            b,
+            b' ' | b'\t'
+                | b'('
+                | b')'
+                | b'<'
+                | b'>'
+                | b'@'
+                | b','
+                | b';'
+                | b':'
+                | b'\\'
+                | b'"'
+                | b'/'
+                | b'['
+                | b']'
+                | b'?'
+                | b'='
+        )
+    })
 }
 
 impl CacheControl {
@@ -231,5 +264,24 @@ mod multipart_content_type_tests {
     fn custom_subtype() {
         let h = ContentType::multipart_custom("alternative", "abc");
         assert_eq!(h.as_ref(), "multipart/alternative; boundary=abc");
+    }
+
+    #[test]
+    fn boundary_with_tspecials_is_quoted() {
+        // ':' is a tspecial — must be wrapped in quotes per RFC 2045.
+        let h = ContentType::multipart_form_data("a:b");
+        assert_eq!(h.as_ref(), "multipart/form-data; boundary=\"a:b\"");
+    }
+
+    #[test]
+    fn boundary_with_internal_space_is_quoted() {
+        let h = ContentType::multipart_form_data("with space");
+        assert_eq!(h.as_ref(), "multipart/form-data; boundary=\"with space\"");
+    }
+
+    #[test]
+    fn plain_token_boundary_remains_unquoted() {
+        let h = ContentType::multipart_form_data("plain-token_42");
+        assert_eq!(h.as_ref(), "multipart/form-data; boundary=plain-token_42");
     }
 }

--- a/volga/src/http/endpoints/args/multipart.rs
+++ b/volga/src/http/endpoints/args/multipart.rs
@@ -1,21 +1,25 @@
-//! Extractors for multipart/form data
+//! Extractors and response types for multipart data.
+
+pub use field::Field;
+pub use part::{Part, PartBody};
 
 use crate::error::Error;
 use crate::headers::{CONTENT_TYPE, HeaderMap};
-use bytes::Bytes;
+use error::MultipartError;
 use futures_util::future::{Ready, ready};
-use tokio::io::{AsyncWriteExt, BufWriter};
 
-use std::{
-    ops::{Deref, DerefMut},
-    path::Path,
-};
+use std::{borrow::Cow, path::Path, sync::Arc};
 
 use crate::http::endpoints::args::{FromPayload, Payload, Source};
 
-/// Describes multipart file/form data
+mod encoder;
+mod error;
+mod field;
+mod part;
+
+/// Multipart content — extractor on the request side, response on the outgoing side.
 ///
-/// # Example
+/// # Inbound (extractor)
 /// ```no_run
 /// use volga::{HttpResult, Multipart, ok};
 ///
@@ -24,120 +28,85 @@ use crate::http::endpoints::args::{FromPayload, Payload, Source};
 ///     ok!("Files saved!")
 /// }
 /// ```
-#[derive(Debug)]
-pub struct Multipart(multer::Multipart<'static>);
-
-/// Represents a single field in a multipart stream
 ///
-///> See also [`multer::Field`]
-#[derive(Debug)]
-pub struct Field(multer::Field<'static>);
+/// # Outbound (response)
+/// ```no_run
+/// use volga::{HttpResult, Multipart};
+/// use volga::multipart::Part;
+///
+/// async fn handle() -> HttpResult {
+///     Multipart::from_parts(vec![
+///         Part::text("greeting", "hi"),
+///         Part::file("logo", "logo.png", b"...image bytes...".to_vec()),
+///     ])
+/// }
+/// ```
+pub struct Multipart {
+    inner: MultipartInner,
+}
 
-impl Field {
-    /// Tries to read a file name, if it's not present tries to read a field name, otherwise returns [`Error`]
-    #[inline]
-    pub fn try_get_file_name(&self) -> Result<&str, Error> {
-        self.0
-            .file_name()
-            .or(self.name())
-            .ok_or(MultipartError::missing_file_name())
-    }
-
-    /// Get the full field data as text.
-    ///
-    ///> See also [`multer::Field::text`]
-    #[inline]
-    pub async fn text(self) -> Result<String, Error> {
-        self.0.text().await.map_err(MultipartError::read_error)
-    }
-
-    /// Stream a chunk of the field data.
-    ///
-    /// When the field data has been exhausted, this will return [`None`].
-    ///
-    ///> See also [`multer::Field::chunk`]
-    #[inline]
-    pub async fn chunk(&mut self) -> Result<Option<Bytes>, Error> {
-        self.0.chunk().await.map_err(MultipartError::read_error)
-    }
-
-    /// Asynchronously writes a multipart field as a file stream to disk with a name taken from `CONTENT_DISPOSITION` header
-    ///
-    /// # Example
-    /// ```no_run
-    /// use volga::{HttpResult, Multipart, ok};
-    ///
-    /// async fn handle(mut files: Multipart) -> HttpResult {
-    ///     while let Some(field) = files.next_field().await? {
-    ///         field.save("path/to/folder").await?;
-    ///     }        
-    ///     ok!("File saved!")
-    /// }
-    /// ```
-    #[inline]
-    pub async fn save(self, path: impl AsRef<Path>) -> Result<(), std::io::Error> {
-        let file_name = self.try_get_file_name()?;
-        let file_path = path.as_ref().join(file_name);
-
-        self.save_as(file_path).await
-    }
-
-    /// Asynchronously writes a multipart field as a file stream to disk with a provided name in `file_path`
-    ///
-    /// # Example
-    /// ```no_run
-    /// use volga::{HttpResult, Multipart, ok};
-    /// use std::path::Path;
-    ///
-    /// async fn handle(mut files: Multipart) -> HttpResult {
-    ///     let path = Path::new("path/to/folder");
-    ///     let mut counter = 0;
-    ///     while let Some(field) = files.next_field().await? {
-    ///         field.save_as(path.join(format!("file_{counter}.dat"))).await?;
-    ///         counter += 1;
-    ///     }        
-    ///     ok!("File saved!")
-    /// }
-    /// ```
-    #[inline]
-    pub async fn save_as(mut self, path: impl AsRef<Path>) -> Result<(), std::io::Error> {
-        let file = tokio::fs::File::create(path).await?;
-        let mut writer = BufWriter::new(file);
-        while let Some(ref chunk) = self.chunk().await? {
-            writer.write_all(chunk).await?
+impl std::fmt::Debug for Multipart {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.inner {
+            MultipartInner::Incoming { boundary, .. } => f
+                .debug_struct("Multipart::Incoming")
+                .field("boundary", boundary)
+                .finish_non_exhaustive(),
+            MultipartInner::Outgoing {
+                subtype, boundary, ..
+            } => f
+                .debug_struct("Multipart::Outgoing")
+                .field("subtype", subtype)
+                .field("boundary", boundary)
+                .finish_non_exhaustive(),
         }
-        writer.flush().await
     }
 }
 
-impl Deref for Field {
-    type Target = multer::Field<'static>;
-
-    #[inline]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
+// `Incoming.boundary` is a `String` because `multer::Multipart` requires `impl Into<String>`
+// at construction; `Outgoing.boundary` is `Arc<str>` so it can be cheaply shared with the
+// streaming encoder. Asymmetry is intentional.
+pub(crate) enum MultipartInner {
+    Incoming {
+        boundary: String,
+        multipart: multer::Multipart<'static>,
+    },
+    Outgoing {
+        subtype: MultipartSubtype,
+        boundary: Arc<str>,
+        #[allow(dead_code)]
+        parts: futures_util::stream::BoxStream<'static, Part>,
+    },
 }
 
-impl DerefMut for Field {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+/// RFC 2046 multipart subtype. Defaults to `FormData` for outbound.
+#[derive(Debug, Clone)]
+pub enum MultipartSubtype {
+    /// `multipart/form-data` — the canonical form / file upload subtype.
+    FormData,
+    /// `multipart/mixed` — heterogeneous parts.
+    Mixed,
+    /// `multipart/byteranges` — partial-content responses for HTTP `Range` requests.
+    ByteRanges,
+    /// Any other subtype, e.g. `alternative`, `related`.
+    Custom(Cow<'static, str>),
+}
+
+impl MultipartSubtype {
+    #[allow(dead_code)]
+    pub(crate) fn as_str(&self) -> &str {
+        match self {
+            Self::FormData => "form-data",
+            Self::Mixed => "mixed",
+            Self::ByteRanges => "byteranges",
+            Self::Custom(s) => s.as_ref(),
+        }
     }
 }
 
 impl Multipart {
-    /// Asynchronously writes a multipart files to disk
-    /// # Example
-    /// ```no_run
-    /// # use volga::{HttpResult, ok};
-    /// use volga::Multipart;
-    ///
-    /// # async fn handle(files: Multipart) -> HttpResult {
-    /// files.save_all("path/to/folder").await?;        
-    /// # ok!("File saved!")
-    /// # }
-    /// ```
+    /// Asynchronously writes incoming multipart files to disk.
+    /// Errors if called on an outgoing multipart.
     pub async fn save_all(mut self, path: impl AsRef<Path>) -> Result<(), Error> {
         while let Some(field) = self.next_field().await? {
             field.save(&path).await?;
@@ -145,14 +114,29 @@ impl Multipart {
         Ok(())
     }
 
-    /// Yields the next [`Field`] if available
+    /// Yields the next [`Field`] from an incoming multipart, or `None` when exhausted.
+    /// Errors with a descriptive message if called on an outgoing multipart.
     #[inline]
     pub async fn next_field(&mut self) -> Result<Option<Field>, Error> {
-        self.0
-            .next_field()
-            .await
-            .map_err(MultipartError::read_error)
-            .map(|field| field.map(Field))
+        match &mut self.inner {
+            MultipartInner::Incoming { multipart, .. } => multipart
+                .next_field()
+                .await
+                .map_err(MultipartError::read_error)
+                .map(|f| f.map(Field)),
+            MultipartInner::Outgoing { .. } => Err(Error::server_error(
+                "next_field called on an outgoing multipart",
+            )),
+        }
+    }
+
+    /// Returns the boundary string of this multipart.
+    #[inline]
+    pub fn boundary(&self) -> &str {
+        match &self.inner {
+            MultipartInner::Incoming { boundary, .. } => boundary,
+            MultipartInner::Outgoing { boundary, .. } => boundary,
+        }
     }
 
     #[inline]
@@ -160,21 +144,124 @@ impl Multipart {
         let content_type = headers.get(CONTENT_TYPE)?.to_str().ok()?;
         multer::parse_boundary(content_type).ok()
     }
-}
 
-impl Deref for Multipart {
-    type Target = multer::Multipart<'static>;
+    /// Consumes self and returns the inner enum.
+    #[allow(dead_code)]
+    pub(crate) fn into_inner(self) -> MultipartInner {
+        self.inner
+    }
 
-    #[inline]
-    fn deref(&self) -> &Self::Target {
-        &self.0
+    /// Builds an outgoing form-data multipart from any iterator of [`Part`]s.
+    /// Default subtype is [`MultipartSubtype::FormData`]; override via [`Multipart::with_subtype`].
+    /// Boundary is auto-generated.
+    pub fn from_parts<I>(parts: I) -> Self
+    where
+        I: IntoIterator<Item = Part>,
+        I::IntoIter: Send + 'static,
+    {
+        Self::from_stream(futures_util::stream::iter(parts))
+    }
+
+    /// Builds an outgoing multipart from a streaming source of [`Part`]s — useful when
+    /// parts are produced lazily (e.g. enumerating files, computing byte ranges).
+    pub fn from_stream<S>(parts: S) -> Self
+    where
+        S: futures_util::Stream<Item = Part> + Send + 'static,
+    {
+        Self {
+            inner: MultipartInner::Outgoing {
+                subtype: MultipartSubtype::FormData,
+                boundary: encoder::generate_boundary(),
+                parts: Box::pin(parts),
+            },
+        }
+    }
+
+    /// Overrides the multipart subtype (defaults to [`MultipartSubtype::FormData`]).
+    /// No-op on incoming multiparts.
+    pub fn with_subtype(mut self, new_subtype: MultipartSubtype) -> Self {
+        if let MultipartInner::Outgoing {
+            ref mut subtype, ..
+        } = self.inner
+        {
+            *subtype = new_subtype;
+        }
+        self
+    }
+
+    /// Returns the canonical Content-Type header for this outgoing multipart.
+    /// Returns `None` for incoming multiparts.
+    pub(crate) fn content_type_header(
+        &self,
+    ) -> Option<crate::headers::Header<crate::headers::ContentType>> {
+        let MultipartInner::Outgoing {
+            subtype, boundary, ..
+        } = &self.inner
+        else {
+            return None;
+        };
+        use crate::headers::ContentType;
+        Some(match subtype {
+            MultipartSubtype::FormData => ContentType::multipart_form_data(boundary),
+            MultipartSubtype::Mixed => ContentType::multipart_mixed(boundary),
+            MultipartSubtype::ByteRanges => ContentType::multipart_byteranges(boundary),
+            MultipartSubtype::Custom(s) => ContentType::multipart_custom(s, boundary),
+        })
+    }
+
+    /// Overrides the auto-generated boundary. Validates per RFC 2046 §5.1.1.
+    /// Errors if the boundary is malformed; no-op on incoming multiparts.
+    pub fn with_boundary(mut self, new_boundary: impl Into<Arc<str>>) -> Result<Self, Error> {
+        let new_boundary = new_boundary.into();
+        encoder::validate_boundary(&new_boundary)?;
+        if let MultipartInner::Outgoing {
+            ref mut boundary, ..
+        } = self.inner
+        {
+            *boundary = new_boundary;
+        }
+        Ok(self)
+    }
+
+    /// Re-encodes an incoming multipart as an outgoing one, lazily streaming each
+    /// field as a [`Part`] with a streaming body. Useful for proxy / forwarding.
+    /// **Not byte-perfect** (boundary regenerates, header ordering may differ).
+    /// For byte-perfect passthrough, skip the [`Multipart`] extractor and forward
+    /// the raw [`HttpBody`](crate::http::body::HttpBody).
+    ///
+    /// Errors if called on an already-outgoing multipart.
+    pub fn into_outgoing(self) -> Result<Self, Error> {
+        let MultipartInner::Incoming {
+            boundary,
+            mut multipart,
+        } = self.inner
+        else {
+            return Err(Error::server_error(
+                "into_outgoing called on a multipart that is already outgoing",
+            ));
+        };
+
+        let boundary: Arc<str> = Arc::from(boundary);
+        let parts_stream = async_stream::stream! {
+            while let Ok(Some(field)) = multipart.next_field().await {
+                yield field_to_part(field);
+            }
+        };
+
+        Ok(Self {
+            inner: MultipartInner::Outgoing {
+                subtype: MultipartSubtype::FormData,
+                boundary,
+                parts: Box::pin(parts_stream),
+            },
+        })
     }
 }
 
-impl DerefMut for Multipart {
+impl From<Vec<Part>> for Multipart {
     #[inline]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+    fn from(parts: Vec<Part>) -> Self {
+        Self::from_parts(parts)
     }
 }
 
@@ -184,23 +271,24 @@ impl<'a> TryFrom<Payload<'a>> for Multipart {
     #[inline]
     fn try_from(payload: Payload<'a>) -> Result<Self, Self::Error> {
         let Payload::Full(parts, body) = payload else {
-            unreachable!()
+            unreachable!("Multipart requires Payload::Full; SOURCE = Source::Full enforces this");
         };
-
         let boundary =
             Self::parse_boundary(&parts.headers).ok_or(MultipartError::invalid_boundary())?;
-
         let stream = body.into_data_stream();
-        let multipart = multer::Multipart::new(stream, boundary);
-
-        Ok(Multipart(multipart))
+        let multipart = multer::Multipart::new(stream, boundary.clone());
+        Ok(Multipart {
+            inner: MultipartInner::Incoming {
+                boundary,
+                multipart,
+            },
+        })
     }
 }
 
 /// Extracts a file stream from the request body
 impl FromPayload for Multipart {
     type Future = Ready<Result<Self, Error>>;
-
     const SOURCE: Source = Source::Full;
 
     #[inline]
@@ -216,22 +304,43 @@ impl FromPayload for Multipart {
     }
 }
 
-struct MultipartError;
-impl MultipartError {
-    #[inline]
-    fn invalid_boundary() -> Error {
-        Error::client_error("Multipart error: invalid boundary")
-    }
+/// Converts a single [`multer::Field`] into a [`Part`] whose body is a stream that
+/// drains chunks lazily from the field. No buffering.
+fn field_to_part(mut field: multer::Field<'static>) -> Part {
+    use crate::headers::{ContentType, Header};
 
-    #[inline]
-    fn missing_file_name() -> Error {
-        Error::client_error("Multipart error: file name is missing")
-    }
+    let name = field.name().unwrap_or("").to_owned();
+    let filename = field.file_name().map(|s| s.to_owned());
+    let content_type_header = field.content_type().map(|m| {
+        Header::<ContentType>::from_bytes(m.essence_str().as_bytes())
+            .unwrap_or_else(|_| ContentType::stream())
+    });
 
-    #[inline]
-    fn read_error(error: multer::Error) -> Error {
-        Error::client_error(format!("Multipart error: {error}"))
+    let body_stream = async_stream::try_stream! {
+        while let Some(chunk) = field
+            .chunk()
+            .await
+            .map_err(|e| Error::client_error(format!("multipart read: {e}")))?
+        {
+            yield chunk;
+        }
+    };
+    let body = PartBody::Stream(Box::pin(body_stream));
+
+    let mut part = Part::new(body).with_disposition(&name, filename.as_deref());
+    if let Some(ct) = content_type_header {
+        part = part.with_content_type(ct);
     }
+    part
+}
+
+/// Encodes an outgoing parts stream into an HTTP body. Wraps `encoder::encode`
+/// so the encoder module stays `pub(super)`.
+pub(crate) fn encode_for_response(
+    boundary: Arc<str>,
+    parts: futures_util::stream::BoxStream<'static, Part>,
+) -> crate::http::body::HttpBody {
+    encoder::encode(boundary, parts)
 }
 
 #[cfg(test)]
@@ -276,5 +385,163 @@ mod tests {
             .header(CONTENT_TYPE, "multipart/form-data; boundary=X-BOUNDARY")
             .body(HttpBody::full(data))
             .unwrap()
+    }
+
+    use super::{MultipartInner, MultipartSubtype, Part};
+
+    #[tokio::test]
+    async fn from_parts_vec() {
+        let mp = Multipart::from_parts(vec![Part::text("a", "1"), Part::text("b", "2")]);
+        assert!(matches!(mp.inner, MultipartInner::Outgoing { .. }));
+        assert!(mp.boundary().starts_with("volga-"));
+    }
+
+    #[tokio::test]
+    async fn from_parts_array() {
+        let _mp = Multipart::from_parts([Part::text("a", "1"), Part::text("b", "2")]);
+    }
+
+    #[tokio::test]
+    async fn from_vec_via_into() {
+        let mp: Multipart = vec![Part::text("a", "1")].into();
+        assert!(matches!(mp.inner, MultipartInner::Outgoing { .. }));
+    }
+
+    #[tokio::test]
+    async fn from_stream_works() {
+        use futures_util::stream;
+        let mp = Multipart::from_stream(stream::iter(vec![Part::text("a", "1")]));
+        assert!(matches!(mp.inner, MultipartInner::Outgoing { .. }));
+    }
+
+    #[tokio::test]
+    async fn with_subtype_changes_subtype() {
+        let mp = Multipart::from_parts(vec![Part::text("a", "1")])
+            .with_subtype(MultipartSubtype::ByteRanges);
+        if let MultipartInner::Outgoing { subtype, .. } = mp.inner {
+            assert!(matches!(subtype, MultipartSubtype::ByteRanges));
+        } else {
+            panic!("expected Outgoing");
+        }
+    }
+
+    #[tokio::test]
+    async fn with_boundary_validates() {
+        let mp = Multipart::from_parts(vec![Part::text("a", "1")]);
+        assert!(mp.with_boundary("good-boundary").is_ok());
+
+        let mp = Multipart::from_parts(vec![Part::text("a", "1")]);
+        assert!(mp.with_boundary("bad\nboundary").is_err());
+    }
+
+    #[tokio::test]
+    async fn with_boundary_overrides() {
+        let mp = Multipart::from_parts(vec![Part::text("a", "1")])
+            .with_boundary("custom")
+            .unwrap();
+        assert_eq!(mp.boundary(), "custom");
+    }
+
+    #[tokio::test]
+    async fn next_field_on_outgoing_returns_error() {
+        let mut mp = Multipart::from_parts(vec![Part::text("a", "1")]);
+        let err = mp.next_field().await.unwrap_err();
+        assert!(format!("{err}").contains("outgoing"));
+    }
+
+    #[tokio::test]
+    async fn into_response_outgoing_yields_correct_content_type() {
+        use crate::http::IntoResponse;
+        let mp = Multipart::from_parts(vec![Part::text("a", "1")])
+            .with_boundary("X-BDY")
+            .unwrap();
+        let resp = mp.into_response().unwrap();
+        let ct = resp
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert_eq!(ct, "multipart/form-data; boundary=X-BDY");
+    }
+
+    #[tokio::test]
+    async fn into_response_byteranges_subtype() {
+        use crate::http::IntoResponse;
+        let mp = Multipart::from_parts(vec![Part::new(b"abc" as &[u8])])
+            .with_subtype(MultipartSubtype::ByteRanges)
+            .with_boundary("R")
+            .unwrap();
+        let resp = mp.into_response().unwrap();
+        let ct = resp
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert_eq!(ct, "multipart/byteranges; boundary=R");
+    }
+
+    #[tokio::test]
+    async fn into_response_incoming_returns_error() {
+        use crate::http::IntoResponse;
+        // Build an incoming Multipart through the extractor path
+        let req = create_multipart_req();
+        let (parts, body) = req.into_parts();
+        let mp = Multipart::from_payload(Payload::Full(&parts, body))
+            .await
+            .unwrap();
+        let err = mp.into_response().unwrap_err();
+        assert!(format!("{err}").contains("incoming"));
+    }
+
+    #[tokio::test]
+    async fn into_outgoing_round_trips_through_multer() {
+        use crate::http::IntoResponse;
+        use http_body_util::BodyExt;
+
+        // 1. Build an incoming multipart from a known wire string
+        let req = create_multipart_req();
+        let (parts, body) = req.into_parts();
+        let mp = Multipart::from_payload(Payload::Full(&parts, body))
+            .await
+            .unwrap();
+
+        // 2. Convert to outgoing and encode
+        let out = mp.into_outgoing().unwrap();
+        let resp = out.into_response().unwrap();
+
+        // 3. Read out the encoded body
+        let ct = resp
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_owned();
+        let bytes = resp
+            .into_inner()
+            .into_body()
+            .collect()
+            .await
+            .unwrap()
+            .to_bytes();
+
+        // 4. Re-parse it with multer and assert the original field is preserved
+        let boundary = multer::parse_boundary(&ct).unwrap();
+        let mut mp2 = multer::Multipart::new(
+            futures_util::stream::iter(vec![Ok::<_, std::io::Error>(bytes)]),
+            boundary,
+        );
+        let f = mp2.next_field().await.unwrap().unwrap();
+        assert_eq!(f.name(), Some("my_text_field"));
+        assert_eq!(f.text().await.unwrap(), "abcd");
+    }
+
+    #[tokio::test]
+    async fn into_outgoing_on_already_outgoing_returns_error() {
+        let mp = Multipart::from_parts(vec![Part::text("a", "1")]);
+        let err = mp.into_outgoing().unwrap_err();
+        assert!(format!("{err}").contains("already"));
     }
 }

--- a/volga/src/http/endpoints/args/multipart.rs
+++ b/volga/src/http/endpoints/args/multipart.rs
@@ -31,10 +31,10 @@ mod part;
 ///
 /// # Outbound (response)
 /// ```no_run
-/// use volga::{HttpResult, Multipart};
+/// use volga::Multipart;
 /// use volga::multipart::Part;
 ///
-/// async fn handle() -> HttpResult {
+/// async fn handle() -> Multipart {
 ///     Multipart::from_parts(vec![
 ///         Part::text("greeting", "hi"),
 ///         Part::file("logo", "logo.png", b"...image bytes...".to_vec()),

--- a/volga/src/http/endpoints/args/multipart.rs
+++ b/volga/src/http/endpoints/args/multipart.rs
@@ -75,7 +75,7 @@ pub(crate) enum MultipartInner {
         subtype: MultipartSubtype,
         boundary: Arc<str>,
         #[allow(dead_code)]
-        parts: futures_util::stream::BoxStream<'static, Part>,
+        parts: futures_util::stream::BoxStream<'static, Result<Part, Error>>,
     },
 }
 
@@ -168,11 +168,12 @@ impl Multipart {
     where
         S: futures_util::Stream<Item = Part> + Send + 'static,
     {
+        use futures_util::StreamExt;
         Self {
             inner: MultipartInner::Outgoing {
                 subtype: MultipartSubtype::FormData,
                 boundary: encoder::generate_boundary(),
-                parts: Box::pin(parts),
+                parts: parts.map(Ok).boxed(),
             },
         }
     }
@@ -242,8 +243,12 @@ impl Multipart {
         };
 
         let boundary: Arc<str> = Arc::from(boundary);
-        let parts_stream = async_stream::stream! {
-            while let Ok(Some(field)) = multipart.next_field().await {
+        let parts_stream = async_stream::try_stream! {
+            while let Some(field) = multipart
+                .next_field()
+                .await
+                .map_err(MultipartError::read_error)?
+            {
                 yield field_to_part(field);
             }
         };
@@ -338,7 +343,7 @@ fn field_to_part(mut field: multer::Field<'static>) -> Part {
 /// so the encoder module stays `pub(super)`.
 pub(crate) fn encode_for_response(
     boundary: Arc<str>,
-    parts: futures_util::stream::BoxStream<'static, Part>,
+    parts: futures_util::stream::BoxStream<'static, Result<Part, Error>>,
 ) -> crate::http::body::HttpBody {
     encoder::encode(boundary, parts)
 }
@@ -543,5 +548,31 @@ mod tests {
         let mp = Multipart::from_parts(vec![Part::text("a", "1")]);
         let err = mp.into_outgoing().unwrap_err();
         assert!(format!("{err}").contains("already"));
+    }
+
+    #[tokio::test]
+    async fn into_outgoing_propagates_parse_error() {
+        use crate::http::IntoResponse;
+        use http_body_util::BodyExt;
+
+        // Truncated payload: opening boundary + headers but no closing boundary.
+        // multer should surface this as a parse error mid-stream.
+        let truncated =
+            "--X-BOUNDARY\r\nContent-Disposition: form-data; name=\"f\"\r\n\r\npartial-data";
+        let req = Request::get("/")
+            .header(CONTENT_TYPE, "multipart/form-data; boundary=X-BOUNDARY")
+            .body(HttpBody::full(truncated))
+            .unwrap();
+        let (parts, body) = req.into_parts();
+        let mp = Multipart::from_payload(Payload::Full(&parts, body))
+            .await
+            .unwrap();
+
+        let resp = mp.into_outgoing().unwrap().into_response().unwrap();
+        let result = resp.into_inner().into_body().collect().await;
+        assert!(
+            result.is_err(),
+            "expected body stream to error on truncated multipart"
+        );
     }
 }

--- a/volga/src/http/endpoints/args/multipart.rs
+++ b/volga/src/http/endpoints/args/multipart.rs
@@ -399,18 +399,14 @@ mod tests {
 
     #[tokio::test]
     async fn from_parts_vec() {
-        let mp = Multipart::from_parts(vec![
-            Part::text("a", "1"),
-            Part::text("b", "2"),
-        ]);
+        let mp = Multipart::from_parts(vec![Part::text("a", "1"), Part::text("b", "2")]);
         assert!(matches!(mp.inner, MultipartInner::Outgoing { .. }));
         assert!(mp.boundary().starts_with("volga-"));
     }
 
     #[tokio::test]
     async fn from_parts_array() {
-        let _mp =
-            Multipart::from_parts([Part::text("a", "1"), Part::text("b", "2")]);
+        let _mp = Multipart::from_parts([Part::text("a", "1"), Part::text("b", "2")]);
     }
 
     #[tokio::test]

--- a/volga/src/http/endpoints/args/multipart.rs
+++ b/volga/src/http/endpoints/args/multipart.rs
@@ -192,22 +192,25 @@ impl Multipart {
     }
 
     /// Returns the canonical Content-Type header for this outgoing multipart.
-    /// Returns `None` for incoming multiparts.
+    /// Returns `Err` for incoming multiparts (with a server-side error explaining the misuse)
+    /// or when the subtype contains bytes invalid in an HTTP header value.
     pub(crate) fn content_type_header(
         &self,
-    ) -> Option<crate::headers::Header<crate::headers::ContentType>> {
+    ) -> Result<crate::headers::Header<crate::headers::ContentType>, Error> {
         let MultipartInner::Outgoing {
             subtype, boundary, ..
         } = &self.inner
         else {
-            return None;
+            return Err(Error::server_error(
+                "cannot return incoming multipart as response; call into_outgoing() first",
+            ));
         };
         use crate::headers::ContentType;
-        Some(match subtype {
+        Ok(match subtype {
             MultipartSubtype::FormData => ContentType::multipart_form_data(boundary),
             MultipartSubtype::Mixed => ContentType::multipart_mixed(boundary),
-            MultipartSubtype::ByteRanges => ContentType::multipart_byteranges(boundary),
-            MultipartSubtype::Custom(s) => ContentType::multipart_custom(s, boundary),
+            MultipartSubtype::ByteRanges => ContentType::multipart_byte_ranges(boundary),
+            MultipartSubtype::Custom(s) => ContentType::multipart_custom(s, boundary)?,
         })
     }
 

--- a/volga/src/http/endpoints/args/multipart.rs
+++ b/volga/src/http/endpoints/args/multipart.rs
@@ -69,6 +69,7 @@ impl std::fmt::Debug for Multipart {
 // streaming encoder. Asymmetry is intentional.
 pub(crate) enum MultipartInner {
     Incoming {
+        subtype: MultipartSubtype,
         boundary: String,
         multipart: multer::Multipart<'static>,
     },
@@ -101,6 +102,20 @@ impl MultipartSubtype {
             Self::Mixed => "mixed",
             Self::ByteRanges => "byteranges",
             Self::Custom(s) => s.as_ref(),
+        }
+    }
+
+    /// Parses the subtype from a `multipart/<subtype>[; ...]` Content-Type header value.
+    /// Falls back to [`Self::FormData`] if the value is malformed (caller has already
+    /// confirmed a boundary exists, so the value is structurally a multipart Content-Type).
+    fn from_content_type(value: &str) -> Self {
+        let after_slash = value.split_once('/').map(|(_, rest)| rest).unwrap_or("");
+        let token = after_slash.split(';').next().unwrap_or("").trim();
+        match token {
+            "" | "form-data" => Self::FormData,
+            "mixed" => Self::Mixed,
+            "byteranges" => Self::ByteRanges,
+            other => Self::Custom(Cow::Owned(other.to_owned())),
         }
     }
 }
@@ -141,9 +156,38 @@ impl Multipart {
     }
 
     #[inline]
+    /// Extracts the `boundary` parameter from a `multipart/*` Content-Type header.
+    /// Subtype-agnostic — accepts any `multipart/<subtype>`, not just form-data —
+    /// because volga supports forwarding `byteranges`, `mixed`, etc.
     fn parse_boundary(headers: &HeaderMap) -> Option<String> {
         let content_type = headers.get(CONTENT_TYPE)?.to_str().ok()?;
-        multer::parse_boundary(content_type).ok()
+        let lower = content_type.to_ascii_lowercase();
+        if !lower.trim_start().starts_with("multipart/") {
+            return None;
+        }
+        let idx = lower.find("boundary=")?;
+        let raw = content_type[idx + "boundary=".len()..].trim_start();
+        let boundary = if let Some(rest) = raw.strip_prefix('"') {
+            rest.split_once('"').map(|(b, _)| b)?
+        } else {
+            raw.split(|c: char| c == ';' || c.is_whitespace())
+                .next()
+                .filter(|s| !s.is_empty())?
+        };
+        if boundary.is_empty() {
+            None
+        } else {
+            Some(boundary.to_string())
+        }
+    }
+
+    #[inline]
+    fn parse_subtype(headers: &HeaderMap) -> MultipartSubtype {
+        headers
+            .get(CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .map(MultipartSubtype::from_content_type)
+            .unwrap_or(MultipartSubtype::FormData)
     }
 
     /// Consumes self and returns the inner enum.
@@ -237,6 +281,7 @@ impl Multipart {
     /// Errors if called on an already-outgoing multipart.
     pub fn into_outgoing(self) -> Result<Self, Error> {
         let MultipartInner::Incoming {
+            subtype,
             boundary,
             mut multipart,
         } = self.inner
@@ -253,13 +298,13 @@ impl Multipart {
                 .await
                 .map_err(MultipartError::read_error)?
             {
-                yield field_to_part(field)?;
+                yield field_to_part(field);
             }
         };
 
         Ok(Self {
             inner: MultipartInner::Outgoing {
-                subtype: MultipartSubtype::FormData,
+                subtype,
                 boundary,
                 parts: Box::pin(parts_stream),
             },
@@ -284,10 +329,12 @@ impl<'a> TryFrom<Payload<'a>> for Multipart {
         };
         let boundary =
             Self::parse_boundary(&parts.headers).ok_or(MultipartError::invalid_boundary())?;
+        let subtype = Self::parse_subtype(&parts.headers);
         let stream = body.into_data_stream();
         let multipart = multer::Multipart::new(stream, boundary.clone());
         Ok(Multipart {
             inner: MultipartInner::Incoming {
+                subtype,
                 boundary,
                 multipart,
             },
@@ -315,17 +362,15 @@ impl FromPayload for Multipart {
 
 /// Converts a single [`multer::Field`] into a [`Part`] whose body is a stream that
 /// drains chunks lazily from the field. No buffering.
-/// Errors if the field's name or filename produces an invalid `Content-Disposition`
-/// header value (e.g. CR/LF in upstream-supplied bytes).
-fn field_to_part(mut field: multer::Field<'static>) -> Result<Part, Error> {
-    use crate::headers::{ContentType, Header};
+///
+/// Forwards every per-part header verbatim — `Content-Type`, `Content-Disposition`
+/// (preserving `filename*` and other parameters), `Content-Range`, plus any custom
+/// header — so proxy / forwarding flows produce a semantically-equivalent body.
+fn field_to_part(mut field: multer::Field<'static>) -> Part {
+    use crate::headers::{ContentDisposition, ContentType, Header};
 
-    let name = field.name().unwrap_or("").to_owned();
-    let filename = field.file_name().map(|s| s.to_owned());
-    let content_type_header = field.content_type().map(|m| {
-        Header::<ContentType>::from_bytes(m.as_ref().as_bytes())
-            .unwrap_or_else(|_| ContentType::stream())
-    });
+    // Snapshot headers before `field.chunk()` takes a mutable borrow.
+    let headers = field.headers().clone();
 
     let body_stream = async_stream::try_stream! {
         while let Some(chunk) = field
@@ -336,13 +381,22 @@ fn field_to_part(mut field: multer::Field<'static>) -> Result<Part, Error> {
             yield chunk;
         }
     };
-    let body = PartBody::Stream(Box::pin(body_stream));
+    let mut part = Part::new(PartBody::Stream(Box::pin(body_stream)));
 
-    let mut part = Part::new(body).try_with_disposition(&name, filename.as_deref())?;
-    if let Some(ct) = content_type_header {
-        part = part.with_content_type(ct);
+    for (name, value) in headers.iter() {
+        if name == CONTENT_TYPE {
+            if let Ok(ct) = Header::<ContentType>::from_bytes(value.as_bytes()) {
+                part = part.with_content_type(ct);
+            }
+        } else if name == crate::headers::CONTENT_DISPOSITION {
+            if let Ok(cd) = Header::<ContentDisposition>::from_bytes(value.as_bytes()) {
+                part = part.with_disposition_raw(cd);
+            }
+        } else {
+            part = part.with_header_raw(name.clone(), value.clone());
+        }
     }
-    Ok(part)
+    part
 }
 
 /// Encodes an outgoing parts stream into an HTTP body. Wraps `encoder::encode`
@@ -592,6 +646,71 @@ mod tests {
             wire.contains("content-type: text/plain; charset=us-ascii"),
             "expected charset parameter to survive forwarding; got: {wire}\nresponse CT: {ct}"
         );
+    }
+
+    #[tokio::test]
+    async fn into_outgoing_preserves_incoming_subtype() {
+        // Inbound is multipart/byteranges; into_outgoing must keep that subtype on the
+        // response Content-Type instead of rewriting to multipart/form-data.
+        let body = "--BNDRY\r\nContent-Range: bytes 0-4/10\r\nContent-Type: text/plain\r\n\r\nfirst\r\n--BNDRY--\r\n";
+        let req = Request::get("/")
+            .header(CONTENT_TYPE, "multipart/byteranges; boundary=BNDRY")
+            .body(HttpBody::full(body))
+            .unwrap();
+        let (parts, body) = req.into_parts();
+        let mp = Multipart::from_payload(Payload::Full(&parts, body))
+            .await
+            .unwrap();
+
+        let outgoing = mp.into_outgoing().unwrap();
+        let ct = outgoing.content_type_header().unwrap();
+        let ct_str = ct.as_ref().to_str().unwrap();
+        assert!(
+            ct_str.starts_with("multipart/byteranges"),
+            "expected byteranges to survive forwarding, got: {ct_str}"
+        );
+    }
+
+    #[tokio::test]
+    async fn into_outgoing_forwards_per_part_headers() {
+        use crate::http::IntoResponse;
+        use http_body_util::BodyExt;
+
+        // Source part has Content-Range, a filename* parameter on Content-Disposition,
+        // and a custom header — none of which the form-data builder API would set.
+        // All must survive the proxy round-trip.
+        let body = "--BNDRY\r\n\
+            Content-Disposition: form-data; name=\"upload\"; filename=\"plain.txt\"; filename*=UTF-8''r%C3%A9sum%C3%A9.txt\r\n\
+            Content-Type: text/plain; charset=utf-8\r\n\
+            Content-Range: bytes 0-4/10\r\n\
+            X-Custom-Trace: trace-abc\r\n\
+            \r\n\
+            hello\r\n--BNDRY--\r\n";
+        let req = Request::get("/")
+            .header(CONTENT_TYPE, "multipart/form-data; boundary=BNDRY")
+            .body(HttpBody::full(body))
+            .unwrap();
+        let (parts, body) = req.into_parts();
+        let mp = Multipart::from_payload(Payload::Full(&parts, body))
+            .await
+            .unwrap();
+
+        let resp = mp.into_outgoing().unwrap().into_response().unwrap();
+        let bytes = resp
+            .into_inner()
+            .into_body()
+            .collect()
+            .await
+            .unwrap()
+            .to_bytes();
+        let wire = std::str::from_utf8(&bytes).unwrap();
+
+        assert!(
+            wire.contains("filename*=UTF-8''r%C3%A9sum%C3%A9.txt"),
+            "got: {wire}"
+        );
+        assert!(wire.contains("content-range: bytes 0-4/10"), "got: {wire}");
+        assert!(wire.contains("x-custom-trace: trace-abc"), "got: {wire}");
     }
 
     #[tokio::test]

--- a/volga/src/http/endpoints/args/multipart.rs
+++ b/volga/src/http/endpoints/args/multipart.rs
@@ -155,29 +155,35 @@ impl Multipart {
         }
     }
 
-    #[inline]
     /// Extracts the `boundary` parameter from a `multipart/*` Content-Type header.
     /// Subtype-agnostic — accepts any `multipart/<subtype>`, not just form-data —
     /// because volga supports forwarding `byteranges`, `mixed`, etc.
+    ///
+    /// Walks parameters as `(name, value)` pairs (RFC 7231 §3.1.1.1) so a quoted
+    /// value containing the substring `boundary=` (e.g. `foo="xboundary=y"`) does
+    /// not confuse the match — the parameter name lookup is structural, not textual.
     fn parse_boundary(headers: &HeaderMap) -> Option<String> {
         let content_type = headers.get(CONTENT_TYPE)?.to_str().ok()?;
-        let lower = content_type.to_ascii_lowercase();
-        if !lower.trim_start().starts_with("multipart/") {
+        let trimmed = content_type.trim_start();
+        let (ty, after_slash) = trimmed.split_once('/')?;
+        if !ty.eq_ignore_ascii_case("multipart") {
             return None;
         }
-        let idx = lower.find("boundary=")?;
-        let raw = content_type[idx + "boundary=".len()..].trim_start();
-        let boundary = if let Some(rest) = raw.strip_prefix('"') {
-            rest.split_once('"').map(|(b, _)| b)?
-        } else {
-            raw.split(|c: char| c == ';' || c.is_whitespace())
-                .next()
-                .filter(|s| !s.is_empty())?
-        };
-        if boundary.is_empty() {
-            None
-        } else {
-            Some(boundary.to_string())
+        // Skip the subtype to the first ';'; absent ';' means no parameters at all.
+        let mut rest = after_slash.split_once(';')?.1;
+        loop {
+            rest = trim_ows(rest);
+            if rest.is_empty() {
+                return None;
+            }
+            let (name, after_eq) = rest.split_once('=')?;
+            let name = name.trim();
+            let (value, tail) = parse_param_value(trim_ows(after_eq))?;
+            if name.eq_ignore_ascii_case("boundary") {
+                return if value.is_empty() { None } else { Some(value) };
+            }
+            // Advance past the trailing ';' (if any) to the next parameter.
+            rest = trim_ows(tail).strip_prefix(';')?;
         }
     }
 
@@ -366,6 +372,38 @@ impl FromPayload for Multipart {
 /// Forwards every per-part header verbatim — `Content-Type`, `Content-Disposition`
 /// (preserving `filename*` and other parameters), `Content-Range`, plus any custom
 /// header — so proxy / forwarding flows produce a semantically-equivalent body.
+/// Strips RFC 7230 OWS (optional whitespace: SP / HTAB) from the front of `s`.
+#[inline]
+fn trim_ows(s: &str) -> &str {
+    s.trim_start_matches([' ', '\t'])
+}
+
+/// Parses a Content-Type parameter value at the start of `s`. Handles either a
+/// `token` (consumed up to the next `;` or end) or a `quoted-string` per RFC 7230
+/// (with backslash-quoted-pair escapes). Returns the unquoted value and the
+/// remainder of the input after the value.
+fn parse_param_value(s: &str) -> Option<(String, &str)> {
+    if let Some(after_quote) = s.strip_prefix('"') {
+        let mut value = String::new();
+        let mut chars = after_quote.char_indices();
+        while let Some((idx, c)) = chars.next() {
+            match c {
+                '"' => return Some((value, &after_quote[idx + c.len_utf8()..])),
+                '\\' => match chars.next() {
+                    Some((_, esc)) => value.push(esc),
+                    None => return None,
+                },
+                other => value.push(other),
+            }
+        }
+        None
+    } else {
+        let end = s.find(';').unwrap_or(s.len());
+        let value = s[..end].trim_end_matches([' ', '\t']).to_owned();
+        Some((value, &s[end..]))
+    }
+}
+
 fn field_to_part(mut field: multer::Field<'static>) -> Part {
     use crate::headers::{ContentDisposition, ContentType, Header};
 
@@ -415,6 +453,53 @@ mod tests {
     use crate::http::body::HttpBody;
     use crate::http::endpoints::args::{FromPayload, Payload};
     use hyper::Request;
+
+    fn make_headers(content_type: &str) -> crate::headers::HeaderMap {
+        let mut h = crate::headers::HeaderMap::new();
+        h.insert(
+            CONTENT_TYPE,
+            crate::headers::HeaderValue::from_str(content_type).unwrap(),
+        );
+        h
+    }
+
+    #[test]
+    fn parse_boundary_simple_token() {
+        let h = make_headers("multipart/form-data; boundary=ABCDEF");
+        assert_eq!(Multipart::parse_boundary(&h).as_deref(), Some("ABCDEF"));
+    }
+
+    #[test]
+    fn parse_boundary_quoted_value() {
+        let h = make_headers(r#"multipart/form-data; boundary="with space""#);
+        assert_eq!(Multipart::parse_boundary(&h).as_deref(), Some("with space"));
+    }
+
+    #[test]
+    fn parse_boundary_skips_other_quoted_param_containing_boundary_substring() {
+        // Regression: substring scan would have matched the literal "boundary=" inside
+        // foo's quoted value. The structured parser must skip it and pick the real one.
+        let h = make_headers(r#"multipart/form-data; foo="xboundary=y"; boundary=real"#);
+        assert_eq!(Multipart::parse_boundary(&h).as_deref(), Some("real"));
+    }
+
+    #[test]
+    fn parse_boundary_case_insensitive_type_and_param_name() {
+        let h = make_headers("MULTIPART/Form-Data; BOUNDARY=ZZZ");
+        assert_eq!(Multipart::parse_boundary(&h).as_deref(), Some("ZZZ"));
+    }
+
+    #[test]
+    fn parse_boundary_rejects_non_multipart_type() {
+        let h = make_headers("text/plain; boundary=ZZZ");
+        assert_eq!(Multipart::parse_boundary(&h), None);
+    }
+
+    #[test]
+    fn parse_boundary_rejects_when_param_absent() {
+        let h = make_headers("multipart/form-data; charset=utf-8");
+        assert_eq!(Multipart::parse_boundary(&h), None);
+    }
 
     #[tokio::test]
     async fn it_reads_from_payload() {

--- a/volga/src/http/endpoints/args/multipart.rs
+++ b/volga/src/http/endpoints/args/multipart.rs
@@ -40,6 +40,7 @@ mod part;
 ///         Part::file("logo", "logo.png", b"...image bytes...".to_vec()),
 ///     ])
 /// }
+/// # let _ = handle;
 /// ```
 pub struct Multipart {
     inner: MultipartInner,
@@ -249,7 +250,7 @@ impl Multipart {
                 .await
                 .map_err(MultipartError::read_error)?
             {
-                yield field_to_part(field);
+                yield field_to_part(field)?;
             }
         };
 
@@ -311,13 +312,15 @@ impl FromPayload for Multipart {
 
 /// Converts a single [`multer::Field`] into a [`Part`] whose body is a stream that
 /// drains chunks lazily from the field. No buffering.
-fn field_to_part(mut field: multer::Field<'static>) -> Part {
+/// Errors if the field's name or filename produces an invalid `Content-Disposition`
+/// header value (e.g. CR/LF in upstream-supplied bytes).
+fn field_to_part(mut field: multer::Field<'static>) -> Result<Part, Error> {
     use crate::headers::{ContentType, Header};
 
     let name = field.name().unwrap_or("").to_owned();
     let filename = field.file_name().map(|s| s.to_owned());
     let content_type_header = field.content_type().map(|m| {
-        Header::<ContentType>::from_bytes(m.essence_str().as_bytes())
+        Header::<ContentType>::from_bytes(m.as_ref().as_bytes())
             .unwrap_or_else(|_| ContentType::stream())
     });
 
@@ -332,11 +335,11 @@ fn field_to_part(mut field: multer::Field<'static>) -> Part {
     };
     let body = PartBody::Stream(Box::pin(body_stream));
 
-    let mut part = Part::new(body).with_disposition(&name, filename.as_deref());
+    let mut part = Part::new(body).try_with_disposition(&name, filename.as_deref())?;
     if let Some(ct) = content_type_header {
         part = part.with_content_type(ct);
     }
-    part
+    Ok(part)
 }
 
 /// Encodes an outgoing parts stream into an HTTP body. Wraps `encoder::encode`
@@ -396,14 +399,18 @@ mod tests {
 
     #[tokio::test]
     async fn from_parts_vec() {
-        let mp = Multipart::from_parts(vec![Part::text("a", "1"), Part::text("b", "2")]);
+        let mp = Multipart::from_parts(vec![
+            Part::text("a", "1"),
+            Part::text("b", "2"),
+        ]);
         assert!(matches!(mp.inner, MultipartInner::Outgoing { .. }));
         assert!(mp.boundary().starts_with("volga-"));
     }
 
     #[tokio::test]
     async fn from_parts_array() {
-        let _mp = Multipart::from_parts([Part::text("a", "1"), Part::text("b", "2")]);
+        let _mp =
+            Multipart::from_parts([Part::text("a", "1"), Part::text("b", "2")]);
     }
 
     #[tokio::test]
@@ -548,6 +555,44 @@ mod tests {
         let mp = Multipart::from_parts(vec![Part::text("a", "1")]);
         let err = mp.into_outgoing().unwrap_err();
         assert!(format!("{err}").contains("already"));
+    }
+
+    #[tokio::test]
+    async fn into_outgoing_preserves_part_content_type_parameters() {
+        use crate::http::IntoResponse;
+        use http_body_util::BodyExt;
+
+        // An inbound part declares a Content-Type with a `charset` parameter.
+        let body = "--B\r\nContent-Disposition: form-data; name=\"f\"\r\nContent-Type: text/plain; charset=us-ascii\r\n\r\nhello\r\n--B--\r\n";
+        let req = Request::get("/")
+            .header(CONTENT_TYPE, "multipart/form-data; boundary=B")
+            .body(HttpBody::full(body))
+            .unwrap();
+        let (parts, body) = req.into_parts();
+        let mp = Multipart::from_payload(Payload::Full(&parts, body))
+            .await
+            .unwrap();
+
+        let resp = mp.into_outgoing().unwrap().into_response().unwrap();
+        let ct = resp
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_owned();
+        let bytes = resp
+            .into_inner()
+            .into_body()
+            .collect()
+            .await
+            .unwrap()
+            .to_bytes();
+        let wire = std::str::from_utf8(&bytes).unwrap();
+        assert!(
+            wire.contains("content-type: text/plain; charset=us-ascii"),
+            "expected charset parameter to survive forwarding; got: {wire}\nresponse CT: {ct}"
+        );
     }
 
     #[tokio::test]

--- a/volga/src/http/endpoints/args/multipart/encoder.rs
+++ b/volga/src/http/endpoints/args/multipart/encoder.rs
@@ -1,0 +1,351 @@
+//! Multipart response encoder — boundary helpers and streaming body builder.
+
+use crate::error::Error;
+use rand::RngExt;
+use std::sync::Arc;
+
+const BOUNDARY_PREFIX: &str = "volga-";
+const BOUNDARY_SUFFIX_LEN: usize = 32;
+const BOUNDARY_ALPHABET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+/// Generates a random RFC 2046 §5.1.1-compliant boundary in the form `volga-<32 alnum>`.
+pub(super) fn generate_boundary() -> Arc<str> {
+    let mut rng = rand::rng();
+    let mut s = String::with_capacity(BOUNDARY_PREFIX.len() + BOUNDARY_SUFFIX_LEN);
+    s.push_str(BOUNDARY_PREFIX);
+    for _ in 0..BOUNDARY_SUFFIX_LEN {
+        let i = rng.random_range(0..BOUNDARY_ALPHABET.len());
+        s.push(BOUNDARY_ALPHABET[i] as char);
+    }
+    Arc::from(s)
+}
+
+/// Validates a boundary string per RFC 2046 §5.1.1:
+/// - Length 1..=70
+/// - Each char is `bcharsnospace` (alnum + `'()+_,-./:=?`) or space
+/// - Last char is not a space
+pub(super) fn validate_boundary(s: &str) -> Result<(), Error> {
+    let bytes = s.as_bytes();
+    if bytes.is_empty() || bytes.len() > 70 {
+        return Err(Error::client_error(
+            "multipart boundary must be between 1 and 70 characters",
+        ));
+    }
+    for (i, &b) in bytes.iter().enumerate() {
+        let is_last = i == bytes.len() - 1;
+        let valid = if is_last {
+            is_bcharsnospace(b)
+        } else {
+            is_bcharsnospace(b) || b == b' '
+        };
+        if !valid {
+            return Err(Error::client_error(
+                "multipart boundary contains invalid characters",
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[inline]
+fn is_bcharsnospace(b: u8) -> bool {
+    matches!(
+        b,
+        b'0'..=b'9'
+            | b'A'..=b'Z'
+            | b'a'..=b'z'
+            | b'\''
+            | b'('
+            | b')'
+            | b'+'
+            | b'_'
+            | b','
+            | b'-'
+            | b'.'
+            | b'/'
+            | b':'
+            | b'='
+            | b'?'
+    )
+}
+
+use crate::headers::{HeaderName, HeaderValue};
+use crate::http::endpoints::args::multipart::Part;
+use bytes::Bytes;
+
+/// Writes `--<boundary>\r\n`.
+#[inline]
+pub(super) fn encode_boundary_open(boundary: &str) -> Bytes {
+    Bytes::from(format!("--{boundary}\r\n"))
+}
+
+/// Writes `--<boundary>--\r\n`.
+#[inline]
+pub(super) fn encode_boundary_close(boundary: &str) -> Bytes {
+    Bytes::from(format!("--{boundary}--\r\n"))
+}
+
+/// Encodes the per-part header block: Content-Type, Content-Disposition, then any extras.
+/// Returns a single allocation containing all `Name: Value\r\n` lines, ready to be yielded.
+#[inline]
+pub(super) fn encode_part_headers(part: &Part) -> Bytes {
+    let mut s = String::with_capacity(64);
+    if let Some(ct) = part.part_content_type() {
+        write_header(&mut s, &ct.name(), ct.value());
+    }
+    if let Some(cd) = part.part_content_disposition() {
+        write_header(&mut s, &cd.name(), cd.value());
+    }
+    if let Some(extras) = part.part_extras() {
+        for (name, value) in extras.iter() {
+            write_header(&mut s, name, value);
+        }
+    }
+    Bytes::from(s)
+}
+
+fn write_header(out: &mut String, name: &HeaderName, value: &HeaderValue) {
+    out.push_str(name.as_str());
+    out.push_str(": ");
+    match value.to_str() {
+        Ok(v) => out.push_str(v),
+        Err(_) => out.push_str("<binary>"),
+    }
+    out.push_str("\r\n");
+}
+
+use crate::http::body::HttpBody;
+use async_stream::try_stream;
+use futures_util::stream::{BoxStream, StreamExt};
+
+use super::part::PartBody;
+
+/// Encodes a stream of [`Part`]s into a multipart [`HttpBody`].
+///
+/// The output stream yields one or more [`Bytes`] chunks per part:
+/// boundary line, header block, separator CRLF, body (possibly chunked),
+/// trailing CRLF; followed by the closing boundary at the end.
+pub(super) fn encode(boundary: Arc<str>, mut parts: BoxStream<'static, Part>) -> HttpBody {
+    let stream = try_stream! {
+        while let Some(part) = parts.next().await {
+            yield encode_boundary_open(&boundary);
+            yield encode_part_headers(&part);
+            yield Bytes::from_static(b"\r\n");
+            match part.into_body() {
+                PartBody::Bytes(b) => {
+                    if !b.is_empty() {
+                        yield b;
+                    }
+                }
+                PartBody::Stream(mut s) => {
+                    while let Some(chunk) = s.next().await {
+                        yield chunk?;
+                    }
+                }
+            }
+            yield Bytes::from_static(b"\r\n");
+        }
+        yield encode_boundary_close(&boundary);
+    };
+    // `try_stream!` yields `Result<Bytes, Error>`; help the compiler resolve the error type.
+    let stream = stream.map(|r: Result<Bytes, Error>| r);
+    HttpBody::stream(stream)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{generate_boundary, validate_boundary};
+
+    #[test]
+    fn validate_accepts_simple_token() {
+        assert!(validate_boundary("X-BOUNDARY").is_ok());
+        assert!(validate_boundary("a").is_ok());
+        assert!(validate_boundary("0123456789").is_ok());
+    }
+
+    #[test]
+    fn validate_accepts_max_length_70() {
+        let s = "a".repeat(70);
+        assert!(validate_boundary(&s).is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_empty() {
+        assert!(validate_boundary("").is_err());
+    }
+
+    #[test]
+    fn validate_rejects_over_70_chars() {
+        let s = "a".repeat(71);
+        assert!(validate_boundary(&s).is_err());
+    }
+
+    #[test]
+    fn validate_rejects_invalid_char() {
+        assert!(validate_boundary("bad\nboundary").is_err());
+        assert!(validate_boundary("bad\tboundary").is_err());
+        assert!(validate_boundary("with;semicolon").is_err());
+    }
+
+    #[test]
+    fn validate_rejects_trailing_space() {
+        assert!(validate_boundary("ends-with-space ").is_err());
+    }
+
+    #[test]
+    fn validate_accepts_internal_space() {
+        assert!(validate_boundary("has space inside").is_ok());
+    }
+
+    #[test]
+    fn generate_format() {
+        let b = generate_boundary();
+        assert!(
+            b.starts_with("volga-"),
+            "boundary {b:?} should start with 'volga-'"
+        );
+        assert_eq!(b.len(), "volga-".len() + 32);
+        assert!(validate_boundary(&b).is_ok());
+    }
+
+    #[test]
+    fn generate_unique() {
+        let a = generate_boundary();
+        let b = generate_boundary();
+        assert_ne!(a, b, "two generated boundaries should not collide");
+    }
+
+    use super::{encode_boundary_close, encode_boundary_open, encode_part_headers};
+    use crate::headers::ContentType;
+    use crate::http::endpoints::args::multipart::Part;
+
+    #[test]
+    fn boundary_open_format() {
+        let b = encode_boundary_open("X");
+        assert_eq!(&b[..], b"--X\r\n");
+    }
+
+    #[test]
+    fn boundary_close_format() {
+        let b = encode_boundary_close("X");
+        assert_eq!(&b[..], b"--X--\r\n");
+    }
+
+    #[test]
+    fn part_headers_ct_then_cd() {
+        let p = Part::text("name", "v");
+        let bytes = encode_part_headers(&p);
+        let s = std::str::from_utf8(&bytes).unwrap();
+        assert!(
+            s.starts_with("content-type: text/plain; charset=utf-8\r\n"),
+            "headers: {s:?}"
+        );
+        assert!(s.contains("content-disposition: form-data; name=\"name\"\r\n"));
+    }
+
+    #[test]
+    fn part_headers_extras_appear_after_ct_cd() {
+        let p = Part::text("n", "v")
+            .with_content_type(ContentType::text_utf_8())
+            .with_header_raw(
+                crate::headers::HeaderName::from_static("x-custom"),
+                crate::headers::HeaderValue::from_static("y"),
+            );
+        let bytes = encode_part_headers(&p);
+        let s = std::str::from_utf8(&bytes).unwrap();
+        let ct_pos = s.find("content-type:").expect("ct");
+        let cd_pos = s.find("content-disposition:").expect("cd");
+        let xc_pos = s.find("x-custom:").expect("x-custom");
+        assert!(ct_pos < xc_pos);
+        assert!(cd_pos < xc_pos);
+    }
+
+    #[test]
+    fn part_headers_no_extras_when_extra_is_none() {
+        let p = Part::text("n", "v");
+        let bytes = encode_part_headers(&p);
+        let s = std::str::from_utf8(&bytes).unwrap();
+        assert!(!s.contains("x-"));
+    }
+
+    use super::encode;
+    use bytes::Bytes;
+    use futures_util::stream;
+    use http_body_util::BodyExt;
+    use std::sync::Arc;
+
+    async fn drain(body: crate::http::body::HttpBody) -> Vec<u8> {
+        let collected = body.collect().await.unwrap();
+        collected.to_bytes().to_vec()
+    }
+
+    #[tokio::test]
+    async fn encode_empty_parts_produces_only_closing_boundary() {
+        let boundary: Arc<str> = Arc::from("X-BOUNDARY");
+        let parts = Box::pin(stream::iter(Vec::<Part>::new())) as _;
+        let body = encode(boundary, parts);
+        let bytes = drain(body).await;
+        assert_eq!(bytes, b"--X-BOUNDARY--\r\n");
+    }
+
+    #[tokio::test]
+    async fn encode_single_text_part_exact_bytes() {
+        let boundary: Arc<str> = Arc::from("X-BOUNDARY");
+        let parts = Box::pin(stream::iter(vec![Part::text("name", "abcd")])) as _;
+        let body = encode(boundary, parts);
+        let s = String::from_utf8(drain(body).await).unwrap();
+        assert!(s.contains("--X-BOUNDARY\r\n"));
+        assert!(s.contains("content-type: text/plain; charset=utf-8\r\n"));
+        assert!(s.contains("content-disposition: form-data; name=\"name\"\r\n"));
+        assert!(s.contains("\r\n\r\nabcd\r\n"));
+        assert!(s.ends_with("--X-BOUNDARY--\r\n"));
+    }
+
+    #[tokio::test]
+    async fn encode_round_trips_through_multer() {
+        let boundary: Arc<str> = Arc::from("ROUND-TRIP");
+        let parts = Box::pin(stream::iter(vec![
+            Part::text("name1", "value1"),
+            Part::file("upload", "data.bin", Bytes::from_static(b"\x01\x02\x03")),
+        ])) as _;
+        let body = encode(boundary.clone(), parts);
+        let bytes = drain(body).await;
+
+        let mut mp = multer::Multipart::new(
+            stream::iter(vec![Ok::<_, std::io::Error>(Bytes::from(bytes))]),
+            boundary.as_ref(),
+        );
+        let f1 = mp.next_field().await.unwrap().unwrap();
+        assert_eq!(f1.name(), Some("name1"));
+        assert_eq!(f1.text().await.unwrap(), "value1");
+
+        let f2 = mp.next_field().await.unwrap().unwrap();
+        assert_eq!(f2.name(), Some("upload"));
+        assert_eq!(f2.file_name(), Some("data.bin"));
+        assert_eq!(
+            f2.bytes().await.unwrap(),
+            Bytes::from_static(b"\x01\x02\x03")
+        );
+
+        assert!(mp.next_field().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn encode_streaming_body_drains_chunks() {
+        let boundary: Arc<str> = Arc::from("STREAM");
+        let chunks = stream::iter(vec![
+            Ok::<_, crate::error::Error>(Bytes::from_static(b"chunk-1-")),
+            Ok(Bytes::from_static(b"chunk-2")),
+        ]);
+        let part = Part::stream(
+            "log",
+            "log.txt",
+            crate::headers::ContentType::text_utf_8(),
+            chunks,
+        );
+        let parts = Box::pin(stream::iter(vec![part])) as _;
+        let body = encode(boundary, parts);
+        let s = String::from_utf8(drain(body).await).unwrap();
+        assert!(s.contains("\r\n\r\nchunk-1-chunk-2\r\n"), "got: {s}");
+    }
+}

--- a/volga/src/http/endpoints/args/multipart/encoder.rs
+++ b/volga/src/http/endpoints/args/multipart/encoder.rs
@@ -317,11 +317,7 @@ mod tests {
         let boundary: Arc<str> = Arc::from("ROUND-TRIP");
         let parts = Box::pin(stream::iter(vec![
             Ok::<_, crate::error::Error>(Part::text("name1", "value1")),
-            Ok(Part::file(
-                "upload",
-                "data.bin",
-                Bytes::from_static(b"\x01\x02\x03"),
-            )),
+            Ok(Part::file("upload", "data.bin", Bytes::from_static(b"\x01\x02\x03"))),
         ])) as _;
         let body = encode(boundary.clone(), parts);
         let bytes = drain(body).await;

--- a/volga/src/http/endpoints/args/multipart/encoder.rs
+++ b/volga/src/http/endpoints/args/multipart/encoder.rs
@@ -125,9 +125,18 @@ use super::part::PartBody;
 /// The output stream yields one or more [`Bytes`] chunks per part:
 /// boundary line, header block, separator CRLF, body (possibly chunked),
 /// trailing CRLF; followed by the closing boundary at the end.
-pub(super) fn encode(boundary: Arc<str>, mut parts: BoxStream<'static, Part>) -> HttpBody {
+///
+/// A `Result::Err` from the input stream (e.g. a parse failure during a
+/// proxy/forward conversion) is propagated into the body stream so the
+/// connection aborts mid-body instead of completing as a successful but
+/// truncated multipart.
+pub(super) fn encode(
+    boundary: Arc<str>,
+    mut parts: BoxStream<'static, Result<Part, Error>>,
+) -> HttpBody {
     let stream = try_stream! {
         while let Some(part) = parts.next().await {
+            let part = part?;
             yield encode_boundary_open(&boundary);
             yield encode_part_headers(&part);
             yield Bytes::from_static(b"\r\n");
@@ -282,7 +291,7 @@ mod tests {
     #[tokio::test]
     async fn encode_empty_parts_produces_only_closing_boundary() {
         let boundary: Arc<str> = Arc::from("X-BOUNDARY");
-        let parts = Box::pin(stream::iter(Vec::<Part>::new())) as _;
+        let parts = Box::pin(stream::iter(Vec::<Result<Part, crate::error::Error>>::new())) as _;
         let body = encode(boundary, parts);
         let bytes = drain(body).await;
         assert_eq!(bytes, b"--X-BOUNDARY--\r\n");
@@ -291,7 +300,9 @@ mod tests {
     #[tokio::test]
     async fn encode_single_text_part_exact_bytes() {
         let boundary: Arc<str> = Arc::from("X-BOUNDARY");
-        let parts = Box::pin(stream::iter(vec![Part::text("name", "abcd")])) as _;
+        let parts = Box::pin(stream::iter(vec![Ok::<_, crate::error::Error>(
+            Part::text("name", "abcd"),
+        )])) as _;
         let body = encode(boundary, parts);
         let s = String::from_utf8(drain(body).await).unwrap();
         assert!(s.contains("--X-BOUNDARY\r\n"));
@@ -305,8 +316,12 @@ mod tests {
     async fn encode_round_trips_through_multer() {
         let boundary: Arc<str> = Arc::from("ROUND-TRIP");
         let parts = Box::pin(stream::iter(vec![
-            Part::text("name1", "value1"),
-            Part::file("upload", "data.bin", Bytes::from_static(b"\x01\x02\x03")),
+            Ok::<_, crate::error::Error>(Part::text("name1", "value1")),
+            Ok(Part::file(
+                "upload",
+                "data.bin",
+                Bytes::from_static(b"\x01\x02\x03"),
+            )),
         ])) as _;
         let body = encode(boundary.clone(), parts);
         let bytes = drain(body).await;
@@ -343,9 +358,22 @@ mod tests {
             crate::headers::ContentType::text_utf_8(),
             chunks,
         );
-        let parts = Box::pin(stream::iter(vec![part])) as _;
+        let parts = Box::pin(stream::iter(vec![Ok::<_, crate::error::Error>(part)])) as _;
         let body = encode(boundary, parts);
         let s = String::from_utf8(drain(body).await).unwrap();
         assert!(s.contains("\r\n\r\nchunk-1-chunk-2\r\n"), "got: {s}");
+    }
+
+    #[tokio::test]
+    async fn encode_propagates_input_error() {
+        use http_body_util::BodyExt;
+        let boundary: Arc<str> = Arc::from("ERR-BDY");
+        let parts = Box::pin(stream::iter(vec![
+            Ok(Part::text("ok", "first")),
+            Err(crate::error::Error::client_error("simulated parse failure")),
+        ])) as _;
+        let body = encode(boundary, parts);
+        let err = body.collect().await.unwrap_err();
+        assert!(format!("{err}").contains("simulated parse failure"));
     }
 }

--- a/volga/src/http/endpoints/args/multipart/encoder.rs
+++ b/volga/src/http/endpoints/args/multipart/encoder.rs
@@ -317,7 +317,11 @@ mod tests {
         let boundary: Arc<str> = Arc::from("ROUND-TRIP");
         let parts = Box::pin(stream::iter(vec![
             Ok::<_, crate::error::Error>(Part::text("name1", "value1")),
-            Ok(Part::file("upload", "data.bin", Bytes::from_static(b"\x01\x02\x03"))),
+            Ok(Part::file(
+                "upload",
+                "data.bin",
+                Bytes::from_static(b"\x01\x02\x03"),
+            )),
         ])) as _;
         let body = encode(boundary.clone(), parts);
         let bytes = drain(body).await;

--- a/volga/src/http/endpoints/args/multipart/encoder.rs
+++ b/volga/src/http/endpoints/args/multipart/encoder.rs
@@ -89,29 +89,26 @@ pub(super) fn encode_boundary_close(boundary: &str) -> Bytes {
 /// Returns a single allocation containing all `Name: Value\r\n` lines, ready to be yielded.
 #[inline]
 pub(super) fn encode_part_headers(part: &Part) -> Bytes {
-    let mut s = String::with_capacity(64);
+    let mut buf = Vec::with_capacity(64);
     if let Some(ct) = part.part_content_type() {
-        write_header(&mut s, &ct.name(), ct.value());
+        write_header(&mut buf, &ct.name(), ct.value());
     }
     if let Some(cd) = part.part_content_disposition() {
-        write_header(&mut s, &cd.name(), cd.value());
+        write_header(&mut buf, &cd.name(), cd.value());
     }
     if let Some(extras) = part.part_extras() {
         for (name, value) in extras.iter() {
-            write_header(&mut s, name, value);
+            write_header(&mut buf, name, value);
         }
     }
-    Bytes::from(s)
+    Bytes::from(buf)
 }
 
-fn write_header(out: &mut String, name: &HeaderName, value: &HeaderValue) {
-    out.push_str(name.as_str());
-    out.push_str(": ");
-    match value.to_str() {
-        Ok(v) => out.push_str(v),
-        Err(_) => out.push_str("<binary>"),
-    }
-    out.push_str("\r\n");
+fn write_header(out: &mut Vec<u8>, name: &HeaderName, value: &HeaderValue) {
+    out.extend_from_slice(name.as_str().as_bytes());
+    out.extend_from_slice(b": ");
+    out.extend_from_slice(value.as_bytes());
+    out.extend_from_slice(b"\r\n");
 }
 
 use crate::http::body::HttpBody;
@@ -275,6 +272,21 @@ mod tests {
         let bytes = encode_part_headers(&p);
         let s = std::str::from_utf8(&bytes).unwrap();
         assert!(!s.contains("x-"));
+    }
+
+    #[test]
+    fn part_headers_preserve_raw_obs_text_bytes() {
+        // RFC 7230 obs-text (0x80..=0xFF) is valid in HeaderValue but not UTF-8.
+        // The encoder must emit the original bytes, not substitute a placeholder.
+        let raw = crate::headers::HeaderValue::from_bytes(b"\xC3\x28").unwrap(); // invalid UTF-8
+        let p = Part::text("n", "v")
+            .with_header_raw(crate::headers::HeaderName::from_static("x-binary"), raw);
+        let bytes = encode_part_headers(&p);
+        let needle = b"x-binary: \xC3(\r\n";
+        assert!(
+            bytes.windows(needle.len()).any(|w| w == needle),
+            "expected raw obs-text bytes to be preserved verbatim, got {bytes:?}"
+        );
     }
 
     use super::encode;

--- a/volga/src/http/endpoints/args/multipart/error.rs
+++ b/volga/src/http/endpoints/args/multipart/error.rs
@@ -1,0 +1,22 @@
+//! Multipart-specific error helpers.
+
+use crate::error::Error;
+
+pub(super) struct MultipartError;
+
+impl MultipartError {
+    #[inline]
+    pub(super) fn invalid_boundary() -> Error {
+        Error::client_error("Multipart error: invalid boundary")
+    }
+
+    #[inline]
+    pub(super) fn missing_file_name() -> Error {
+        Error::client_error("Multipart error: file name is missing")
+    }
+
+    #[inline]
+    pub(super) fn read_error(error: multer::Error) -> Error {
+        Error::client_error(format!("Multipart error: {error}"))
+    }
+}

--- a/volga/src/http/endpoints/args/multipart/field.rs
+++ b/volga/src/http/endpoints/args/multipart/field.rs
@@ -1,0 +1,109 @@
+//! Multipart field — represents a single part of an incoming multipart stream.
+
+use bytes::Bytes;
+use std::{
+    ops::{Deref, DerefMut},
+    path::Path,
+};
+use tokio::io::{AsyncWriteExt, BufWriter};
+
+use super::error::MultipartError;
+use crate::error::Error;
+
+/// Represents a single field in a multipart stream
+///
+///> See also [`multer::Field`]
+#[derive(Debug)]
+pub struct Field(pub(super) multer::Field<'static>);
+
+impl Field {
+    /// Tries to read a file name, if it's not present tries to read a field name, otherwise returns [`Error`]
+    #[inline]
+    pub fn try_get_file_name(&self) -> Result<&str, Error> {
+        self.0
+            .file_name()
+            .or(self.name())
+            .ok_or(MultipartError::missing_file_name())
+    }
+
+    /// Get the full field data as text.
+    ///
+    ///> See also [`multer::Field::text`]
+    #[inline]
+    pub async fn text(self) -> Result<String, Error> {
+        self.0.text().await.map_err(MultipartError::read_error)
+    }
+
+    /// Stream a chunk of the field data.
+    ///
+    /// When the field data has been exhausted, this will return [`None`].
+    ///
+    ///> See also [`multer::Field::chunk`]
+    #[inline]
+    pub async fn chunk(&mut self) -> Result<Option<Bytes>, Error> {
+        self.0.chunk().await.map_err(MultipartError::read_error)
+    }
+
+    /// Asynchronously writes a multipart field as a file stream to disk with a name taken from `CONTENT_DISPOSITION` header
+    ///
+    /// # Example
+    /// ```no_run
+    /// use volga::{HttpResult, Multipart, ok};
+    ///
+    /// async fn handle(mut files: Multipart) -> HttpResult {
+    ///     while let Some(field) = files.next_field().await? {
+    ///         field.save("path/to/folder").await?;
+    ///     }
+    ///     ok!("File saved!")
+    /// }
+    /// ```
+    #[inline]
+    pub async fn save(self, path: impl AsRef<Path>) -> Result<(), std::io::Error> {
+        let file_name = self.try_get_file_name()?;
+        let file_path = path.as_ref().join(file_name);
+        self.save_as(file_path).await
+    }
+
+    /// Asynchronously writes a multipart field as a file stream to disk with a provided name in `file_path`
+    ///
+    /// # Example
+    /// ```no_run
+    /// use volga::{HttpResult, Multipart, ok};
+    /// use std::path::Path;
+    ///
+    /// async fn handle(mut files: Multipart) -> HttpResult {
+    ///     let path = Path::new("path/to/folder");
+    ///     let mut counter = 0;
+    ///     while let Some(field) = files.next_field().await? {
+    ///         field.save_as(path.join(format!("file_{counter}.dat"))).await?;
+    ///         counter += 1;
+    ///     }
+    ///     ok!("File saved!")
+    /// }
+    /// ```
+    #[inline]
+    pub async fn save_as(mut self, path: impl AsRef<Path>) -> Result<(), std::io::Error> {
+        let file = tokio::fs::File::create(path).await?;
+        let mut writer = BufWriter::new(file);
+        while let Some(ref chunk) = self.chunk().await? {
+            writer.write_all(chunk).await?
+        }
+        writer.flush().await
+    }
+}
+
+impl Deref for Field {
+    type Target = multer::Field<'static>;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Field {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}

--- a/volga/src/http/endpoints/args/multipart/part.rs
+++ b/volga/src/http/endpoints/args/multipart/part.rs
@@ -1,0 +1,393 @@
+//! Outgoing multipart parts.
+
+use bytes::Bytes;
+use futures_util::stream::BoxStream;
+
+use crate::error::Error;
+
+/// Body of an outgoing multipart [`Part`]. Either eager bytes or a streaming source.
+pub enum PartBody {
+    /// Materialized bytes ready to be written.
+    Bytes(Bytes),
+    /// Streaming body, drained chunk-by-chunk during encoding.
+    Stream(BoxStream<'static, Result<Bytes, Error>>),
+}
+
+impl std::fmt::Debug for PartBody {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Bytes(b) => f.debug_tuple("Bytes").field(b).finish(),
+            Self::Stream(_) => f.debug_struct("Stream").finish_non_exhaustive(),
+        }
+    }
+}
+
+impl From<Bytes> for PartBody {
+    #[inline]
+    fn from(b: Bytes) -> Self {
+        Self::Bytes(b)
+    }
+}
+
+impl From<&'static [u8]> for PartBody {
+    #[inline]
+    fn from(b: &'static [u8]) -> Self {
+        Self::Bytes(Bytes::from_static(b))
+    }
+}
+
+impl From<Vec<u8>> for PartBody {
+    #[inline]
+    fn from(v: Vec<u8>) -> Self {
+        Self::Bytes(Bytes::from(v))
+    }
+}
+
+impl From<&'static str> for PartBody {
+    #[inline]
+    fn from(s: &'static str) -> Self {
+        Self::Bytes(Bytes::from_static(s.as_bytes()))
+    }
+}
+
+impl From<String> for PartBody {
+    #[inline]
+    fn from(s: String) -> Self {
+        Self::Bytes(Bytes::from(s))
+    }
+}
+
+use crate::headers::{ContentDisposition, ContentType, FromHeaders, Header, HeaderMap};
+
+/// An outgoing multipart part — either form-data, byteranges, or any RFC 2046 subtype.
+///
+/// Construct with [`Part::new`] (bare) or one of the form-data convenience constructors:
+/// [`Part::text`], [`Part::bytes`], [`Part::file`], [`Part::stream`]. Use the `with_*`
+/// builder methods to attach headers.
+#[derive(Debug)]
+pub struct Part {
+    pub(super) content_type: Option<Header<ContentType>>,
+    pub(super) content_disposition: Option<Header<ContentDisposition>>,
+    pub(super) extra: Option<HeaderMap>,
+    pub(super) body: PartBody,
+}
+
+impl Part {
+    /// Constructs a bare part with no headers — for `multipart/byteranges`,
+    /// `multipart/mixed`, or any subtype where Content-Disposition is not appropriate.
+    pub fn new(body: impl Into<PartBody>) -> Self {
+        Self {
+            content_type: None,
+            content_disposition: None,
+            extra: None,
+            body: body.into(),
+        }
+    }
+
+    /// Constructs a form-data text field.
+    /// Sets `Content-Type: text/plain; charset=utf-8` and `Content-Disposition: form-data; name="<name>"`.
+    pub fn text(name: impl AsRef<str>, value: impl Into<String>) -> Self {
+        let body: PartBody = value.into().into();
+        Self {
+            content_type: Some(ContentType::text_utf_8()),
+            content_disposition: Some(make_form_disposition(name.as_ref(), None)),
+            extra: None,
+            body,
+        }
+    }
+
+    /// Constructs a form-data binary field (no filename).
+    /// Sets `Content-Type: application/octet-stream` and `Content-Disposition: form-data; name="<name>"`.
+    pub fn bytes(name: impl AsRef<str>, bytes: impl Into<Bytes>) -> Self {
+        Self {
+            content_type: Some(ContentType::stream()),
+            content_disposition: Some(make_form_disposition(name.as_ref(), None)),
+            extra: None,
+            body: PartBody::Bytes(bytes.into()),
+        }
+    }
+
+    /// Constructs a form-data file part. Content-Type is guessed from the filename
+    /// extension via [`mime_guess`], falling back to `application/octet-stream`.
+    pub fn file(name: impl AsRef<str>, filename: impl AsRef<str>, bytes: impl Into<Bytes>) -> Self {
+        let filename_str = filename.as_ref();
+        let mime = mime_guess::from_path(filename_str).first_or_octet_stream();
+        let ct = Header::<ContentType>::from_bytes(mime.essence_str().as_bytes())
+            .unwrap_or_else(|_| ContentType::stream());
+        Self {
+            content_type: Some(ct),
+            content_disposition: Some(make_form_disposition(name.as_ref(), Some(filename_str))),
+            extra: None,
+            body: PartBody::Bytes(bytes.into()),
+        }
+    }
+
+    /// Constructs a streaming form-data file part. The caller supplies the Content-Type
+    /// since filename-based guessing is not always meaningful for streams.
+    pub fn stream<S>(
+        name: impl AsRef<str>,
+        filename: impl AsRef<str>,
+        content_type: Header<ContentType>,
+        stream: S,
+    ) -> Self
+    where
+        S: futures_util::Stream<Item = Result<Bytes, Error>> + Send + 'static,
+    {
+        Self {
+            content_type: Some(content_type),
+            content_disposition: Some(make_form_disposition(
+                name.as_ref(),
+                Some(filename.as_ref()),
+            )),
+            extra: None,
+            body: PartBody::Stream(Box::pin(stream)),
+        }
+    }
+
+    /// Overrides the Content-Type header.
+    pub fn with_content_type(mut self, ct: Header<ContentType>) -> Self {
+        self.content_type = Some(ct);
+        self
+    }
+
+    /// Sets the Content-Disposition header to `form-data; name="<name>"[; filename="<filename>"]`.
+    pub fn with_disposition(self, name: &str, filename: Option<&str>) -> Self {
+        self.with_disposition_raw(make_form_disposition(name, filename))
+    }
+
+    /// Sets the Content-Disposition header verbatim — for cases not covered by the
+    /// form-data builder (RFC 5987 encoding, alternative dispositions, etc).
+    pub fn with_disposition_raw(mut self, cd: Header<ContentDisposition>) -> Self {
+        self.content_disposition = Some(cd);
+        self
+    }
+
+    /// Appends a typed header. The `extra` map is allocated lazily on first call.
+    pub fn with_header<T: FromHeaders>(mut self, header: Header<T>) -> Self {
+        let map = self.extra.get_or_insert_with(HeaderMap::new);
+        let name = header.name();
+        map.insert(name, header.into_inner());
+        self
+    }
+
+    /// Appends a raw header — escape hatch for one-off headers that don't have
+    /// a dedicated marker type.
+    pub fn with_header_raw(
+        mut self,
+        name: crate::headers::HeaderName,
+        value: crate::headers::HeaderValue,
+    ) -> Self {
+        let map = self.extra.get_or_insert_with(HeaderMap::new);
+        map.insert(name, value);
+        self
+    }
+
+    /// `pub(super)` accessor for the encoder.
+    #[inline]
+    pub(super) fn part_content_type(&self) -> Option<&Header<ContentType>> {
+        self.content_type.as_ref()
+    }
+
+    /// `pub(super)` accessor for the encoder.
+    #[inline]
+    pub(super) fn part_content_disposition(&self) -> Option<&Header<ContentDisposition>> {
+        self.content_disposition.as_ref()
+    }
+
+    /// `pub(super)` accessor for the encoder.
+    #[inline]
+    pub(super) fn part_extras(&self) -> Option<&HeaderMap> {
+        self.extra.as_ref()
+    }
+
+    /// `pub(super)` consumer for the encoder.
+    #[inline]
+    pub(super) fn into_body(self) -> PartBody {
+        self.body
+    }
+}
+
+/// Builds a `Content-Disposition` header value of the form
+/// `form-data; name="<name>"[; filename="<filename>"]` with backslash-escaping
+/// of `"` and `\` in the parameter values per RFC 7578 / RFC 2183.
+pub(super) fn make_form_disposition(
+    name: &str,
+    filename: Option<&str>,
+) -> Header<ContentDisposition> {
+    let mut s = String::with_capacity(32);
+    s.push_str("form-data; name=\"");
+    escape_disposition_param(&mut s, name);
+    s.push('"');
+    if let Some(fname) = filename {
+        s.push_str("; filename=\"");
+        escape_disposition_param(&mut s, fname);
+        s.push('"');
+    }
+    Header::<ContentDisposition>::from_bytes(s.as_bytes())
+        .expect("escaped disposition value should be a valid header")
+}
+
+fn escape_disposition_param(out: &mut String, value: &str) {
+    for ch in value.chars() {
+        if ch == '"' || ch == '\\' {
+            out.push('\\');
+        }
+        out.push(ch);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Part, PartBody};
+    use crate::headers::ContentType;
+    use bytes::Bytes;
+    use futures_util::stream;
+
+    #[test]
+    fn from_bytes() {
+        let pb: PartBody = Bytes::from_static(b"hello").into();
+        assert!(matches!(pb, PartBody::Bytes(b) if b == "hello"));
+    }
+
+    #[test]
+    fn from_static_slice() {
+        let pb: PartBody = (b"hello" as &'static [u8]).into();
+        assert!(matches!(pb, PartBody::Bytes(b) if b == "hello"));
+    }
+
+    #[test]
+    fn from_vec() {
+        let pb: PartBody = vec![1u8, 2, 3].into();
+        assert!(matches!(pb, PartBody::Bytes(b) if b.as_ref() == [1, 2, 3]));
+    }
+
+    #[test]
+    fn from_static_str() {
+        let pb: PartBody = "hello".into();
+        assert!(matches!(pb, PartBody::Bytes(b) if b == "hello"));
+    }
+
+    #[test]
+    fn from_string() {
+        let pb: PartBody = String::from("hello").into();
+        assert!(matches!(pb, PartBody::Bytes(b) if b == "hello"));
+    }
+
+    #[test]
+    fn new_creates_bare_part_no_headers() {
+        let p = Part::new("hello");
+        assert!(p.content_type.is_none());
+        assert!(p.content_disposition.is_none());
+        assert!(p.extra.is_none());
+    }
+
+    #[test]
+    fn text_sets_text_plain_utf8_and_disposition() {
+        let p = Part::text("name", "value");
+        let ct = p.content_type.expect("ct set");
+        assert_eq!(ct.as_ref(), "text/plain; charset=utf-8");
+        let cd = p.content_disposition.expect("cd set");
+        assert_eq!(cd.as_ref(), "form-data; name=\"name\"");
+    }
+
+    #[test]
+    fn bytes_sets_octet_stream_and_disposition() {
+        let p = Part::bytes("blob", Bytes::from_static(b"\x01\x02\x03"));
+        let ct = p.content_type.expect("ct set");
+        assert_eq!(ct.as_ref(), "application/octet-stream");
+        let cd = p.content_disposition.expect("cd set");
+        assert_eq!(cd.as_ref(), "form-data; name=\"blob\"");
+    }
+
+    #[test]
+    fn disposition_escapes_quote_and_backslash() {
+        let p = Part::text(r#"weird"name\with\\backslashes"#, "x");
+        let cd = p.content_disposition.expect("cd set");
+        assert_eq!(
+            cd.as_ref(),
+            r#"form-data; name="weird\"name\\with\\\\backslashes""#
+        );
+    }
+
+    #[test]
+    fn file_guesses_pdf_mime() {
+        let p = Part::file("doc", "report.pdf", Bytes::from_static(b"%PDF-1.4\n"));
+        let ct = p.content_type.expect("ct set");
+        assert_eq!(ct.as_ref(), "application/pdf");
+        let cd = p.content_disposition.expect("cd set");
+        assert_eq!(
+            cd.as_ref(),
+            "form-data; name=\"doc\"; filename=\"report.pdf\""
+        );
+    }
+
+    #[test]
+    fn file_falls_back_to_octet_stream_for_unknown_extension() {
+        let p = Part::file("doc", "weird.zzz", Bytes::from_static(b"x"));
+        let ct = p.content_type.expect("ct set");
+        assert_eq!(ct.as_ref(), "application/octet-stream");
+    }
+
+    #[tokio::test]
+    async fn stream_keeps_caller_supplied_content_type() {
+        let body = stream::iter(vec![Ok::<_, crate::error::Error>(Bytes::from_static(b"x"))]);
+        let p = Part::stream("doc", "log.txt", ContentType::text_utf_8(), body);
+        let ct = p.content_type.expect("ct set");
+        assert_eq!(ct.as_ref(), "text/plain; charset=utf-8");
+        let cd = p.content_disposition.expect("cd set");
+        assert_eq!(cd.as_ref(), "form-data; name=\"doc\"; filename=\"log.txt\"");
+        assert!(matches!(p.body, PartBody::Stream(_)));
+    }
+
+    use crate::headers::{ContentDisposition, ContentEncoding, HeaderName, HeaderValue};
+
+    #[test]
+    fn with_content_type_overrides() {
+        let p = Part::text("n", "v").with_content_type(ContentType::html_utf_8());
+        assert_eq!(p.content_type.unwrap().as_ref(), "text/html; charset=utf-8");
+    }
+
+    #[test]
+    fn with_disposition_replaces() {
+        let p = Part::text("old", "v").with_disposition("new", Some("file.txt"));
+        assert_eq!(
+            p.content_disposition.unwrap().as_ref(),
+            "form-data; name=\"new\"; filename=\"file.txt\""
+        );
+    }
+
+    #[test]
+    fn with_disposition_raw_passes_through() {
+        let cd = crate::headers::Header::<ContentDisposition>::from_static(
+            r#"attachment; filename="x""#,
+        );
+        let p = Part::new("body").with_disposition_raw(cd);
+        assert_eq!(
+            p.content_disposition.unwrap().as_ref(),
+            r#"attachment; filename="x""#
+        );
+    }
+
+    #[test]
+    fn with_header_typed_lazily_allocates_extra() {
+        let p = Part::text("n", "v");
+        assert!(p.extra.is_none(), "extra is None until first custom header");
+
+        let enc = crate::headers::Header::<ContentEncoding>::from_static("gzip");
+        let p = p.with_header(enc);
+        assert!(p.extra.is_some(), "extra allocated after first with_header");
+        let map = p.extra.unwrap();
+        assert_eq!(map.get("content-encoding").unwrap(), "gzip");
+    }
+
+    #[test]
+    fn with_header_raw_lazily_allocates_extra() {
+        let p = Part::text("n", "v");
+        assert!(p.extra.is_none());
+        let p = p.with_header_raw(
+            HeaderName::from_static("x-custom"),
+            HeaderValue::from_static("y"),
+        );
+        assert_eq!(p.extra.unwrap().get("x-custom").unwrap(), "y");
+    }
+}

--- a/volga/src/http/endpoints/args/multipart/part.rs
+++ b/volga/src/http/endpoints/args/multipart/part.rs
@@ -59,8 +59,7 @@ impl From<String> for PartBody {
 
 use crate::headers::{ContentDisposition, ContentType, FromHeaders, Header, HeaderMap};
 
-const INVALID_HEADER_BYTES_MSG: &str =
-    "invalid bytes in part name or filename (e.g. CR/LF); use the corresponding `try_*` constructor for untrusted input";
+const INVALID_HEADER_BYTES_MSG: &str = "invalid bytes in part name or filename (e.g. CR/LF); use the corresponding `try_*` constructor for untrusted input";
 
 /// An outgoing multipart part — either form-data, byteranges, or any RFC 2046 subtype.
 ///
@@ -136,11 +135,7 @@ impl Part {
     /// # Panics
     /// if `name` or `filename` contains bytes that are invalid in an HTTP header value.
     /// For untrusted input, use [`Part::try_file`].
-    pub fn file(
-        name: impl AsRef<str>,
-        filename: impl AsRef<str>,
-        bytes: impl Into<Bytes>,
-    ) -> Self {
+    pub fn file(name: impl AsRef<str>, filename: impl AsRef<str>, bytes: impl Into<Bytes>) -> Self {
         Self::try_file(name, filename, bytes).expect(INVALID_HEADER_BYTES_MSG)
     }
 
@@ -221,11 +216,7 @@ impl Part {
 
     /// Fallible counterpart of [`Part::with_disposition`]. Returns `Err` if `name` or
     /// `filename` contains bytes that are invalid in an HTTP header value.
-    pub fn try_with_disposition(
-        self,
-        name: &str,
-        filename: Option<&str>,
-    ) -> Result<Self, Error> {
+    pub fn try_with_disposition(self, name: &str, filename: Option<&str>) -> Result<Self, Error> {
         Ok(self.with_disposition_raw(make_form_disposition(name, filename)?))
     }
 
@@ -386,8 +377,8 @@ mod tests {
 
     #[test]
     fn try_file_rejects_invalid_header_bytes() {
-        let err = Part::try_file("name\r\nfield", "ev\nil.txt", Bytes::from_static(b"x"))
-            .unwrap_err();
+        let err =
+            Part::try_file("name\r\nfield", "ev\nil.txt", Bytes::from_static(b"x")).unwrap_err();
         assert!(
             !format!("{err}").is_empty(),
             "expected an error describing the invalid header value"

--- a/volga/src/http/endpoints/args/multipart/part.rs
+++ b/volga/src/http/endpoints/args/multipart/part.rs
@@ -59,6 +59,9 @@ impl From<String> for PartBody {
 
 use crate::headers::{ContentDisposition, ContentType, FromHeaders, Header, HeaderMap};
 
+const INVALID_HEADER_BYTES_MSG: &str =
+    "invalid bytes in part name or filename (e.g. CR/LF); use the corresponding `try_*` constructor for untrusted input";
+
 /// An outgoing multipart part — either form-data, byteranges, or any RFC 2046 subtype.
 ///
 /// Construct with [`Part::new`] (bare) or one of the form-data convenience constructors:
@@ -86,44 +89,86 @@ impl Part {
 
     /// Constructs a form-data text field.
     /// Sets `Content-Type: text/plain; charset=utf-8` and `Content-Disposition: form-data; name="<name>"`.
+    ///
+    /// # Panics
+    /// if `name` contains bytes that are invalid in an HTTP header value (e.g. CR/LF).
+    /// For untrusted input, use [`Part::try_text`].
     pub fn text(name: impl AsRef<str>, value: impl Into<String>) -> Self {
+        Self::try_text(name, value).expect(INVALID_HEADER_BYTES_MSG)
+    }
+
+    /// Fallible counterpart of [`Part::text`]. Returns `Err` if `name` contains bytes
+    /// that are invalid in an HTTP header value.
+    pub fn try_text(name: impl AsRef<str>, value: impl Into<String>) -> Result<Self, Error> {
         let body: PartBody = value.into().into();
-        Self {
+        Ok(Self {
             content_type: Some(ContentType::text_utf_8()),
-            content_disposition: Some(make_form_disposition(name.as_ref(), None)),
+            content_disposition: Some(make_form_disposition(name.as_ref(), None)?),
             extra: None,
             body,
-        }
+        })
     }
 
     /// Constructs a form-data binary field (no filename).
     /// Sets `Content-Type: application/octet-stream` and `Content-Disposition: form-data; name="<name>"`.
+    ///
+    /// # Panics
+    /// if `name` contains bytes that are invalid in an HTTP header value (e.g. CR/LF).
+    /// For untrusted input, use [`Part::try_bytes`].
     pub fn bytes(name: impl AsRef<str>, bytes: impl Into<Bytes>) -> Self {
-        Self {
+        Self::try_bytes(name, bytes).expect(INVALID_HEADER_BYTES_MSG)
+    }
+
+    /// Fallible counterpart of [`Part::bytes`]. Returns `Err` if `name` contains bytes
+    /// that are invalid in an HTTP header value.
+    pub fn try_bytes(name: impl AsRef<str>, bytes: impl Into<Bytes>) -> Result<Self, Error> {
+        Ok(Self {
             content_type: Some(ContentType::stream()),
-            content_disposition: Some(make_form_disposition(name.as_ref(), None)),
+            content_disposition: Some(make_form_disposition(name.as_ref(), None)?),
             extra: None,
             body: PartBody::Bytes(bytes.into()),
-        }
+        })
     }
 
     /// Constructs a form-data file part. Content-Type is guessed from the filename
     /// extension via [`mime_guess`], falling back to `application/octet-stream`.
-    pub fn file(name: impl AsRef<str>, filename: impl AsRef<str>, bytes: impl Into<Bytes>) -> Self {
+    ///
+    /// # Panics
+    /// if `name` or `filename` contains bytes that are invalid in an HTTP header value.
+    /// For untrusted input, use [`Part::try_file`].
+    pub fn file(
+        name: impl AsRef<str>,
+        filename: impl AsRef<str>,
+        bytes: impl Into<Bytes>,
+    ) -> Self {
+        Self::try_file(name, filename, bytes).expect(INVALID_HEADER_BYTES_MSG)
+    }
+
+    /// Fallible counterpart of [`Part::file`]. Returns `Err` if `name` or `filename`
+    /// contains bytes that are invalid in an HTTP header value.
+    pub fn try_file(
+        name: impl AsRef<str>,
+        filename: impl AsRef<str>,
+        bytes: impl Into<Bytes>,
+    ) -> Result<Self, Error> {
         let filename_str = filename.as_ref();
         let mime = mime_guess::from_path(filename_str).first_or_octet_stream();
         let ct = Header::<ContentType>::from_bytes(mime.essence_str().as_bytes())
             .unwrap_or_else(|_| ContentType::stream());
-        Self {
+        Ok(Self {
             content_type: Some(ct),
-            content_disposition: Some(make_form_disposition(name.as_ref(), Some(filename_str))),
+            content_disposition: Some(make_form_disposition(name.as_ref(), Some(filename_str))?),
             extra: None,
             body: PartBody::Bytes(bytes.into()),
-        }
+        })
     }
 
     /// Constructs a streaming form-data file part. The caller supplies the Content-Type
     /// since filename-based guessing is not always meaningful for streams.
+    ///
+    /// # Panics
+    /// if `name` or `filename` contains bytes that are invalid in an HTTP header value.
+    /// For untrusted input, use [`Part::try_stream`].
     pub fn stream<S>(
         name: impl AsRef<str>,
         filename: impl AsRef<str>,
@@ -133,15 +178,29 @@ impl Part {
     where
         S: futures_util::Stream<Item = Result<Bytes, Error>> + Send + 'static,
     {
-        Self {
+        Self::try_stream(name, filename, content_type, stream).expect(INVALID_HEADER_BYTES_MSG)
+    }
+
+    /// Fallible counterpart of [`Part::stream`]. Returns `Err` if `name` or `filename`
+    /// contains bytes that are invalid in an HTTP header value.
+    pub fn try_stream<S>(
+        name: impl AsRef<str>,
+        filename: impl AsRef<str>,
+        content_type: Header<ContentType>,
+        stream: S,
+    ) -> Result<Self, Error>
+    where
+        S: futures_util::Stream<Item = Result<Bytes, Error>> + Send + 'static,
+    {
+        Ok(Self {
             content_type: Some(content_type),
             content_disposition: Some(make_form_disposition(
                 name.as_ref(),
                 Some(filename.as_ref()),
-            )),
+            )?),
             extra: None,
             body: PartBody::Stream(Box::pin(stream)),
-        }
+        })
     }
 
     /// Overrides the Content-Type header.
@@ -151,8 +210,23 @@ impl Part {
     }
 
     /// Sets the Content-Disposition header to `form-data; name="<name>"[; filename="<filename>"]`.
+    ///
+    /// # Panics
+    /// if `name` or `filename` contains bytes that are invalid in an HTTP header value.
+    /// For untrusted input, use [`Part::try_with_disposition`].
     pub fn with_disposition(self, name: &str, filename: Option<&str>) -> Self {
-        self.with_disposition_raw(make_form_disposition(name, filename))
+        self.try_with_disposition(name, filename)
+            .expect(INVALID_HEADER_BYTES_MSG)
+    }
+
+    /// Fallible counterpart of [`Part::with_disposition`]. Returns `Err` if `name` or
+    /// `filename` contains bytes that are invalid in an HTTP header value.
+    pub fn try_with_disposition(
+        self,
+        name: &str,
+        filename: Option<&str>,
+    ) -> Result<Self, Error> {
+        Ok(self.with_disposition_raw(make_form_disposition(name, filename)?))
     }
 
     /// Sets the Content-Disposition header verbatim — for cases not covered by the
@@ -210,10 +284,12 @@ impl Part {
 /// Builds a `Content-Disposition` header value of the form
 /// `form-data; name="<name>"[; filename="<filename>"]` with backslash-escaping
 /// of `"` and `\` in the parameter values per RFC 7578 / RFC 2183.
+/// Returns `Err` if `name` or `filename` contains bytes that aren't valid in an HTTP
+/// header value (e.g. CR / LF / NUL).
 pub(super) fn make_form_disposition(
     name: &str,
     filename: Option<&str>,
-) -> Header<ContentDisposition> {
+) -> Result<Header<ContentDisposition>, Error> {
     let mut s = String::with_capacity(32);
     s.push_str("form-data; name=\"");
     escape_disposition_param(&mut s, name);
@@ -224,7 +300,6 @@ pub(super) fn make_form_disposition(
         s.push('"');
     }
     Header::<ContentDisposition>::from_bytes(s.as_bytes())
-        .expect("escaped disposition value should be a valid header")
 }
 
 fn escape_disposition_param(out: &mut String, value: &str) {
@@ -310,6 +385,22 @@ mod tests {
     }
 
     #[test]
+    fn try_file_rejects_invalid_header_bytes() {
+        let err = Part::try_file("name\r\nfield", "ev\nil.txt", Bytes::from_static(b"x"))
+            .unwrap_err();
+        assert!(
+            !format!("{err}").is_empty(),
+            "expected an error describing the invalid header value"
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid bytes in part name")]
+    fn text_panics_on_invalid_header_bytes() {
+        let _ = Part::text("name\r\nfield", "x");
+    }
+
+    #[test]
     fn file_guesses_pdf_mime() {
         let p = Part::file("doc", "report.pdf", Bytes::from_static(b"%PDF-1.4\n"));
         let ct = p.content_type.expect("ct set");
@@ -354,6 +445,14 @@ mod tests {
             p.content_disposition.unwrap().as_ref(),
             "form-data; name=\"new\"; filename=\"file.txt\""
         );
+    }
+
+    #[test]
+    fn try_with_disposition_returns_err_on_invalid_bytes() {
+        let err = Part::new("body")
+            .try_with_disposition("name\r\nfield", None)
+            .unwrap_err();
+        assert!(!format!("{err}").is_empty());
     }
 
     #[test]

--- a/volga/src/http/response/into_response.rs
+++ b/volga/src/http/response/into_response.rs
@@ -207,6 +207,38 @@ impl<T: Serialize> IntoResponse for Form<T> {
     }
 }
 
+#[cfg(feature = "multipart")]
+impl IntoResponse for crate::http::endpoints::args::multipart::Multipart {
+    fn into_response(self) -> HttpResult {
+        use crate::http::endpoints::args::multipart::MultipartInner;
+        use crate::response;
+
+        let ct = self.content_type_header().ok_or_else(|| {
+            Error::server_error(
+                "cannot return incoming multipart as response; call into_outgoing() first",
+            )
+        })?;
+
+        let MultipartInner::Outgoing {
+            boundary, parts, ..
+        } = self.into_inner()
+        else {
+            // Already filtered above by content_type_header(); unreachable.
+            unreachable!()
+        };
+
+        let body = crate::http::endpoints::args::multipart::encode_for_response(boundary, parts);
+        response!(200, body; [ct])
+    }
+
+    #[cfg(feature = "openapi")]
+    fn describe_openapi(
+        config: crate::openapi::OpenApiRouteConfig,
+    ) -> crate::openapi::OpenApiRouteConfig {
+        config.produces_multipart(200u16)
+    }
+}
+
 impl IntoResponse for StatusCode {
     #[inline]
     fn into_response(self) -> HttpResult {

--- a/volga/src/http/response/into_response.rs
+++ b/volga/src/http/response/into_response.rs
@@ -213,11 +213,7 @@ impl IntoResponse for crate::http::endpoints::args::multipart::Multipart {
         use crate::http::endpoints::args::multipart::MultipartInner;
         use crate::response;
 
-        let ct = self.content_type_header().ok_or_else(|| {
-            Error::server_error(
-                "cannot return incoming multipart as response; call into_outgoing() first",
-            )
-        })?;
+        let ct = self.content_type_header()?;
 
         let MultipartInner::Outgoing {
             boundary, parts, ..

--- a/volga/src/lib.rs
+++ b/volga/src/lib.rs
@@ -89,7 +89,9 @@ pub use http::HttpRequestMut;
 pub use limits::Limit;
 
 #[cfg(feature = "multipart")]
-pub use crate::http::endpoints::args::multipart::Multipart;
+pub use {
+    crate::http::endpoints::args::multipart, crate::http::endpoints::args::multipart::Multipart,
+};
 
 /// Route mapping helpers
 pub mod routing {

--- a/volga/tests/multipart_response_tests.rs
+++ b/volga/tests/multipart_response_tests.rs
@@ -4,7 +4,6 @@
 
 use bytes::Bytes;
 use futures_util::stream;
-use volga::http::IntoResponse;
 use volga::http::endpoints::args::multipart::{Multipart, MultipartSubtype, Part};
 use volga::test::TestServer;
 
@@ -13,11 +12,10 @@ async fn end_to_end_form_data_response() {
     let server = TestServer::builder()
         .setup(|app| {
             app.map_get("/mp", || async {
-                let mp = Multipart::from_parts(vec![
+                Multipart::from_parts(vec![
                     Part::text("greeting", "hello"),
                     Part::file("logo", "logo.bin", Bytes::from_static(b"\x01\x02\x03")),
-                ]);
-                mp.into_response()
+                ])
             });
         })
         .build()

--- a/volga/tests/multipart_response_tests.rs
+++ b/volga/tests/multipart_response_tests.rs
@@ -1,0 +1,182 @@
+//! Integration tests for outgoing `Multipart` responses.
+
+#![cfg(all(feature = "multipart", feature = "test"))]
+
+use bytes::Bytes;
+use futures_util::stream;
+use volga::http::IntoResponse;
+use volga::http::endpoints::args::multipart::{Multipart, MultipartSubtype, Part};
+use volga::test::TestServer;
+
+#[tokio::test]
+async fn end_to_end_form_data_response() {
+    let server = TestServer::builder()
+        .setup(|app| {
+            app.map_get("/mp", || async {
+                let mp = Multipart::from_parts(vec![
+                    Part::text("greeting", "hello"),
+                    Part::file("logo", "logo.bin", Bytes::from_static(b"\x01\x02\x03")),
+                ]);
+                mp.into_response()
+            });
+        })
+        .build()
+        .await;
+
+    let res = server.client().get(server.url("/mp")).send().await.unwrap();
+    let ct = res
+        .headers()
+        .get("content-type")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_owned();
+    assert!(ct.starts_with("multipart/form-data; boundary="));
+    let body = res.bytes().await.unwrap();
+
+    let boundary = multer::parse_boundary(&ct).unwrap();
+    let mut mp =
+        multer::Multipart::new(stream::iter(vec![Ok::<_, std::io::Error>(body)]), boundary);
+
+    let f1 = mp.next_field().await.unwrap().unwrap();
+    assert_eq!(f1.name(), Some("greeting"));
+    assert_eq!(f1.text().await.unwrap(), "hello");
+
+    let f2 = mp.next_field().await.unwrap().unwrap();
+    assert_eq!(f2.name(), Some("logo"));
+    assert_eq!(f2.file_name(), Some("logo.bin"));
+    assert_eq!(
+        f2.bytes().await.unwrap(),
+        Bytes::from_static(b"\x01\x02\x03")
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn end_to_end_streaming_response() {
+    let server = TestServer::builder()
+        .setup(|app| {
+            app.map_get("/stream", || async {
+                let chunks = stream::iter(vec![
+                    Ok::<_, volga::error::Error>(Bytes::from_static(b"alpha-")),
+                    Ok(Bytes::from_static(b"beta-")),
+                    Ok(Bytes::from_static(b"gamma")),
+                ]);
+                let part = Part::stream(
+                    "log",
+                    "log.txt",
+                    volga::headers::ContentType::text_utf_8(),
+                    chunks,
+                );
+                Multipart::from_parts(vec![part])
+            });
+        })
+        .build()
+        .await;
+
+    let res = server
+        .client()
+        .get(server.url("/stream"))
+        .send()
+        .await
+        .unwrap();
+    let ct = res
+        .headers()
+        .get("content-type")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_owned();
+    let body = res.bytes().await.unwrap();
+    let boundary = multer::parse_boundary(&ct).unwrap();
+    let mut mp =
+        multer::Multipart::new(stream::iter(vec![Ok::<_, std::io::Error>(body)]), boundary);
+    let f = mp.next_field().await.unwrap().unwrap();
+    assert_eq!(f.text().await.unwrap(), "alpha-beta-gamma");
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn end_to_end_byteranges_subtype() {
+    let server = TestServer::builder()
+        .setup(|app| {
+            app.map_get("/ranges", || async {
+                let part1 = Part::new(b"first" as &[u8])
+                    .with_content_type(volga::headers::ContentType::text_utf_8())
+                    .with_header_raw(
+                        volga::headers::HeaderName::from_static("content-range"),
+                        volga::headers::HeaderValue::from_static("bytes 0-4/10"),
+                    );
+                let part2 = Part::new(b"five!" as &[u8])
+                    .with_content_type(volga::headers::ContentType::text_utf_8())
+                    .with_header_raw(
+                        volga::headers::HeaderName::from_static("content-range"),
+                        volga::headers::HeaderValue::from_static("bytes 5-9/10"),
+                    );
+                Multipart::from_parts(vec![part1, part2]).with_subtype(MultipartSubtype::ByteRanges)
+            });
+        })
+        .build()
+        .await;
+
+    let res = server
+        .client()
+        .get(server.url("/ranges"))
+        .send()
+        .await
+        .unwrap();
+    let ct = res
+        .headers()
+        .get("content-type")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_owned();
+    assert!(ct.starts_with("multipart/byteranges; boundary="));
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn end_to_end_proxy_via_into_outgoing() {
+    let server = TestServer::builder()
+        .setup(|app| {
+            app.map_post("/echo", |mp: Multipart| async move { mp.into_outgoing() });
+        })
+        .build()
+        .await;
+
+    // Build a multipart request body manually
+    let body = b"--CLI-BDY\r\n\
+Content-Disposition: form-data; name=\"x\"\r\n\
+\r\n\
+hello-world\r\n\
+--CLI-BDY--\r\n";
+    let res = server
+        .client()
+        .post(server.url("/echo"))
+        .header("content-type", "multipart/form-data; boundary=CLI-BDY")
+        .body(body.to_vec())
+        .send()
+        .await
+        .unwrap();
+    let ct = res
+        .headers()
+        .get("content-type")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_owned();
+    let bytes = res.bytes().await.unwrap();
+
+    let boundary = multer::parse_boundary(&ct).unwrap();
+    let mut mp =
+        multer::Multipart::new(stream::iter(vec![Ok::<_, std::io::Error>(bytes)]), boundary);
+    let f = mp.next_field().await.unwrap().unwrap();
+    assert_eq!(f.name(), Some("x"));
+    assert_eq!(f.text().await.unwrap(), "hello-world");
+
+    server.shutdown().await;
+}


### PR DESCRIPTION
## Summary
Added ability to respond with multipart bytes, text or file data

## Type
- [ ] Bug fix
- [x] Feature
- [x] Enhancement
- [ ] Performance
- [ ] Documentation
- [ ] Refactor
- [ ] Security
- [ ] Breaking change

## Checklist
- [x] I added/updated tests where it makes sense
- [x] I updated docs/examples if needed
- [x] This change is backwards-compatible (or clearly marked as breaking)
- [x] I ran formatting/lints locally (if applicable)
