### PR TITLE
HTTP QUERY support

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -28,8 +28,14 @@ jobs:
           toolchain: ${{ env.RUST_NIGHTLY }}
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz --locked
-      - name: Verify fuzz lockfile is up to date
-        run: cargo +${{ env.RUST_NIGHTLY }} metadata --locked --manifest-path fuzz/Cargo.toml --format-version 1 > /dev/null
+      - name: Sync fuzz lockfile (minimal relock, preserves pinned deps)
+        # NOT --locked: the fuzz crate is a separate workspace, so its Cargo.lock is not
+        # auto-updated when a normal PR bumps a dependency version in the main manifests.
+        # A strict --locked gate therefore breaks on every such bump. Instead we seed from
+        # the committed fuzz/Cargo.lock and let cargo minimally update only the out-of-range
+        # entries. Seeding from the committed lock keeps alloc-no-stdlib pinned at 2.0.4,
+        # which is what prevents the 2.0.4/3.0.0 split that breaks brotli on a fresh resolve.
+        run: cargo +${{ env.RUST_NIGHTLY }} metadata --manifest-path fuzz/Cargo.toml --format-version 1 > /dev/null
       - name: Build fuzz targets
         run: cargo +${{ env.RUST_NIGHTLY }} fuzz build
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,9 +290,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cast"
@@ -2227,9 +2227,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -2985,9 +2985,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3474,9 +3474,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.3"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -221,9 +221,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cc"

--- a/volga-macros/Cargo.toml
+++ b/volga-macros/Cargo.toml
@@ -17,8 +17,8 @@ keywords = ["volga", "http", "web", "framework"]
 proc-macro = true
 
 [dependencies]
-quote = "1.0.45"
-syn = { version = "2.0.117", features = ["full"] }
+quote = "1.0.46"
+syn = { version = "2.0.118", features = ["full"] }
 proc-macro2 = "1.0.106"
 
 [features]

--- a/volga-open-api/Cargo.toml
+++ b/volga-open-api/Cargo.toml
@@ -14,7 +14,7 @@ categories.workspace = true
 keywords = ["volga", "openapi", "documentation", "rest-api"]
 
 [dependencies]
-http = "1.4.1"
+http = "1.4.2"
 mime = "0.3.17"
 serde_json = "1.0.150"
 serde_urlencoded = "0.7.1"

--- a/volga/Cargo.toml
+++ b/volga/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["async", "server", "http", "web", "framework"]
 [dependencies]
 # required
 async-stream = "0.3.6"
-bytes = "1.11.1"
+bytes = "1.12.0"
 futures-util = { version = "0.3.32", default-features = false, features = ["alloc"] }
 http-body-util = "0.1.3"
 itoa = "1.0.18"
@@ -39,7 +39,7 @@ base64 = { version = "0.22.1", optional = true }
 cookie = { version = "0.18.1", features = ["percent-encode"], optional = true }
 jsonwebtoken = { version = "10.4.0", features = ["rust_crypto"], optional = true }
 httpdate = { version = "1.0.3", optional = true }
-hyper = { version = "1.10.0", features = ["server"], optional = true }
+hyper = { version = "1.10.1", features = ["server"], optional = true }
 hyper-util = { version = "0.1.20", features = ["server", "server-auto", "server-graceful", "service", "tokio"], optional = true }
 multer = { version = "3.1.0", optional = true }
 rand = { version = "0.10.1", optional = true }
@@ -63,11 +63,11 @@ volga-rate-limiter = { workspace = true, optional = true }
 [dev-dependencies]
 base64 = { version = "0.22.1" }
 jsonwebtoken = { version = "10.4.0", features = ["rust_crypto"] }
-hyper = { version = "1.9.0", features = ["client"] }
+hyper = { version = "1.10.1", features = ["client"] }
 reqwest = { version = "0.13.4", features = ["rustls-no-provider"] }
 serde = { version = "1.0.228", features = ["derive"] }
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
-uuid = { version = "1.23.0", features = ["v4"] }
+uuid = { version = "1.23.4", features = ["v4"] }
 criterion = { version = "0.8.2", features = ["async_tokio"] }
 tempfile = "3.27.0"
 

--- a/volga/src/app/router.rs
+++ b/volga/src/app/router.rs
@@ -284,6 +284,44 @@ impl App {
         self.map_route(Method::CONNECT, pattern, handler)
     }
 
+    /// Adds a request handler that matches HTTP QUERY requests for the specified pattern.
+    ///
+    /// > **Note:** Prefer putting complex selection criteria in the request body.
+    /// > Use URI query parameters only for routing/cache-affecting metadata such as tenant,
+    /// > locale, version, flags, or pagination compatibility.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// use volga::{App, Json, ok};
+    /// use serde::Deserialize;
+    ///
+    /// #[derive(Deserialize)]
+    /// struct SearchQuery {
+    ///     criteria: String
+    /// }
+    ///
+    ///# #[tokio::main]
+    ///# async fn main() -> std::io::Result<()> {
+    /// let mut app = App::new();
+    ///
+    /// app.map_query("/search", |query: Json<SearchQuery>| async {
+    ///    // do search by query.criteria....
+    ///    ok!("search, result...")
+    /// });
+    ///# app.run().await
+    ///# }
+    /// ```
+    pub fn map_query<'a, F, R, Args>(&'a mut self, pattern: &'a str, handler: F) -> Route<'a>
+    where
+        F: GenericHandler<Args, Output = R>,
+        R: IntoResponse + 'static,
+        Args: FromRequest + Send + 'static,
+    {
+        const QUERY: &[u8] = b"QUERY";
+        let method = Method::from_bytes(QUERY).expect("invalid QUERY verb");
+        self.map_route(method, pattern, handler)
+    }
+
     #[inline]
     fn map_route<'a, F, R, Args>(
         &'a mut self,

--- a/volga/src/app/router.rs
+++ b/volga/src/app/router.rs
@@ -323,6 +323,53 @@ impl App {
         self.map_route(method, pattern, handler)
     }
 
+    /// Adds a request handler that matches the given HTTP `method` for the specified pattern.
+    ///
+    /// This is a generic counterpart to [`map_get`](Self::map_get) and friends, useful when the
+    /// method is only known at runtime, when registering the same handler for several methods,
+    /// or for non-standard verbs. The `method` accepts both a typed [`Method`] and a string
+    /// (e.g. `"QUERY"`).
+    ///
+    /// # Examples
+    /// ```no_run
+    /// use volga::{App, ok};
+    /// use volga::http::Method;
+    ///
+    ///# #[tokio::main]
+    ///# async fn main() -> std::io::Result<()> {
+    /// let mut app = App::new();
+    ///
+    /// app.map(Method::GET, "/hello", || async {
+    ///    ok!("Hello World!")
+    /// });
+    ///
+    /// // a string verb works as well
+    /// app.map("QUERY", "/search", || async {
+    ///    ok!("search, result...")
+    /// });
+    ///# app.run().await
+    ///# }
+    /// ```
+    ///
+    /// # Panics
+    /// if `method` cannot be converted into a valid [`Method`].
+    pub fn map<'a, M, F, R, Args>(
+        &'a mut self,
+        method: M,
+        pattern: &'a str,
+        handler: F,
+    ) -> Route<'a>
+    where
+        M: TryInto<Method>,
+        M::Error: std::fmt::Debug,
+        F: GenericHandler<Args, Output = R>,
+        R: IntoResponse + 'static,
+        Args: FromRequest + Send + 'static,
+    {
+        let method = method.try_into().expect("invalid HTTP method");
+        self.map_route(method, pattern, handler)
+    }
+
     #[inline]
     fn map_route<'a, F, R, Args>(
         &'a mut self,
@@ -541,6 +588,55 @@ impl<'a> RouteGroup<'a> {
         }
 
         f(&mut child);
+    }
+
+    /// Maps a request handler that matches the given HTTP `method` for the specified pattern.
+    ///
+    /// See [`App::map`] for more details.
+    pub fn map<M, F, R, Args>(&mut self, method: M, pattern: &str, handler: F) -> Route<'_>
+    where
+        M: TryInto<Method>,
+        M::Error: std::fmt::Debug,
+        F: GenericHandler<Args, Output = R>,
+        R: IntoResponse + 'static,
+        Args: FromRequest + Send + 'static,
+    {
+        let method = method.try_into().expect("invalid HTTP method");
+        self.route_count += 1;
+        let pattern = [self.prefix.as_str(), pattern].concat();
+
+        #[cfg(feature = "middleware")]
+        {
+            let mut route = self
+                .app
+                .map_route_owned(method, pattern, handler)
+                .cors_override(self.cors.clone());
+
+            for filter in self.middleware.iter() {
+                route = route.map_middleware(filter.clone());
+            }
+
+            #[cfg(feature = "openapi")]
+            {
+                let openapi_config = self.openapi_config.clone();
+                route = route.open_api(|config| config.merge(&openapi_config));
+            }
+
+            route
+        }
+
+        #[cfg(not(feature = "middleware"))]
+        {
+            let route = self.app.map_route_owned(method, pattern, handler);
+
+            #[cfg(feature = "openapi")]
+            let route = {
+                let openapi_config = self.openapi_config.clone();
+                route.open_api(|config| config.merge(&openapi_config))
+            };
+
+            route
+        }
     }
 }
 

--- a/volga/src/app/router.rs
+++ b/volga/src/app/router.rs
@@ -16,6 +16,8 @@ use crate::openapi::{OpenApiRouteConfig, RouteKey};
 #[cfg(feature = "middleware")]
 use {crate::http::cors::CorsOverride, crate::middleware::MiddlewareFn};
 
+const QUERY: &[u8] = b"QUERY";
+
 /// Routes mapping
 impl App {
     /// Maps a group of request handlers combined by `prefix`
@@ -317,7 +319,6 @@ impl App {
         R: IntoResponse + 'static,
         Args: FromRequest + Send + 'static,
     {
-        const QUERY: &[u8] = b"QUERY";
         let method = Method::from_bytes(QUERY).expect("invalid QUERY verb");
         self.map_route(method, pattern, handler)
     }
@@ -619,4 +620,5 @@ define_route_group_methods! {
     (map_options, Method::OPTIONS)
     (map_trace, Method::TRACE)
     (map_connect, Method::CONNECT)
+    (map_query, Method::from_bytes(QUERY).expect("invalid QUERY verb"))
 }

--- a/volga/src/app/router.rs
+++ b/volga/src/app/router.rs
@@ -328,7 +328,8 @@ impl App {
     /// This is a generic counterpart to [`map_get`](Self::map_get) and friends, useful when the
     /// method is only known at runtime, when registering the same handler for several methods,
     /// or for non-standard verbs. The `method` accepts both a typed [`Method`] and a string
-    /// (e.g. `"QUERY"`).
+    /// (e.g. `"QUERY"`), and the `pattern` accepts both a borrowed `&str` (no allocation) and an
+    /// owned [`String`] (e.g. built at runtime).
     ///
     /// # Examples
     /// ```no_run
@@ -343,8 +344,8 @@ impl App {
     ///    ok!("Hello World!")
     /// });
     ///
-    /// // a string verb works as well
-    /// app.map("QUERY", "/search", || async {
+    /// // a string verb and a runtime-built pattern work as well
+    /// app.map("QUERY", format!("/search/{}", "v1"), || async {
     ///    ok!("search, result...")
     /// });
     ///# app.run().await
@@ -353,21 +354,17 @@ impl App {
     ///
     /// # Panics
     /// if `method` cannot be converted into a valid [`Method`].
-    pub fn map<'a, M, F, R, Args>(
-        &'a mut self,
-        method: M,
-        pattern: &'a str,
-        handler: F,
-    ) -> Route<'a>
+    pub fn map<'a, M, P, F, R, Args>(&'a mut self, method: M, pattern: P, handler: F) -> Route<'a>
     where
         M: TryInto<Method>,
         M::Error: std::fmt::Debug,
+        P: Into<Cow<'a, str>>,
         F: GenericHandler<Args, Output = R>,
         R: IntoResponse + 'static,
         Args: FromRequest + Send + 'static,
     {
         let method = method.try_into().expect("invalid HTTP method");
-        self.map_route(method, pattern, handler)
+        self.map_route_impl(method, pattern.into(), handler)
     }
 
     #[inline]
@@ -593,17 +590,18 @@ impl<'a> RouteGroup<'a> {
     /// Maps a request handler that matches the given HTTP `method` for the specified pattern.
     ///
     /// See [`App::map`] for more details.
-    pub fn map<M, F, R, Args>(&mut self, method: M, pattern: &str, handler: F) -> Route<'_>
+    pub fn map<M, P, F, R, Args>(&mut self, method: M, pattern: P, handler: F) -> Route<'_>
     where
         M: TryInto<Method>,
         M::Error: std::fmt::Debug,
+        P: AsRef<str>,
         F: GenericHandler<Args, Output = R>,
         R: IntoResponse + 'static,
         Args: FromRequest + Send + 'static,
     {
         let method = method.try_into().expect("invalid HTTP method");
         self.route_count += 1;
-        let pattern = [self.prefix.as_str(), pattern].concat();
+        let pattern = [self.prefix.as_str(), pattern.as_ref()].concat();
 
         #[cfg(feature = "middleware")]
         {

--- a/volga/tests/mapping_tests.rs
+++ b/volga/tests/mapping_tests.rs
@@ -168,6 +168,26 @@ async fn it_maps_to_trace_request() {
 }
 
 #[tokio::test]
+async fn it_maps_to_query_request() {
+    let server = TestServer::spawn(|app| {
+        app.map_query("/test", async || "Pass!");
+    })
+        .await;
+
+    let response = server
+        .client()
+        .request(Method::from_bytes(b"QUERY").unwrap(), server.url("/test"))
+        .send()
+        .await
+        .unwrap();
+
+    assert!(response.status().is_success());
+    assert_eq!(response.text().await.unwrap(), "Pass!");
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
 async fn it_maps_to_head_along_with_get_request() {
     let server = TestServer::spawn(|app| {
         app.map_get("/test", async || "Pass!");

--- a/volga/tests/mapping_tests.rs
+++ b/volga/tests/mapping_tests.rs
@@ -213,6 +213,71 @@ async fn it_maps_to_query_request_in_group() {
 }
 
 #[tokio::test]
+async fn it_maps_with_typed_method() {
+    let server = TestServer::spawn(|app| {
+        app.map(Method::GET, "/test", async || "Pass!");
+    })
+    .await;
+
+    let response = server
+        .client()
+        .get(server.url("/test"))
+        .send()
+        .await
+        .unwrap();
+
+    assert!(response.status().is_success());
+    assert_eq!(response.text().await.unwrap(), "Pass!");
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn it_maps_with_string_method() {
+    let server = TestServer::spawn(|app| {
+        app.map("QUERY", "/test", async || "Pass!");
+    })
+    .await;
+
+    let response = server
+        .client()
+        .request(Method::from_bytes(b"QUERY").unwrap(), server.url("/test"))
+        .send()
+        .await
+        .unwrap();
+
+    assert!(response.status().is_success());
+    assert_eq!(response.text().await.unwrap(), "Pass!");
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn it_maps_with_method_in_group() {
+    let server = TestServer::spawn(|app| {
+        app.group("/test", |api| {
+            api.map("QUERY", "/test", async || "Pass!");
+        });
+    })
+    .await;
+
+    let response = server
+        .client()
+        .request(
+            Method::from_bytes(b"QUERY").unwrap(),
+            server.url("/test/test"),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    assert!(response.status().is_success());
+    assert_eq!(response.text().await.unwrap(), "Pass!");
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
 async fn it_maps_to_head_along_with_get_request() {
     let server = TestServer::spawn(|app| {
         app.map_get("/test", async || "Pass!");

--- a/volga/tests/mapping_tests.rs
+++ b/volga/tests/mapping_tests.rs
@@ -188,6 +188,31 @@ async fn it_maps_to_query_request() {
 }
 
 #[tokio::test]
+async fn it_maps_to_query_request_in_group() {
+    let server = TestServer::spawn(|app| {
+        app.group("/test", |api| {
+            api.map_query("/test", async || "Pass!");
+        });
+    })
+    .await;
+
+    let response = server
+        .client()
+        .request(
+            Method::from_bytes(b"QUERY").unwrap(),
+            server.url("/test/test"),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    assert!(response.status().is_success());
+    assert_eq!(response.text().await.unwrap(), "Pass!");
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
 async fn it_maps_to_head_along_with_get_request() {
     let server = TestServer::spawn(|app| {
         app.map_get("/test", async || "Pass!");

--- a/volga/tests/mapping_tests.rs
+++ b/volga/tests/mapping_tests.rs
@@ -253,6 +253,26 @@ async fn it_maps_with_string_method() {
 }
 
 #[tokio::test]
+async fn it_maps_with_owned_string_pattern() {
+    let server = TestServer::spawn(|app| {
+        app.map(Method::GET, format!("/test/{}", "v1"), async || "Pass!");
+    })
+    .await;
+
+    let response = server
+        .client()
+        .get(server.url("/test/v1"))
+        .send()
+        .await
+        .unwrap();
+
+    assert!(response.status().is_success());
+    assert_eq!(response.text().await.unwrap(), "Pass!");
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
 async fn it_maps_with_method_in_group() {
     let server = TestServer::spawn(|app| {
         app.group("/test", |api| {

--- a/volga/tests/mapping_tests.rs
+++ b/volga/tests/mapping_tests.rs
@@ -172,7 +172,7 @@ async fn it_maps_to_query_request() {
     let server = TestServer::spawn(|app| {
         app.map_query("/test", async || "Pass!");
     })
-        .await;
+    .await;
 
     let response = server
         .client()


### PR DESCRIPTION
## Summary
* Added HTTP QUERY (https://datatracker.ietf.org/doc/rfc10008/) method support
* Added a generic `map()` to register routes explicitly

## Type
- [ ] Bug fix
- [ ] Feature
- [x] Enhancement
- [ ] Performance
- [ ] Documentation
- [ ] Refactor
- [ ] Security
- [ ] Breaking change

## Checklist
- [x] I added/updated tests where it makes sense
- [x] I updated docs/examples if needed
- [x] This change is backwards-compatible (or clearly marked as breaking)
- [x] I ran formatting/lints locally (if applicable)
