### PR TITLE
Manual shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+# 0.9.3
+
+## Added
+* `ShutdownHandle` — programmatic graceful shutdown that composes with the built-in OS signal handler. Construct via `ShutdownHandle::new()`, `ShutdownHandle::from_token(token)` / `From<CancellationToken>`, or `ShutdownHandle::on_signal(future)`. Chain additional async triggers with `handle.shutdown_on(future)`.
+* `App::with_shutdown()` — returns `(App, ShutdownHandle)` for the common case where the framework owns the handle.
+* `App::with_shutdown_signal(handle)` — registers an externally-owned `ShutdownHandle` on an existing `App`.
+
 # 0.9.2
 
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 # 0.9.3
 
 ## Added
-* `ShutdownHandle` — programmatic graceful shutdown that composes with the built-in OS signal handler. Construct via `ShutdownHandle::new()`, `ShutdownHandle::from_token(token)` / `From<CancellationToken>`, or `ShutdownHandle::on_signal(future)`. Chain additional async triggers with `handle.shutdown_on(future)`.
+* `ShutdownHandle` — programmatic graceful shutdown that composes with the built-in OS signal handler. Construct via `ShutdownHandle::new()` or `ShutdownHandle::from_token(token)` / `From<CancellationToken>`. Trigger with `handle.shutdown()`; observe with `handle.is_shutdown_requested()` and `handle.cancelled()`.
 * `App::with_shutdown()` — returns `(App, ShutdownHandle)` for the common case where the framework owns the handle.
 * `App::with_shutdown_signal(handle)` — registers an externally-owned `ShutdownHandle` on an existing `App`.
+* `App::shutdown_on(future)` — chains async triggers (e.g. an external watchdog future) that fire a graceful shutdown when they resolve. Composes with the OS signal handler and any `ShutdownHandle` already registered, and is safe to call before a Tokio runtime exists.
 
 # 0.9.2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.9.2"
+version = "0.9.3"
 license = "MIT"
 edition = "2024"
 rust-version = "1.90.0"
@@ -21,11 +21,11 @@ categories = [
 ]
 
 [workspace.dependencies]
-volga-dev-cert    = { path = "volga-dev-cert",    version = "0.9.2" }
-volga-di          = { path = "volga-di",          version = "0.9.2" }
-volga-macros      = { path = "volga-macros",      version = "0.9.2" }
-volga-open-api    = { path = "volga-open-api",    version = "0.9.2" }
-volga-rate-limiter = { path = "volga-rate-limiter", version = "0.9.2" }
+volga-dev-cert    = { path = "volga-dev-cert",    version = "0.9.3" }
+volga-di          = { path = "volga-di",          version = "0.9.3" }
+volga-macros      = { path = "volga-macros",      version = "0.9.3" }
+volga-open-api    = { path = "volga-open-api",    version = "0.9.3" }
+volga-rate-limiter = { path = "volga-rate-limiter", version = "0.9.3" }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Fast, simple, and high-performance web framework for Rust, built on top of
 Volga is designed to make building HTTP services straightforward and explicit,
 while keeping performance predictable and overhead minimal.
 
-[![latest](https://img.shields.io/badge/latest-0.9.2-blue)](https://crates.io/crates/volga)
+[![latest](https://img.shields.io/badge/latest-0.9.3-blue)](https://crates.io/crates/volga)
 [![latest](https://img.shields.io/badge/rustc-1.90+-964B00)](https://releases.rs/docs/1.90.0/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-violet.svg)](https://github.com/RomanEmreis/volga/blob/main/LICENSE)
 [![Build](https://github.com/RomanEmreis/volga/actions/workflows/rust.yml/badge.svg)](https://github.com/RomanEmreis/volga/actions/workflows/rust.yml)
@@ -46,7 +46,7 @@ Volga is a good fit if you:
 ### Dependencies
 ```toml
 [dependencies]
-volga = "0.9.2"
+volga = "0.9.3"
 tokio = { version = "1", features = ["full"] }
 ```
 ### Simple request handler

--- a/volga/Cargo.toml
+++ b/volga/Cargo.toml
@@ -24,7 +24,7 @@ memchr = "2.8.0"
 mime = "0.3.17"
 mime_guess = "2.0.5"
 pin-project-lite = "0.2.17"
-tokio = { version = "1.52.1", features = ["fs", "io-util", "macros", "net", "rt", "rt-multi-thread", "signal", "sync", "time"] }
+tokio = { version = "1.52.3", features = ["fs", "io-util", "macros", "net", "rt", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-util = "0.7.18"
 serde = "1.0.228"
 serde_json = "1.0.149"

--- a/volga/src/app.rs
+++ b/volga/src/app.rs
@@ -732,7 +732,7 @@ impl App {
     }
 
     #[inline]
-    async fn run_internal(self, tcp_listener: TcpListener) -> io::Result<()> {
+    async fn run_internal(mut self, tcp_listener: TcpListener) -> io::Result<()> {
         #[cfg(all(debug_assertions, feature = "openapi"))]
         if self.openapi.is_configure_but_not_exposed() {
             #[cfg(feature = "tracing")]
@@ -761,6 +761,11 @@ impl App {
 
         let (shutdown_tx, shutdown_rx) = watch::channel::<()>(());
         let shutdown_tx = Arc::new(shutdown_tx);
+
+        if let Some(handle) = self.shutdown_handle.as_mut() {
+            handle.arm_pending();
+        }
+
         Self::shutdown_signal(shutdown_rx, self.shutdown_handle.clone());
 
         #[cfg(feature = "tls")]
@@ -850,9 +855,10 @@ impl App {
             };
             match handle {
                 Some(h) => {
+                    let cancelled = h.token().cancelled_owned();
                     tokio::select! {
                         _ = os => {},
-                        _ = h.cancelled() => {},
+                        _ = cancelled => {},
                     }
                 }
                 None => os.await,

--- a/volga/src/app.rs
+++ b/volga/src/app.rs
@@ -66,6 +66,7 @@ pub use crate::limits::Http2Limits;
 #[cfg(feature = "tls")]
 pub(crate) use app_env::GRACEFUL_SHUTDOWN_TIMEOUT;
 
+use crate::app::shutdown::ShutdownHandle;
 pub(crate) use app_env::AppEnv;
 
 mod app_env;
@@ -76,6 +77,7 @@ mod host_env;
 pub(crate) mod pipeline;
 pub mod router;
 pub(crate) mod scope;
+pub(crate) mod shutdown;
 
 /// The main entry point for building and running a Volga application.
 ///
@@ -199,6 +201,10 @@ pub struct App {
     /// Pre-built config store (populated by `with_config`/`with_default_config`, passed to `AppEnv`)
     #[cfg(feature = "config")]
     pub(crate) config_store: Option<Arc<crate::config::ConfigStore>>,
+
+    /// Optional user-provided shutdown handle that composes with the
+    /// built-in OS signal handler.
+    shutdown_handle: Option<ShutdownHandle>,
 }
 
 impl Default for App {
@@ -258,7 +264,57 @@ impl App {
             openapi: Default::default(),
             #[cfg(feature = "config")]
             config_store: None,
+            shutdown_handle: None,
         }
+    }
+
+    /// Creates a new [`App`] paired with a fresh [`ShutdownHandle`].
+    ///
+    /// The returned handle can be cloned freely. Calling
+    /// [`ShutdownHandle::shutdown`] from anywhere triggers a graceful
+    /// server shutdown that composes with the built-in OS signal
+    /// handler (Ctrl+C, SIGTERM).
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use volga::App;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> std::io::Result<()> {
+    ///     let (app, shutdown) = App::with_shutdown();
+    ///     tokio::spawn(async move {
+    ///         tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+    ///         shutdown.shutdown();
+    ///     });
+    ///     app.run().await
+    /// }
+    /// ```
+    pub fn with_shutdown() -> (Self, ShutdownHandle) {
+        let handle = ShutdownHandle::new();
+        (Self::new().with_shutdown_signal(handle.clone()), handle)
+    }
+
+    /// Registers an external shutdown signal.
+    ///
+    /// The handle is composed with the built-in OS signal handler
+    /// (Ctrl+C, SIGTERM on Unix, or the equivalents on Windows) —
+    /// whichever fires first triggers a graceful shutdown.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use volga::{App, ShutdownHandle};
+    ///
+    /// let handle = ShutdownHandle::new();
+    /// let app = App::new().with_shutdown_signal(handle.clone());
+    /// // Later: handle.shutdown() triggers a graceful shutdown.
+    /// # let _ = app;
+    /// # let _ = handle;
+    /// ```
+    pub fn with_shutdown_signal(mut self, handle: ShutdownHandle) -> Self {
+        self.shutdown_handle = Some(handle);
+        self
     }
 
     /// Returns the current bound socket address.
@@ -705,7 +761,7 @@ impl App {
 
         let (shutdown_tx, shutdown_rx) = watch::channel::<()>(());
         let shutdown_tx = Arc::new(shutdown_tx);
-        Self::shutdown_signal(shutdown_rx);
+        Self::shutdown_signal(shutdown_rx, self.shutdown_handle.clone());
 
         #[cfg(feature = "tls")]
         let redirection_config = self
@@ -784,14 +840,22 @@ impl App {
     }
 
     #[inline]
-    fn shutdown_signal(shutdown_rx: watch::Receiver<()>) {
+    fn shutdown_signal(shutdown_rx: watch::Receiver<()>, handle: Option<ShutdownHandle>) {
         tokio::spawn(async move {
-            match Self::wait_for_shutdown_signal().await {
-                Ok(_) => (),
-                #[cfg(feature = "tracing")]
-                Err(err) => tracing::error!("unable to listen for shutdown signal: {err:#}"),
-                #[cfg(not(feature = "tracing"))]
-                Err(_) => (),
+            let os = async {
+                if let Err(_err) = Self::wait_for_shutdown_signal().await {
+                    #[cfg(feature = "tracing")]
+                    tracing::error!("unable to listen for shutdown signal: {_err:#}");
+                }
+            };
+            match handle {
+                Some(h) => {
+                    tokio::select! {
+                        _ = os => {},
+                        _ = h.cancelled() => {},
+                    }
+                }
+                None => os.await,
             }
             #[cfg(feature = "tracing")]
             tracing::trace!("shutdown signal received, not accepting new requests");

--- a/volga/src/app.rs
+++ b/volga/src/app.rs
@@ -918,28 +918,30 @@ impl App {
 
     #[inline]
     fn shutdown_signal(shutdown_rx: watch::Receiver<()>, handle: Option<ShutdownHandle>) {
+        let token = handle.map(|h| h.token()).unwrap_or_default();
+
+        // OS signal listener — spawned as its own task so it lives
+        // independently of the manual-shutdown path. Tokio's process-wide
+        // signal handlers are installed on first poll and never removed
+        // (see `tokio::signal::ctrl_c` docs), so dropping the polled
+        // signal future when the manual-shutdown path wins would leave
+        // future SIGINT/SIGTERM with no Volga listener. Keeping the
+        // listener alive ensures the next signal is still consumed and
+        // (idempotently) cancels the shared token.
+        let os_token = token.clone();
         tokio::spawn(async move {
-            let os = async {
-                if let Err(_err) = Self::wait_for_shutdown_signal().await {
-                    #[cfg(feature = "tracing")]
-                    tracing::error!("unable to listen for shutdown signal: {_err:#}");
-                }
-            };
-            match handle {
-                Some(h) => {
-                    let cancelled = h.token().cancelled_owned();
-                    tokio::select! {
-                        _ = os => {},
-                        _ = cancelled => {},
-                    }
-                    // Mirror the `shutdown_on` path: ensure the shared
-                    // token is cancelled when the OS arm wins, so external
-                    // observers awaiting `handle.cancelled()` /
-                    // `is_shutdown_requested()` see the signal.
-                    h.shutdown();
-                }
-                None => os.await,
+            if let Err(_err) = Self::wait_for_shutdown_signal().await {
+                #[cfg(feature = "tracing")]
+                tracing::error!("unable to listen for shutdown signal: {_err:#}");
             }
+            os_token.cancel();
+        });
+
+        // Watch the shared token: any source (OS signal, `ShutdownHandle`,
+        // or `App::shutdown_on` trigger) cancels it, and we then drop
+        // `shutdown_rx` to start the accept loop's drain.
+        tokio::spawn(async move {
+            token.cancelled_owned().await;
             #[cfg(feature = "tracing")]
             tracing::trace!("shutdown signal received, not accepting new requests");
             drop(shutdown_rx);

--- a/volga/src/app.rs
+++ b/volga/src/app.rs
@@ -9,7 +9,9 @@ use connection::Connection;
 use hyper_util::rt::TokioIo;
 
 use std::{
+    fmt,
     future::Future,
+    pin::Pin,
     sync::{Arc, Weak},
 };
 
@@ -205,6 +207,24 @@ pub struct App {
     /// Optional user-provided shutdown handle that composes with the
     /// built-in OS signal handler.
     shutdown_handle: Option<ShutdownHandle>,
+
+    /// Async triggers registered via [`App::shutdown_on`]. Drained and
+    /// spawned by [`App::run_internal`] once a Tokio runtime is active.
+    shutdown_triggers: ShutdownTriggers,
+}
+
+/// Async triggers queued via [`App::shutdown_on`]. Wraps a vector of
+/// boxed futures with a manual [`fmt::Debug`] impl, since trait objects
+/// don't implement [`Debug`].
+#[derive(Default)]
+struct ShutdownTriggers(Vec<Pin<Box<dyn Future<Output = ()> + Send + 'static>>>);
+
+impl fmt::Debug for ShutdownTriggers {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ShutdownTriggers")
+            .field("len", &self.0.len())
+            .finish()
+    }
 }
 
 impl Default for App {
@@ -265,6 +285,7 @@ impl App {
             #[cfg(feature = "config")]
             config_store: None,
             shutdown_handle: None,
+            shutdown_triggers: ShutdownTriggers::default(),
         }
     }
 
@@ -314,6 +335,47 @@ impl App {
     /// ```
     pub fn with_shutdown_signal(mut self, handle: ShutdownHandle) -> Self {
         self.shutdown_handle = Some(handle);
+        self
+    }
+
+    /// Registers an async trigger that fires a graceful shutdown when
+    /// the given future resolves.
+    ///
+    /// Multiple `shutdown_on` calls compose — any of the registered
+    /// futures resolving will trigger shutdown. The trigger composes
+    /// with both the OS signal handler and any [`ShutdownHandle`]
+    /// registered via [`App::with_shutdown`] or
+    /// [`App::with_shutdown_signal`]. If no handle has been registered,
+    /// a fresh internal one is created automatically.
+    ///
+    /// The future is spawned onto the Tokio runtime when the app starts
+    /// running, so this method is safe to call before any runtime exists
+    /// (e.g. before [`App::run_blocking`]).
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use volga::App;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> std::io::Result<()> {
+    ///     let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+    ///     let app = App::new()
+    ///         .bind("127.0.0.1:7878")
+    ///         .shutdown_on(async move { let _ = rx.await; });
+    ///     // Sending on `tx` later triggers a graceful shutdown.
+    ///     # let _ = tx;
+    ///     app.run().await
+    /// }
+    /// ```
+    pub fn shutdown_on<F>(mut self, future: F) -> Self
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        if self.shutdown_handle.is_none() {
+            self.shutdown_handle = Some(ShutdownHandle::new());
+        }
+        self.shutdown_triggers.0.push(Box::pin(future));
         self
     }
 
@@ -762,8 +824,18 @@ impl App {
         let (shutdown_tx, shutdown_rx) = watch::channel::<()>(());
         let shutdown_tx = Arc::new(shutdown_tx);
 
-        if let Some(handle) = self.shutdown_handle.as_mut() {
-            handle.arm_pending();
+        // Spawn any async triggers registered via `App::shutdown_on`.
+        // Each trigger cancels the handle's token when it resolves.
+        if !self.shutdown_triggers.0.is_empty() {
+            let handle = self.shutdown_handle.get_or_insert_with(ShutdownHandle::new);
+            let token = handle.token();
+            for trigger in self.shutdown_triggers.0.drain(..) {
+                let token = token.clone();
+                tokio::spawn(async move {
+                    trigger.await;
+                    token.cancel();
+                });
+            }
         }
 
         Self::shutdown_signal(shutdown_rx, self.shutdown_handle.clone());

--- a/volga/src/app.rs
+++ b/volga/src/app.rs
@@ -825,15 +825,19 @@ impl App {
         let shutdown_tx = Arc::new(shutdown_tx);
 
         // Spawn any async triggers registered via `App::shutdown_on`.
-        // Each trigger cancels the handle's token when it resolves.
+        // Each trigger cancels the handle's token when it resolves, and
+        // exits early if another arm cancels the token first — otherwise
+        // an unresolved watchdog future would leak its task after shutdown.
         if !self.shutdown_triggers.0.is_empty() {
             let handle = self.shutdown_handle.get_or_insert_with(ShutdownHandle::new);
             let token = handle.token();
             for trigger in self.shutdown_triggers.0.drain(..) {
                 let token = token.clone();
                 tokio::spawn(async move {
-                    trigger.await;
-                    token.cancel();
+                    tokio::select! {
+                        _ = trigger => token.cancel(),
+                        _ = token.cancelled() => {}
+                    }
                 });
             }
         }

--- a/volga/src/app.rs
+++ b/volga/src/app.rs
@@ -932,6 +932,11 @@ impl App {
                         _ = os => {},
                         _ = cancelled => {},
                     }
+                    // Mirror the `shutdown_on` path: ensure the shared
+                    // token is cancelled when the OS arm wins, so external
+                    // observers awaiting `handle.cancelled()` /
+                    // `is_shutdown_requested()` see the signal.
+                    h.shutdown();
                 }
                 None => os.await,
             }

--- a/volga/src/app/shutdown.rs
+++ b/volga/src/app/shutdown.rs
@@ -3,45 +3,17 @@
 //! Wraps a [`tokio_util::sync::CancellationToken`] so callers can trigger
 //! a graceful server shutdown without sending an OS signal.
 
-use std::fmt;
 use std::future::Future;
-use std::pin::Pin;
 
 use tokio_util::sync::CancellationToken;
-
-type PendingFuture = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
 
 /// A handle that triggers a graceful shutdown of running [`crate::App`].
 ///
 /// Clones share the same shutdown signal — any clone calling
-/// [`ShutdownHandle::shutdown`] cancels the shared token. Each clone
-/// carries its own empty trigger list, so register triggers via
-/// [`ShutdownHandle::shutdown_on`] (or [`ShutdownHandle::on_signal`])
-/// *before* passing the handle to [`crate::App::with_shutdown_signal`].
-#[derive(Default)]
+/// [`ShutdownHandle::shutdown`] cancels the shared token.
+#[derive(Debug, Clone, Default)]
 pub struct ShutdownHandle {
     token: CancellationToken,
-    /// Async triggers registered while no Tokio runtime was active.
-    /// Spawned by [`ShutdownHandle::arm_pending`] once a runtime is available.
-    pending: Vec<PendingFuture>,
-}
-
-impl Clone for ShutdownHandle {
-    fn clone(&self) -> Self {
-        Self {
-            token: self.token.clone(),
-            pending: Vec::new(),
-        }
-    }
-}
-
-impl fmt::Debug for ShutdownHandle {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ShutdownHandle")
-            .field("token", &self.token)
-            .field("pending", &self.pending.len())
-            .finish()
-    }
 }
 
 impl ShutdownHandle {
@@ -49,7 +21,6 @@ impl ShutdownHandle {
     pub fn new() -> Self {
         Self {
             token: CancellationToken::new(),
-            pending: Vec::new(),
         }
     }
 
@@ -58,76 +29,7 @@ impl ShutdownHandle {
     /// Useful for sharing a single shutdown signal with other subsystems
     /// that already use a `CancellationToken`.
     pub fn from_token(token: CancellationToken) -> Self {
-        Self {
-            token,
-            pending: Vec::new(),
-        }
-    }
-
-    /// Builds a handle whose shutdown is triggered when the given
-    /// future resolves. Spawns a background task internally.
-    ///
-    /// # Example
-    ///
-    /// ```no_run
-    /// use volga::ShutdownHandle;
-    ///
-    /// let (tx, rx) = tokio::sync::oneshot::channel::<()>();
-    /// let handle = ShutdownHandle::on_signal(async move {
-    ///     let _ = rx.await;
-    /// });
-    /// // Sending on `tx` later triggers shutdown.
-    /// # let _ = tx;
-    /// # let _ = handle;
-    /// ```
-    pub fn on_signal<F>(future: F) -> Self
-    where
-        F: Future<Output = ()> + Send + 'static,
-    {
-        let mut handle = Self::new();
-        handle.shutdown_on(future);
-        handle
-    }
-
-    /// Adds an additional async trigger to an existing handle.
-    ///
-    /// Multiple `shutdown_on` calls compose — any of the futures
-    /// resolving will trigger shutdown. The underlying [`CancellationToken::cancel`]
-    /// is idempotent, so triggers that fire after shutdown was already
-    /// requested are no-ops.
-    ///
-    /// Safe to call outside a Tokio runtime: when no runtime is active
-    /// the future is queued and spawned automatically once [`crate::App::run`]
-    /// (or [`crate::App::run_blocking`]) enters async context. Register
-    /// triggers *before* cloning or moving the handle into the app —
-    /// each clone starts with an empty trigger list.
-    pub fn shutdown_on<F>(&mut self, future: F)
-    where
-        F: Future<Output = ()> + Send + 'static,
-    {
-        if tokio::runtime::Handle::try_current().is_ok() {
-            let token = self.token.clone();
-            tokio::spawn(async move {
-                future.await;
-                token.cancel();
-            });
-        } else {
-            self.pending.push(Box::pin(future));
-        }
-    }
-
-    /// Spawns any futures registered via [`ShutdownHandle::shutdown_on`]
-    /// while no Tokio runtime was active. Must be called from within a
-    /// runtime; called once by [`crate::App::run`] before the shutdown
-    /// signal task is spawned.
-    pub(crate) fn arm_pending(&mut self) {
-        for future in std::mem::take(&mut self.pending) {
-            let token = self.token.clone();
-            tokio::spawn(async move {
-                future.await;
-                token.cancel();
-            });
-        }
+        Self { token }
     }
 
     /// Triggers a graceful shutdown of the associated server.
@@ -237,81 +139,5 @@ mod tests {
     fn it_yields_a_fresh_handle_when_defaulted() {
         let handle = ShutdownHandle::default();
         assert!(!handle.is_shutdown_requested());
-    }
-
-    #[tokio::test]
-    async fn it_triggers_shutdown_when_on_signal_future_resolves() {
-        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
-        let handle = ShutdownHandle::on_signal(async move {
-            let _ = rx.await;
-        });
-        assert!(!handle.is_shutdown_requested());
-        tx.send(()).unwrap();
-        handle.cancelled().await;
-        assert!(handle.is_shutdown_requested());
-    }
-
-    #[tokio::test]
-    async fn it_composes_multiple_shutdown_on_triggers() {
-        let mut handle = ShutdownHandle::new();
-        let (tx_a, rx_a) = tokio::sync::oneshot::channel::<()>();
-        let (_tx_b, rx_b) = tokio::sync::oneshot::channel::<()>();
-        handle.shutdown_on(async move {
-            let _ = rx_a.await;
-        });
-        handle.shutdown_on(async move {
-            let _ = rx_b.await;
-        });
-        assert!(!handle.is_shutdown_requested());
-        // Firing only one trigger is enough.
-        tx_a.send(()).unwrap();
-        handle.cancelled().await;
-        assert!(handle.is_shutdown_requested());
-    }
-
-    #[tokio::test]
-    async fn it_treats_shutdown_on_after_cancel_as_noop() {
-        let mut handle = ShutdownHandle::new();
-        handle.shutdown();
-        // The trigger future is allowed to run but cancel() is a no-op.
-        handle.shutdown_on(async {});
-        // Yield to let the spawned task execute and call cancel() on the already-cancelled token.
-        tokio::task::yield_now().await;
-        assert!(handle.is_shutdown_requested());
-    }
-
-    #[test]
-    fn it_does_not_panic_when_shutdown_on_is_called_without_runtime() {
-        let mut handle = ShutdownHandle::new();
-        handle.shutdown_on(async {});
-        assert!(!handle.is_shutdown_requested());
-    }
-
-    #[test]
-    fn it_does_not_panic_when_on_signal_is_called_without_runtime() {
-        let _handle = ShutdownHandle::on_signal(async {});
-    }
-
-    #[test]
-    fn it_arms_pending_triggers_once_runtime_starts() {
-        let mut handle = ShutdownHandle::new();
-        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
-        // Registered outside a runtime — must be queued.
-        handle.shutdown_on(async move {
-            let _ = rx.await;
-        });
-        assert!(!handle.is_shutdown_requested());
-
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap();
-
-        rt.block_on(async {
-            handle.arm_pending();
-            tx.send(()).unwrap();
-            handle.cancelled().await;
-        });
-        assert!(handle.is_shutdown_requested());
     }
 }

--- a/volga/src/app/shutdown.rs
+++ b/volga/src/app/shutdown.rs
@@ -1,0 +1,228 @@
+//! Programmatic shutdown handle for [`crate::App`].
+//!
+//! Wraps a [`tokio_util::sync::CancellationToken`] so callers can trigger
+//! a graceful server shutdown without sending an OS signal.
+
+use std::future::Future;
+
+use tokio_util::sync::CancellationToken;
+
+/// A handle that triggers a graceful shutdown of a running [`crate::App`].
+///
+/// Cloning a handle yields another reference to the same shutdown signal —
+/// any clone calling [`ShutdownHandle::shutdown`] cancels the shared token.
+#[derive(Debug, Clone, Default)]
+pub struct ShutdownHandle {
+    token: CancellationToken,
+}
+
+impl ShutdownHandle {
+    /// Creates a new handle backed by a fresh [`CancellationToken`].
+    pub fn new() -> Self {
+        Self {
+            token: CancellationToken::new(),
+        }
+    }
+
+    /// Wraps an existing [`CancellationToken`].
+    ///
+    /// Useful for sharing a single shutdown signal with other subsystems
+    /// that already use a `CancellationToken`.
+    pub fn from_token(token: CancellationToken) -> Self {
+        Self { token }
+    }
+
+    /// Builds a handle whose shutdown is triggered when the given
+    /// future resolves. Spawns a background task internally.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use volga::ShutdownHandle;
+    ///
+    /// let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+    /// let handle = ShutdownHandle::on_signal(async move {
+    ///     let _ = rx.await;
+    /// });
+    /// // Sending on `tx` later triggers shutdown.
+    /// # let _ = tx;
+    /// # let _ = handle;
+    /// ```
+    pub fn on_signal<F>(future: F) -> Self
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        let handle = Self::new();
+        handle.shutdown_on(future);
+        handle
+    }
+
+    /// Adds an additional async trigger to an existing handle.
+    ///
+    /// Multiple `shutdown_on` calls compose — any of the futures
+    /// resolving will trigger shutdown. The underlying [`CancellationToken::cancel`]
+    /// is idempotent, so triggers that fire after shutdown was already
+    /// requested are no-ops.
+    pub fn shutdown_on<F>(&self, future: F)
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        let token = self.token.clone();
+        tokio::spawn(async move {
+            future.await;
+            token.cancel();
+        });
+    }
+
+    /// Triggers a graceful shutdown of the associated server.
+    ///
+    /// Idempotent — repeated calls are no-ops. The server will stop
+    /// accepting new connections and drain in-flight requests up to
+    /// the configured graceful-shutdown timeout.
+    pub fn shutdown(&self) {
+        self.token.cancel();
+    }
+
+    /// Returns `true` if a shutdown has been requested.
+    ///
+    /// Note this reports only that the trigger fired — the server may
+    /// still be draining in-flight requests.
+    pub fn is_shutdown_requested(&self) -> bool {
+        self.token.is_cancelled()
+    }
+
+    /// Resolves when shutdown has been requested.
+    ///
+    /// The returned future borrows `self`. For an owned future suitable
+    /// for passing to [`tokio::spawn`] without cloning the handle, use
+    /// `handle.token().cancelled_owned()`.
+    pub async fn cancelled(&self) {
+        self.token.cancelled().await;
+    }
+
+    /// Returns a clone of the underlying [`CancellationToken`] for
+    /// interop with the `tokio-util` ecosystem.
+    pub fn token(&self) -> CancellationToken {
+        self.token.clone()
+    }
+}
+
+impl From<CancellationToken> for ShutdownHandle {
+    fn from(token: CancellationToken) -> Self {
+        Self::from_token(token)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_starts_in_not_shutdown_state() {
+        let handle = ShutdownHandle::new();
+        assert!(!handle.is_shutdown_requested());
+    }
+
+    #[test]
+    fn it_reports_shutdown_after_trigger() {
+        let handle = ShutdownHandle::new();
+        handle.shutdown();
+        assert!(handle.is_shutdown_requested());
+    }
+
+    #[test]
+    fn it_is_idempotent_on_repeated_shutdown() {
+        let handle = ShutdownHandle::new();
+        handle.shutdown();
+        handle.shutdown();
+        assert!(handle.is_shutdown_requested());
+    }
+
+    #[test]
+    fn it_shares_state_across_clones() {
+        let original = ShutdownHandle::new();
+        let cloned = original.clone();
+        cloned.shutdown();
+        assert!(original.is_shutdown_requested());
+    }
+
+    #[tokio::test]
+    async fn it_resolves_cancelled_after_shutdown() {
+        let handle = ShutdownHandle::new();
+        let waiter = handle.clone();
+        let task = tokio::spawn(async move { waiter.cancelled().await });
+        handle.shutdown();
+        task.await.unwrap();
+    }
+
+    #[test]
+    fn it_returns_a_clone_of_the_underlying_token() {
+        let handle = ShutdownHandle::new();
+        let token = handle.token();
+        token.cancel();
+        assert!(handle.is_shutdown_requested());
+    }
+
+    #[test]
+    fn it_constructs_from_existing_token() {
+        let token = CancellationToken::new();
+        let handle = ShutdownHandle::from_token(token.clone());
+        token.cancel();
+        assert!(handle.is_shutdown_requested());
+    }
+
+    #[test]
+    fn it_constructs_via_from_impl() {
+        let token = CancellationToken::new();
+        let handle: ShutdownHandle = token.clone().into();
+        token.cancel();
+        assert!(handle.is_shutdown_requested());
+    }
+
+    #[test]
+    fn it_yields_a_fresh_handle_when_defaulted() {
+        let handle = ShutdownHandle::default();
+        assert!(!handle.is_shutdown_requested());
+    }
+
+    #[tokio::test]
+    async fn it_triggers_shutdown_when_on_signal_future_resolves() {
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let handle = ShutdownHandle::on_signal(async move {
+            let _ = rx.await;
+        });
+        assert!(!handle.is_shutdown_requested());
+        tx.send(()).unwrap();
+        handle.cancelled().await;
+        assert!(handle.is_shutdown_requested());
+    }
+
+    #[tokio::test]
+    async fn it_composes_multiple_shutdown_on_triggers() {
+        let handle = ShutdownHandle::new();
+        let (tx_a, rx_a) = tokio::sync::oneshot::channel::<()>();
+        let (_tx_b, rx_b) = tokio::sync::oneshot::channel::<()>();
+        handle.shutdown_on(async move {
+            let _ = rx_a.await;
+        });
+        handle.shutdown_on(async move {
+            let _ = rx_b.await;
+        });
+        assert!(!handle.is_shutdown_requested());
+        // Firing only one trigger is enough.
+        tx_a.send(()).unwrap();
+        handle.cancelled().await;
+        assert!(handle.is_shutdown_requested());
+    }
+
+    #[tokio::test]
+    async fn it_treats_shutdown_on_after_cancel_as_noop() {
+        let handle = ShutdownHandle::new();
+        handle.shutdown();
+        // The trigger future is allowed to run but cancel() is a no-op.
+        handle.shutdown_on(async {});
+        // Yield to let the spawned task execute and call cancel() on the already-cancelled token.
+        tokio::task::yield_now().await;
+        assert!(handle.is_shutdown_requested());
+    }
+}

--- a/volga/src/app/shutdown.rs
+++ b/volga/src/app/shutdown.rs
@@ -3,17 +3,45 @@
 //! Wraps a [`tokio_util::sync::CancellationToken`] so callers can trigger
 //! a graceful server shutdown without sending an OS signal.
 
+use std::fmt;
 use std::future::Future;
+use std::pin::Pin;
 
 use tokio_util::sync::CancellationToken;
 
-/// A handle that triggers a graceful shutdown of a running [`crate::App`].
+type PendingFuture = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
+
+/// A handle that triggers a graceful shutdown of running [`crate::App`].
 ///
-/// Cloning a handle yields another reference to the same shutdown signal —
-/// any clone calling [`ShutdownHandle::shutdown`] cancels the shared token.
-#[derive(Debug, Clone, Default)]
+/// Clones share the same shutdown signal — any clone calling
+/// [`ShutdownHandle::shutdown`] cancels the shared token. Each clone
+/// carries its own empty trigger list, so register triggers via
+/// [`ShutdownHandle::shutdown_on`] (or [`ShutdownHandle::on_signal`])
+/// *before* passing the handle to [`crate::App::with_shutdown_signal`].
+#[derive(Default)]
 pub struct ShutdownHandle {
     token: CancellationToken,
+    /// Async triggers registered while no Tokio runtime was active.
+    /// Spawned by [`ShutdownHandle::arm_pending`] once a runtime is available.
+    pending: Vec<PendingFuture>,
+}
+
+impl Clone for ShutdownHandle {
+    fn clone(&self) -> Self {
+        Self {
+            token: self.token.clone(),
+            pending: Vec::new(),
+        }
+    }
+}
+
+impl fmt::Debug for ShutdownHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ShutdownHandle")
+            .field("token", &self.token)
+            .field("pending", &self.pending.len())
+            .finish()
+    }
 }
 
 impl ShutdownHandle {
@@ -21,6 +49,7 @@ impl ShutdownHandle {
     pub fn new() -> Self {
         Self {
             token: CancellationToken::new(),
+            pending: Vec::new(),
         }
     }
 
@@ -29,7 +58,10 @@ impl ShutdownHandle {
     /// Useful for sharing a single shutdown signal with other subsystems
     /// that already use a `CancellationToken`.
     pub fn from_token(token: CancellationToken) -> Self {
-        Self { token }
+        Self {
+            token,
+            pending: Vec::new(),
+        }
     }
 
     /// Builds a handle whose shutdown is triggered when the given
@@ -52,7 +84,7 @@ impl ShutdownHandle {
     where
         F: Future<Output = ()> + Send + 'static,
     {
-        let handle = Self::new();
+        let mut handle = Self::new();
         handle.shutdown_on(future);
         handle
     }
@@ -63,15 +95,39 @@ impl ShutdownHandle {
     /// resolving will trigger shutdown. The underlying [`CancellationToken::cancel`]
     /// is idempotent, so triggers that fire after shutdown was already
     /// requested are no-ops.
-    pub fn shutdown_on<F>(&self, future: F)
+    ///
+    /// Safe to call outside a Tokio runtime: when no runtime is active
+    /// the future is queued and spawned automatically once [`crate::App::run`]
+    /// (or [`crate::App::run_blocking`]) enters async context. Register
+    /// triggers *before* cloning or moving the handle into the app —
+    /// each clone starts with an empty trigger list.
+    pub fn shutdown_on<F>(&mut self, future: F)
     where
         F: Future<Output = ()> + Send + 'static,
     {
-        let token = self.token.clone();
-        tokio::spawn(async move {
-            future.await;
-            token.cancel();
-        });
+        if tokio::runtime::Handle::try_current().is_ok() {
+            let token = self.token.clone();
+            tokio::spawn(async move {
+                future.await;
+                token.cancel();
+            });
+        } else {
+            self.pending.push(Box::pin(future));
+        }
+    }
+
+    /// Spawns any futures registered via [`ShutdownHandle::shutdown_on`]
+    /// while no Tokio runtime was active. Must be called from within a
+    /// runtime; called once by [`crate::App::run`] before the shutdown
+    /// signal task is spawned.
+    pub(crate) fn arm_pending(&mut self) {
+        for future in std::mem::take(&mut self.pending) {
+            let token = self.token.clone();
+            tokio::spawn(async move {
+                future.await;
+                token.cancel();
+            });
+        }
     }
 
     /// Triggers a graceful shutdown of the associated server.
@@ -91,13 +147,11 @@ impl ShutdownHandle {
         self.token.is_cancelled()
     }
 
-    /// Resolves when shutdown has been requested.
-    ///
-    /// The returned future borrows `self`. For an owned future suitable
-    /// for passing to [`tokio::spawn`] without cloning the handle, use
-    /// `handle.token().cancelled_owned()`.
-    pub async fn cancelled(&self) {
-        self.token.cancelled().await;
+    /// Returns a `'static` future that resolves when shutdown has been
+    /// requested. Suitable for passing to [`tokio::spawn`] without
+    /// cloning the handle.
+    pub fn cancelled(&self) -> impl Future<Output = ()> + Send + 'static {
+        self.token.clone().cancelled_owned()
     }
 
     /// Returns a clone of the underlying [`CancellationToken`] for
@@ -199,7 +253,7 @@ mod tests {
 
     #[tokio::test]
     async fn it_composes_multiple_shutdown_on_triggers() {
-        let handle = ShutdownHandle::new();
+        let mut handle = ShutdownHandle::new();
         let (tx_a, rx_a) = tokio::sync::oneshot::channel::<()>();
         let (_tx_b, rx_b) = tokio::sync::oneshot::channel::<()>();
         handle.shutdown_on(async move {
@@ -217,12 +271,47 @@ mod tests {
 
     #[tokio::test]
     async fn it_treats_shutdown_on_after_cancel_as_noop() {
-        let handle = ShutdownHandle::new();
+        let mut handle = ShutdownHandle::new();
         handle.shutdown();
         // The trigger future is allowed to run but cancel() is a no-op.
         handle.shutdown_on(async {});
         // Yield to let the spawned task execute and call cancel() on the already-cancelled token.
         tokio::task::yield_now().await;
+        assert!(handle.is_shutdown_requested());
+    }
+
+    #[test]
+    fn it_does_not_panic_when_shutdown_on_is_called_without_runtime() {
+        let mut handle = ShutdownHandle::new();
+        handle.shutdown_on(async {});
+        assert!(!handle.is_shutdown_requested());
+    }
+
+    #[test]
+    fn it_does_not_panic_when_on_signal_is_called_without_runtime() {
+        let _handle = ShutdownHandle::on_signal(async {});
+    }
+
+    #[test]
+    fn it_arms_pending_triggers_once_runtime_starts() {
+        let mut handle = ShutdownHandle::new();
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        // Registered outside a runtime — must be queued.
+        handle.shutdown_on(async move {
+            let _ = rx.await;
+        });
+        assert!(!handle.is_shutdown_requested());
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        rt.block_on(async {
+            handle.arm_pending();
+            tx.send(()).unwrap();
+            handle.cancelled().await;
+        });
         assert!(handle.is_shutdown_requested());
     }
 }

--- a/volga/src/lib.rs
+++ b/volga/src/lib.rs
@@ -66,6 +66,7 @@ pub mod utils;
 pub mod ws;
 
 pub use crate::app::App;
+pub use crate::app::shutdown::ShutdownHandle;
 pub use crate::http::{
     BoxBody, HttpBody, HttpRequest, HttpResponse, HttpResult, UnsyncBoxBody,
     endpoints::args::{

--- a/volga/tests/shutdown_tests.rs
+++ b/volga/tests/shutdown_tests.rs
@@ -13,11 +13,20 @@ fn pick_free_port() -> u16 {
         .port()
 }
 
-async fn wait_until_listening(port: u16) {
+/// A `reqwest::Client` with proxies disabled, so localhost probes are
+/// not redirected by HTTP(S)_PROXY env vars set in the test environment.
+fn local_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("failed to build reqwest client")
+}
+
+async fn wait_until_listening(client: &reqwest::Client, port: u16) {
     let deadline = Instant::now() + Duration::from_secs(5);
     let url = format!("http://127.0.0.1:{port}/ping");
     while Instant::now() < deadline {
-        if reqwest::get(&url).await.is_ok() {
+        if client.get(&url).send().await.is_ok() {
             return;
         }
         tokio::time::sleep(Duration::from_millis(20)).await;
@@ -38,9 +47,12 @@ async fn manual_shutdown_stops_a_running_server() {
     let (app, handle) = build_app(port);
     let task = tokio::spawn(async move { app.run().await });
 
-    wait_until_listening(port).await;
+    let client = local_client();
+    wait_until_listening(&client, port).await;
 
-    let response = reqwest::get(format!("http://127.0.0.1:{port}/ping"))
+    let response = client
+        .get(format!("http://127.0.0.1:{port}/ping"))
+        .send()
         .await
         .unwrap();
     assert!(response.status().is_success());
@@ -60,7 +72,7 @@ async fn shutdown_is_idempotent_with_a_running_server() {
     let (app, handle) = build_app(port);
     let task = tokio::spawn(async move { app.run().await });
 
-    wait_until_listening(port).await;
+    wait_until_listening(&local_client(), port).await;
 
     handle.shutdown();
     handle.shutdown(); // second call must be a no-op
@@ -86,7 +98,7 @@ async fn shutdown_on_drives_server_shutdown() {
     app.map_get("/ping", || async { ok!("pong") });
     let task = tokio::spawn(async move { app.run().await });
 
-    wait_until_listening(port).await;
+    wait_until_listening(&local_client(), port).await;
 
     signal_tx.send(()).unwrap();
 
@@ -115,7 +127,7 @@ async fn shutdown_on_chained_triggers_compose() {
     app.map_get("/ping", || async { ok!("pong") });
     let task = tokio::spawn(async move { app.run().await });
 
-    wait_until_listening(port).await;
+    wait_until_listening(&local_client(), port).await;
 
     // Firing only the first trigger is enough.
     tx_a.send(()).unwrap();
@@ -142,7 +154,7 @@ async fn shutdown_on_composes_with_with_shutdown_handle() {
     app.map_get("/ping", || async { ok!("pong") });
     let task = tokio::spawn(async move { app.run().await });
 
-    wait_until_listening(port).await;
+    wait_until_listening(&local_client(), port).await;
 
     // Firing the trigger should cancel the handle's shared token.
     signal_tx.send(()).unwrap();
@@ -171,7 +183,7 @@ async fn from_cancellation_token_drives_server_shutdown() {
     app.map_get("/ping", || async { ok!("pong") });
     let task = tokio::spawn(async move { app.run().await });
 
-    wait_until_listening(port).await;
+    wait_until_listening(&local_client(), port).await;
 
     token.cancel();
 
@@ -204,10 +216,13 @@ async fn shutdown_drains_in_flight_requests() {
     app.map_get("/ping", || async { ok!("pong") });
     let task = tokio::spawn(async move { app.run().await });
 
-    wait_until_listening(port).await;
+    let client = local_client();
+    wait_until_listening(&client, port).await;
 
     let request = tokio::spawn(async move {
-        reqwest::get(format!("http://127.0.0.1:{port}/slow"))
+        client
+            .get(format!("http://127.0.0.1:{port}/slow"))
+            .send()
             .await
             .unwrap()
     });

--- a/volga/tests/shutdown_tests.rs
+++ b/volga/tests/shutdown_tests.rs
@@ -101,7 +101,7 @@ async fn on_signal_constructor_drives_server_shutdown() {
 #[tokio::test]
 async fn shutdown_on_chained_triggers_compose() {
     let port = pick_free_port();
-    let handle = ShutdownHandle::new();
+    let mut handle = ShutdownHandle::new();
     let (tx_a, rx_a) = tokio::sync::oneshot::channel::<()>();
     let (_tx_b, rx_b) = tokio::sync::oneshot::channel::<()>();
     handle.shutdown_on(async move {
@@ -112,7 +112,7 @@ async fn shutdown_on_chained_triggers_compose() {
     });
 
     let mut app = App::new()
-        .with_shutdown_signal(handle.clone())
+        .with_shutdown_signal(handle)
         .bind(format!("127.0.0.1:{port}"))
         .without_greeter();
     app.map_get("/ping", || async { ok!("pong") });

--- a/volga/tests/shutdown_tests.rs
+++ b/volga/tests/shutdown_tests.rs
@@ -73,17 +73,16 @@ async fn shutdown_is_idempotent_with_a_running_server() {
 }
 
 #[tokio::test]
-async fn on_signal_constructor_drives_server_shutdown() {
+async fn shutdown_on_drives_server_shutdown() {
     let port = pick_free_port();
     let (signal_tx, signal_rx) = tokio::sync::oneshot::channel::<()>();
-    let handle = ShutdownHandle::on_signal(async move {
-        let _ = signal_rx.await;
-    });
 
     let mut app = App::new()
-        .with_shutdown_signal(handle)
         .bind(format!("127.0.0.1:{port}"))
-        .without_greeter();
+        .without_greeter()
+        .shutdown_on(async move {
+            let _ = signal_rx.await;
+        });
     app.map_get("/ping", || async { ok!("pong") });
     let task = tokio::spawn(async move { app.run().await });
 
@@ -93,7 +92,7 @@ async fn on_signal_constructor_drives_server_shutdown() {
 
     tokio::time::timeout(Duration::from_secs(5), task)
         .await
-        .expect("server did not exit after on_signal trigger")
+        .expect("server did not exit after shutdown_on trigger")
         .expect("server task panicked")
         .expect("server returned an error");
 }
@@ -101,20 +100,18 @@ async fn on_signal_constructor_drives_server_shutdown() {
 #[tokio::test]
 async fn shutdown_on_chained_triggers_compose() {
     let port = pick_free_port();
-    let mut handle = ShutdownHandle::new();
     let (tx_a, rx_a) = tokio::sync::oneshot::channel::<()>();
     let (_tx_b, rx_b) = tokio::sync::oneshot::channel::<()>();
-    handle.shutdown_on(async move {
-        let _ = rx_a.await;
-    });
-    handle.shutdown_on(async move {
-        let _ = rx_b.await;
-    });
 
     let mut app = App::new()
-        .with_shutdown_signal(handle)
         .bind(format!("127.0.0.1:{port}"))
-        .without_greeter();
+        .without_greeter()
+        .shutdown_on(async move {
+            let _ = rx_a.await;
+        })
+        .shutdown_on(async move {
+            let _ = rx_b.await;
+        });
     app.map_get("/ping", || async { ok!("pong") });
     let task = tokio::spawn(async move { app.run().await });
 
@@ -128,6 +125,35 @@ async fn shutdown_on_chained_triggers_compose() {
         .expect("server did not exit after first trigger")
         .expect("server task panicked")
         .expect("server returned an error");
+}
+
+#[tokio::test]
+async fn shutdown_on_composes_with_with_shutdown_handle() {
+    let port = pick_free_port();
+    let (signal_tx, signal_rx) = tokio::sync::oneshot::channel::<()>();
+    let (app, handle) = App::with_shutdown();
+
+    let mut app = app
+        .bind(format!("127.0.0.1:{port}"))
+        .without_greeter()
+        .shutdown_on(async move {
+            let _ = signal_rx.await;
+        });
+    app.map_get("/ping", || async { ok!("pong") });
+    let task = tokio::spawn(async move { app.run().await });
+
+    wait_until_listening(port).await;
+
+    // Firing the trigger should cancel the handle's shared token.
+    signal_tx.send(()).unwrap();
+
+    tokio::time::timeout(Duration::from_secs(5), task)
+        .await
+        .expect("server did not exit after shutdown_on trigger")
+        .expect("server task panicked")
+        .expect("server returned an error");
+
+    assert!(handle.is_shutdown_requested());
 }
 
 #[tokio::test]

--- a/volga/tests/shutdown_tests.rs
+++ b/volga/tests/shutdown_tests.rs
@@ -1,0 +1,213 @@
+#![allow(missing_docs)]
+#![cfg(feature = "test")]
+
+use std::time::{Duration, Instant};
+
+use volga::{App, ShutdownHandle, ok};
+
+fn pick_free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+async fn wait_until_listening(port: u16) {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let url = format!("http://127.0.0.1:{port}/ping");
+    while Instant::now() < deadline {
+        if reqwest::get(&url).await.is_ok() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("server never started listening on port {port}");
+}
+
+fn build_app(port: u16) -> (App, ShutdownHandle) {
+    let (app, handle) = App::with_shutdown();
+    let mut app = app.bind(format!("127.0.0.1:{port}")).without_greeter();
+    app.map_get("/ping", || async { ok!("pong") });
+    (app, handle)
+}
+
+#[tokio::test]
+async fn manual_shutdown_stops_a_running_server() {
+    let port = pick_free_port();
+    let (app, handle) = build_app(port);
+    let task = tokio::spawn(async move { app.run().await });
+
+    wait_until_listening(port).await;
+
+    let response = reqwest::get(format!("http://127.0.0.1:{port}/ping"))
+        .await
+        .unwrap();
+    assert!(response.status().is_success());
+
+    handle.shutdown();
+
+    let result = tokio::time::timeout(Duration::from_secs(5), task)
+        .await
+        .expect("server did not exit after shutdown")
+        .expect("server task panicked");
+    result.expect("server returned an error");
+}
+
+#[tokio::test]
+async fn shutdown_is_idempotent_with_a_running_server() {
+    let port = pick_free_port();
+    let (app, handle) = build_app(port);
+    let task = tokio::spawn(async move { app.run().await });
+
+    wait_until_listening(port).await;
+
+    handle.shutdown();
+    handle.shutdown(); // second call must be a no-op
+
+    let result = tokio::time::timeout(Duration::from_secs(5), task)
+        .await
+        .expect("server did not exit after shutdown")
+        .expect("server task panicked");
+    result.expect("server returned an error");
+}
+
+#[tokio::test]
+async fn on_signal_constructor_drives_server_shutdown() {
+    let port = pick_free_port();
+    let (signal_tx, signal_rx) = tokio::sync::oneshot::channel::<()>();
+    let handle = ShutdownHandle::on_signal(async move {
+        let _ = signal_rx.await;
+    });
+
+    let mut app = App::new()
+        .with_shutdown_signal(handle)
+        .bind(format!("127.0.0.1:{port}"))
+        .without_greeter();
+    app.map_get("/ping", || async { ok!("pong") });
+    let task = tokio::spawn(async move { app.run().await });
+
+    wait_until_listening(port).await;
+
+    signal_tx.send(()).unwrap();
+
+    tokio::time::timeout(Duration::from_secs(5), task)
+        .await
+        .expect("server did not exit after on_signal trigger")
+        .expect("server task panicked")
+        .expect("server returned an error");
+}
+
+#[tokio::test]
+async fn shutdown_on_chained_triggers_compose() {
+    let port = pick_free_port();
+    let handle = ShutdownHandle::new();
+    let (tx_a, rx_a) = tokio::sync::oneshot::channel::<()>();
+    let (_tx_b, rx_b) = tokio::sync::oneshot::channel::<()>();
+    handle.shutdown_on(async move {
+        let _ = rx_a.await;
+    });
+    handle.shutdown_on(async move {
+        let _ = rx_b.await;
+    });
+
+    let mut app = App::new()
+        .with_shutdown_signal(handle.clone())
+        .bind(format!("127.0.0.1:{port}"))
+        .without_greeter();
+    app.map_get("/ping", || async { ok!("pong") });
+    let task = tokio::spawn(async move { app.run().await });
+
+    wait_until_listening(port).await;
+
+    // Firing only the first trigger is enough.
+    tx_a.send(()).unwrap();
+
+    tokio::time::timeout(Duration::from_secs(5), task)
+        .await
+        .expect("server did not exit after first trigger")
+        .expect("server task panicked")
+        .expect("server returned an error");
+}
+
+#[tokio::test]
+async fn from_cancellation_token_drives_server_shutdown() {
+    use tokio_util::sync::CancellationToken;
+
+    let port = pick_free_port();
+    let token = CancellationToken::new();
+    let handle: ShutdownHandle = token.clone().into();
+
+    let mut app = App::new()
+        .with_shutdown_signal(handle)
+        .bind(format!("127.0.0.1:{port}"))
+        .without_greeter();
+    app.map_get("/ping", || async { ok!("pong") });
+    let task = tokio::spawn(async move { app.run().await });
+
+    wait_until_listening(port).await;
+
+    token.cancel();
+
+    tokio::time::timeout(Duration::from_secs(5), task)
+        .await
+        .expect("server did not exit after cancel on outer token")
+        .expect("server task panicked")
+        .expect("server returned an error");
+}
+
+#[tokio::test]
+async fn shutdown_drains_in_flight_requests() {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    let port = pick_free_port();
+    let (app, handle) = App::with_shutdown();
+    let started = Arc::new(AtomicBool::new(false));
+    let started_for_handler = Arc::clone(&started);
+
+    let mut app = app.bind(format!("127.0.0.1:{port}")).without_greeter();
+    app.map_get("/slow", move || {
+        let started = Arc::clone(&started_for_handler);
+        async move {
+            started.store(true, Ordering::SeqCst);
+            tokio::time::sleep(Duration::from_millis(300)).await;
+            ok!("done")
+        }
+    });
+    app.map_get("/ping", || async { ok!("pong") });
+    let task = tokio::spawn(async move { app.run().await });
+
+    wait_until_listening(port).await;
+
+    let request = tokio::spawn(async move {
+        reqwest::get(format!("http://127.0.0.1:{port}/slow"))
+            .await
+            .unwrap()
+    });
+
+    // Wait until the slow handler is actually executing.
+    let started_deadline = Instant::now() + Duration::from_secs(5);
+    while !started.load(Ordering::SeqCst) {
+        assert!(
+            Instant::now() < started_deadline,
+            "/slow handler did not start within 5s"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    handle.shutdown();
+
+    let response = tokio::time::timeout(Duration::from_secs(5), request)
+        .await
+        .expect("in-flight request did not finish")
+        .expect("request task panicked");
+    assert!(response.status().is_success());
+    assert_eq!(response.text().await.unwrap(), "done");
+
+    tokio::time::timeout(Duration::from_secs(5), task)
+        .await
+        .expect("server did not exit after drain")
+        .expect("server task panicked")
+        .expect("server returned an error");
+}

--- a/volga/tests/shutdown_tests.rs
+++ b/volga/tests/shutdown_tests.rs
@@ -140,6 +140,63 @@ async fn shutdown_on_chained_triggers_compose() {
 }
 
 #[tokio::test]
+async fn shutdown_on_remaining_triggers_release_after_shutdown() {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    let port = pick_free_port();
+    let (tx_a, rx_a) = tokio::sync::oneshot::channel::<()>();
+    // The second trigger never resolves on its own — it's a watchdog future.
+    // The trigger task wraps it in a `select!` against the shared token,
+    // so when trigger A cancels, this future is *dropped*, which fires
+    // `dropped` via the `Drop` impl below.
+    let dropped = Arc::new(AtomicBool::new(false));
+    let dropped_for_future = Arc::clone(&dropped);
+
+    struct DropFlag(Arc<AtomicBool>);
+    impl Drop for DropFlag {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    let watchdog = async move {
+        let _flag = DropFlag(dropped_for_future);
+        std::future::pending::<()>().await;
+    };
+
+    let mut app = App::new()
+        .bind(format!("127.0.0.1:{port}"))
+        .without_greeter()
+        .shutdown_on(async move {
+            let _ = rx_a.await;
+        })
+        .shutdown_on(watchdog);
+    app.map_get("/ping", || async { ok!("pong") });
+    let task = tokio::spawn(async move { app.run().await });
+
+    wait_until_listening(&local_client(), port).await;
+
+    tx_a.send(()).unwrap();
+
+    tokio::time::timeout(Duration::from_secs(5), task)
+        .await
+        .expect("server did not exit after trigger")
+        .expect("server task panicked")
+        .expect("server returned an error");
+
+    // Give the task scheduler a tick to drop the unresolved trigger.
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while !dropped.load(Ordering::SeqCst) {
+        assert!(
+            Instant::now() < deadline,
+            "remaining shutdown_on trigger was not dropped after shutdown"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+#[tokio::test]
 async fn shutdown_on_composes_with_with_shutdown_handle() {
     let port = pick_free_port();
     let (signal_tx, signal_rx) = tokio::sync::oneshot::channel::<()>();


### PR DESCRIPTION
## Summary
  Adds a `ShutdownHandle` API for programmatic graceful shutdown that composes with the existing OS signal handler (Ctrl+C, SIGTERM). Users can now stop a running server from inside
  their own code — an `/admin/shutdown` route, an external IPC, a custom orchestrator, or integration tests that don't use `TestServer` — without having to send themselves a signal.     
                                                                                                                                                                                          
  The handle is a thin newtype around `tokio_util::sync::CancellationToken` (already a workspace dependency, already re-exported as `volga::CancellationToken`). Two ways to use it:      
                                                                                                                                                                                          
  ```rust                                                                                                                                                                                 
  // Framework owns the handle.
  let (app, shutdown) = App::with_shutdown();
  
  // Or bring your own.
  let handle = ShutdownHandle::new(); // also: from_token, on_signal, From<CancellationToken>
  let app = App::new().with_shutdown_signal(handle.clone()); 
```
                                                                                                                                                                                          
  Internally the existing `tokio::sync::watch::channel<()>` shutdown bus is unchanged — `shutdown_signal()` just races the OS signal against `handle.cancelled()`, and either path drains in-flight requests via the same code as Ctrl+C today. 

## Type
- [ ] Bug fix
- [x] Feature
- [x] Enhancement
- [ ] Performance
- [ ] Documentation
- [ ] Refactor
- [ ] Security
- [ ] Breaking change

## Checklist
- [x] I added/updated tests where it makes sense
- [x] I updated docs/examples if needed
- [x] This change is backwards-compatible (or clearly marked as breaking)
- [x] I ran formatting/lints locally (if applicable)

## Notes for reviewers
  - Composition, not replacement. `with_shutdown_signal` adds a trigger; the OS signal handler is always still active. There's no opt-out yet — if a use case appears, that's a follow-up.  
  - Graceful only. No `shutdown_now()` / hard-kill variant. Easy to add later without breaking the current API.
  - `shutdown_on` task lifetime. Each `shutdown_on(future)` spawns a task that runs the future to completion even if the handle is dropped. The trailing `token.cancel()` is a no-op in that case — no leak beyond the user-supplied future. Documented in `shutdown.rs`.                                                                                                              
  - Test infra. Integration tests in `volga/tests/shutdown_tests.rs` drive `App::run()` directly rather than going through `TestServer` (which has its own shutdown plumbing and wouldn't exercise this path). Helpers `pick_free_port`/`wait_until_listening` are kept local to the file.                                                                                          
  - `pub(crate) mod shutdown`. The module is crate-private; only `ShutdownHandle` is re-exported from `volga::`. No redundant `volga::app::shutdown::ShutdownHandle` path.
