### PR TITLE
feat: oauth metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1677,6 +1677,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "oauth_metadata"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "volga",
+]
+
+[[package]]
 name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/examples/oauth_metadata/Cargo.toml
+++ b/examples/oauth_metadata/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "oauth_metadata"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+volga = { path = "../../volga", features = ["jwt-auth"] }
+serde = "1.0.219"
+
+[lints]
+workspace = true

--- a/examples/oauth_metadata/src/main.rs
+++ b/examples/oauth_metadata/src/main.rs
@@ -1,0 +1,65 @@
+//! Serving OAuth 2.0 metadata documents (RFC 8414 / RFC 9728).
+//!
+//! Run with:
+//!
+//! ```no_rust
+//! cargo run -p oauth_metadata
+//! ```
+//!
+//! Then:
+//!
+//! ```no_rust
+//! curl http://127.0.0.1:7878/.well-known/oauth-protected-resource
+//! curl http://127.0.0.1:7878/.well-known/oauth-authorization-server
+//! curl http://127.0.0.1:7878/.well-known/openid-configuration
+//! curl -i http://127.0.0.1:7878/protected   # note the WWW-Authenticate header
+//! ```
+
+use serde::Deserialize;
+use volga::{
+    App,
+    auth::{AuthClaims, DecodingKey, oauth::ProtectedResourceMetadata, roles},
+    ok,
+};
+
+#[derive(Clone, Deserialize)]
+struct Claims {
+    role: String,
+}
+
+impl AuthClaims for Claims {
+    fn role(&self) -> Option<&str> {
+        Some(&self.role)
+    }
+}
+
+fn main() {
+    let mut app = App::new()
+        // The derived metadata URL is advertised automatically as
+        // `resource_metadata` in WWW-Authenticate challenges (RFC 9728 §5.1)
+        .with_bearer_auth(|auth| {
+            auth.set_decoding_key(DecodingKey::from_secret(b"secret"))
+                .require_https(false)
+        });
+
+    // Protected Resource Metadata (RFC 9728),
+    // served at /.well-known/oauth-protected-resource
+    let resource = ProtectedResourceMetadata::new("http://127.0.0.1:7878")
+        .with_authorization_servers(["https://auth.example.com"])
+        .with_scopes(["read", "write"])
+        .with_bearer_methods(["header"]);
+    app.use_oauth_resource_metadata(resource);
+
+    // Authorization Server Metadata (RFC 8414) — only when the application
+    // is also an authorization server; the identifier string alone serves
+    // the minimal document at /.well-known/oauth-authorization-server.
+    // The same document is commonly published at the OpenID Connect
+    // Discovery path too (/.well-known/openid-configuration)
+    app.use_oauth_server_metadata("http://127.0.0.1:7878")
+        .use_oidc_metadata("http://127.0.0.1:7878");
+
+    app.map_get("/protected", || async { ok!("protected") })
+        .authorize::<Claims>(roles(["admin"]));
+
+    app.run_blocking()
+}

--- a/volga/src/app.rs
+++ b/volga/src/app.rs
@@ -136,6 +136,11 @@ pub struct App {
     #[cfg(feature = "jwt-auth")]
     pub(super) auth_config: Option<BearerAuthConfig>,
 
+    /// Metadata URL derived by [`App::use_oauth_resource_metadata`], used as
+    /// the default `resource_metadata` challenge parameter (RFC 9728 §5.1)
+    #[cfg(feature = "jwt-auth")]
+    pub(super) oauth_resource_metadata_url: Option<String>,
+
     /// Global rate limiter
     #[cfg(feature = "rate-limiting")]
     pub(super) rate_limiter: Option<GlobalRateLimiter>,
@@ -257,6 +262,8 @@ impl App {
             host_env: HostEnv::default(),
             #[cfg(feature = "jwt-auth")]
             auth_config: None,
+            #[cfg(feature = "jwt-auth")]
+            oauth_resource_metadata_url: None,
             #[cfg(feature = "rate-limiting")]
             rate_limiter: None,
             #[cfg(feature = "rate-limiting")]

--- a/volga/src/app/app_env.rs
+++ b/volga/src/app/app_env.rs
@@ -150,9 +150,12 @@ impl TryFrom<App> for AppEnv {
         };
 
         #[cfg(feature = "jwt-auth")]
-        let bearer_token_service = app
-            .auth_config
-            .map(|cfg| crate::auth::BearerTokenService::from_config(cfg, tls_enabled));
+        let bearer_token_service = {
+            let derived_metadata_url = app.oauth_resource_metadata_url;
+            app.auth_config.map(|cfg| {
+                crate::auth::BearerTokenService::from_config(cfg, tls_enabled, derived_metadata_url)
+            })
+        };
 
         let default_cache_control = app.cache_control.map(|c| c.try_into()).transpose()?;
 

--- a/volga/src/auth/bearer.rs
+++ b/volga/src/auth/bearer.rs
@@ -315,9 +315,11 @@ impl BearerAuthConfig {
     /// Sets the URL advertised as `resource_metadata` in the `WWW-Authenticate`
     /// challenge per RFC 9728 (OAuth 2.0 Protected Resource Metadata).
     ///
-    /// volga does **not** serve the metadata document at this URL — that is
-    /// the application's responsibility. This setting only controls the
-    /// challenge-header hint sent to clients.
+    /// This setting only controls the challenge-header hint sent to clients;
+    /// serving the document is a separate concern. When the application
+    /// serves it via [`App::use_oauth_resource_metadata`](crate::App::use_oauth_resource_metadata),
+    /// the URL is derived automatically and this setting is only needed to
+    /// override it.
     pub fn with_resource_metadata_url<U: Into<String>>(mut self, url: U) -> Self {
         self.resource_metadata_url = Some(url.into());
         self
@@ -386,7 +388,7 @@ impl std::fmt::Debug for BearerTokenService {
 impl From<BearerAuthConfig> for BearerTokenService {
     #[inline]
     fn from(value: BearerAuthConfig) -> Self {
-        Self::from_config(value, false)
+        Self::from_config(value, false, None)
     }
 }
 
@@ -395,16 +397,28 @@ impl BearerTokenService {
     /// whether the outer server accepts TLS traffic.
     ///
     /// `tls_enabled` is consulted together with `require_https` to decide
-    /// whether to reject plaintext requests. Applications should prefer the
-    /// [`From<BearerAuthConfig>`] impl in tests and when TLS status is irrelevant.
+    /// whether to reject plaintext requests. `default_resource_metadata_url`
+    /// is the URL derived by
+    /// [`App::use_oauth_resource_metadata`](crate::App::use_oauth_resource_metadata);
+    /// it applies only when the config carries no explicit
+    /// [`with_resource_metadata_url`](BearerAuthConfig::with_resource_metadata_url).
+    /// Applications should prefer the [`From<BearerAuthConfig>`] impl in tests
+    /// and when TLS status is irrelevant.
     #[inline]
-    pub(crate) fn from_config(cfg: BearerAuthConfig, tls_enabled: bool) -> Self {
+    pub(crate) fn from_config(
+        cfg: BearerAuthConfig,
+        tls_enabled: bool,
+        default_resource_metadata_url: Option<String>,
+    ) -> Self {
         Self {
             validation: Arc::new(cfg.validation),
             encoding: cfg.encoding.map(Arc::new),
             decoding: cfg.decoding.map(Arc::new),
             strip_token_from_request: cfg.strip_token_from_request,
-            resource_metadata_url: cfg.resource_metadata_url.map(Into::into),
+            resource_metadata_url: cfg
+                .resource_metadata_url
+                .or(default_resource_metadata_url)
+                .map(Into::into),
             require_https: cfg.require_https,
             tls_enabled,
         }
@@ -1184,8 +1198,31 @@ mod tests {
 
     #[tokio::test]
     async fn it_from_config_records_tls_enabled() {
-        let service = BearerTokenService::from_config(BearerAuthConfig::default(), true);
+        let service = BearerTokenService::from_config(BearerAuthConfig::default(), true, None);
         assert!(service.tls_enabled);
+    }
+
+    #[tokio::test]
+    async fn it_from_config_prefers_explicit_resource_metadata_url_over_default() {
+        let service = BearerTokenService::from_config(
+            BearerAuthConfig::default().with_resource_metadata_url("https://a.com/explicit"),
+            false,
+            Some("https://a.com/derived".into()),
+        );
+        assert_eq!(
+            service.resource_metadata_url.as_deref(),
+            Some("https://a.com/explicit")
+        );
+
+        let service = BearerTokenService::from_config(
+            BearerAuthConfig::default(),
+            false,
+            Some("https://a.com/derived".into()),
+        );
+        assert_eq!(
+            service.resource_metadata_url.as_deref(),
+            Some("https://a.com/derived")
+        );
     }
 
     #[tokio::test]

--- a/volga/src/auth/oauth.rs
+++ b/volga/src/auth/oauth.rs
@@ -6,19 +6,27 @@
 //! * Authorization Server Metadata per [RFC 8414](https://www.rfc-editor.org/rfc/rfc8414)
 //! * Protected Resource Metadata per [RFC 9728](https://www.rfc-editor.org/rfc/rfc9728)
 //! * Utilities: the `WWW-Authenticate` Bearer challenge builder and parser,
-//!   and resource URI canonicalization per [RFC 8707](https://www.rfc-editor.org/rfc/rfc8707)
+//!   resource URI canonicalization per [RFC 8707](https://www.rfc-editor.org/rfc/rfc8707)
+//!   and well-known metadata URL derivation
+//! * Built-in handlers serving the metadata documents from a volga
+//!   application ([`App::use_oauth_resource_metadata`](crate::App::use_oauth_resource_metadata),
+//!   [`App::use_oauth_server_metadata`](crate::App::use_oauth_server_metadata),
+//!   [`App::use_oidc_metadata`](crate::App::use_oidc_metadata))
 //!
-//! This module intentionally contains no client or server flows yet — those
-//! are built on top of these types (discovery handlers in `volga`, the OAuth
-//! client in a separate crate).
+//! This module intentionally contains no client flows yet — the discovery
+//! client is built on top of these types separately.
 
 pub use error::{OAuthError, OAuthErrorCode};
 pub use metadata::{
     AuthorizationServerMetadata, ProtectedResourceMetadata, WELL_KNOWN_AUTHORIZATION_SERVER,
     WELL_KNOWN_OPENID_CONFIGURATION, WELL_KNOWN_PROTECTED_RESOURCE,
 };
-pub use utils::{BearerChallenge, canonicalize_resource_uri};
+pub use utils::{
+    BearerChallenge, authorization_server_metadata_url, canonicalize_resource_uri,
+    openid_configuration_url, protected_resource_metadata_url,
+};
 
 mod error;
+mod handlers;
 mod metadata;
 mod utils;

--- a/volga/src/auth/oauth/handlers.rs
+++ b/volga/src/auth/oauth/handlers.rs
@@ -1,0 +1,196 @@
+//! Built-in handlers serving OAuth metadata documents
+//!
+//! * [`App::use_oauth_resource_metadata`] — Protected Resource Metadata
+//!   per [RFC 9728 §3](https://www.rfc-editor.org/rfc/rfc9728#section-3)
+//! * [`App::use_oauth_server_metadata`] — Authorization Server Metadata
+//!   per [RFC 8414 §3](https://www.rfc-editor.org/rfc/rfc8414#section-3)
+//! * [`App::use_oidc_metadata`] — the same document at the OpenID Connect
+//!   Discovery path per [OIDC Discovery 1.0 §4](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig)
+
+use serde::Serialize;
+use std::sync::Arc;
+
+use crate::{
+    App,
+    headers::{CacheControl, Header},
+};
+
+use super::{
+    AuthorizationServerMetadata, ProtectedResourceMetadata, authorization_server_metadata_url,
+    openid_configuration_url, protected_resource_metadata_url,
+};
+
+impl App {
+    /// Serves OAuth 2.0 Protected Resource Metadata (RFC 9728 §3)
+    ///
+    /// Mounts a `GET` route returning the document as `application/json` at
+    /// the well-known path derived from the `resource` identifier per
+    /// RFC 9728 §3.1: `/.well-known/oauth-protected-resource`, with the
+    /// resource's path appended (e.g. `/.well-known/oauth-protected-resource/v1`
+    /// for `https://api.example.com/v1`).
+    ///
+    /// Accepts anything convertible into [`ProtectedResourceMetadata`],
+    /// including the resource identifier itself (`&str` / `String`) for the
+    /// minimal document. When bearer authentication is configured and no
+    /// explicit [`with_resource_metadata_url`] is set, the derived metadata
+    /// URL is advertised automatically in `WWW-Authenticate` challenges
+    /// (RFC 9728 §5.1).
+    ///
+    /// Panics when the `resource` identifier is not a valid `http`/`https`
+    /// URI or contains a query — this is a startup misconfiguration.
+    ///
+    /// [`with_resource_metadata_url`]: crate::auth::BearerAuthConfig::with_resource_metadata_url
+    ///
+    /// # Example
+    /// ```no_run
+    /// use volga::{App, auth::oauth::ProtectedResourceMetadata};
+    ///
+    /// let mut app = App::new();
+    ///
+    /// let metadata = ProtectedResourceMetadata::new("https://api.example.com")
+    ///     .with_authorization_servers(["https://auth.example.com"])
+    ///     .with_scopes(["read", "write"]);
+    ///
+    /// app.use_oauth_resource_metadata(metadata);
+    /// // GET /.well-known/oauth-protected-resource
+    /// ```
+    pub fn use_oauth_resource_metadata<M>(&mut self, metadata: M) -> &mut Self
+    where
+        M: Into<ProtectedResourceMetadata>,
+    {
+        let metadata = metadata.into();
+        let metadata_url = protected_resource_metadata_url(&metadata.resource)
+            .unwrap_or_else(|err| panic!("OAuth protected resource metadata: {err}"));
+
+        serve_metadata(self, well_known_route(&metadata_url), metadata);
+
+        // The derived URL's only consumer is the WWW-Authenticate challenge
+        // built by bearer auth; without `jwt-auth` nothing reads it
+        #[cfg(feature = "jwt-auth")]
+        {
+            self.oauth_resource_metadata_url = Some(metadata_url);
+        }
+        self
+    }
+
+    /// Serves OAuth 2.0 Authorization Server Metadata (RFC 8414 §3)
+    ///
+    /// Mounts a `GET` route returning the document as `application/json` at
+    /// the well-known path derived from the `issuer` identifier per
+    /// RFC 8414 §3.1: `/.well-known/oauth-authorization-server`, with the
+    /// issuer's path appended (e.g.
+    /// `/.well-known/oauth-authorization-server/tenant1` for
+    /// `https://auth.example.com/tenant1`).
+    ///
+    /// Accepts anything convertible into [`AuthorizationServerMetadata`],
+    /// including the issuer identifier itself (`&str` / `String`) for the
+    /// minimal document.
+    ///
+    /// Panics when the `issuer` identifier is not a valid `http`/`https`
+    /// URI or contains a query — this is a startup misconfiguration.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use volga::{App, auth::oauth::AuthorizationServerMetadata};
+    ///
+    /// let mut app = App::new();
+    ///
+    /// let metadata = AuthorizationServerMetadata::new("https://auth.example.com")
+    ///     .with_authorization_endpoint("https://auth.example.com/authorize")
+    ///     .with_token_endpoint("https://auth.example.com/token");
+    ///
+    /// app.use_oauth_server_metadata(metadata);
+    /// // GET /.well-known/oauth-authorization-server
+    /// ```
+    pub fn use_oauth_server_metadata<M>(&mut self, metadata: M) -> &mut Self
+    where
+        M: Into<AuthorizationServerMetadata>,
+    {
+        let metadata = metadata.into();
+        let metadata_url = authorization_server_metadata_url(&metadata.issuer)
+            .unwrap_or_else(|err| panic!("OAuth authorization server metadata: {err}"));
+
+        serve_metadata(self, well_known_route(&metadata_url), metadata);
+        self
+    }
+
+    /// Serves the metadata document at the OpenID Connect Discovery path
+    ///
+    /// Mounts a `GET` route returning the document as `application/json` at
+    /// the path derived from the `issuer` identifier per
+    /// [OIDC Discovery 1.0 §4](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig):
+    /// unlike RFC 8414, `/.well-known/openid-configuration` is appended
+    /// **after** the issuer's path (e.g.
+    /// `/tenant1/.well-known/openid-configuration` for
+    /// `https://auth.example.com/tenant1`).
+    ///
+    /// Accepts anything convertible into [`AuthorizationServerMetadata`],
+    /// including the issuer identifier itself (`&str` / `String`).
+    /// OIDC-specific fields required by a compliant provider document
+    /// (`subject_types_supported`, `id_token_signing_alg_values_supported`,
+    /// `userinfo_endpoint`, …) can be supplied through
+    /// [`with_additional_field`](AuthorizationServerMetadata::with_additional_field).
+    /// Authorization servers commonly publish the same document at both
+    /// discovery paths — chain this with [`use_oauth_server_metadata`]:
+    ///
+    /// [`use_oauth_server_metadata`]: App::use_oauth_server_metadata
+    ///
+    /// Panics when the `issuer` identifier is not a valid `http`/`https`
+    /// URI or contains a query — this is a startup misconfiguration.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use volga::{App, auth::oauth::AuthorizationServerMetadata};
+    ///
+    /// let mut app = App::new();
+    ///
+    /// let metadata = AuthorizationServerMetadata::new("https://auth.example.com")
+    ///     .with_token_endpoint("https://auth.example.com/token");
+    ///
+    /// app.use_oauth_server_metadata(metadata.clone())
+    ///     .use_oidc_metadata(metadata);
+    /// // GET /.well-known/oauth-authorization-server
+    /// // GET /.well-known/openid-configuration
+    /// ```
+    pub fn use_oidc_metadata<M>(&mut self, metadata: M) -> &mut Self
+    where
+        M: Into<AuthorizationServerMetadata>,
+    {
+        let metadata = metadata.into();
+        let metadata_url = openid_configuration_url(&metadata.issuer)
+            .unwrap_or_else(|err| panic!("OpenID Connect discovery metadata: {err}"));
+
+        serve_metadata(self, well_known_route(&metadata_url), metadata);
+        self
+    }
+}
+
+/// Extracts the absolute-path part of a derived metadata URL to mount the
+/// route at (`https://host/.well-known/…` → `/.well-known/…`).
+fn well_known_route(metadata_url: &str) -> &str {
+    let after_scheme = metadata_url.find("://").expect("derived URL is absolute") + 3;
+    let path_start = metadata_url[after_scheme..]
+        .find('/')
+        .expect("derived URL contains the well-known path");
+    &metadata_url[after_scheme + path_start..]
+}
+
+/// Mounts a `GET` route serving the document as JSON; metadata documents
+/// are immutable, so responses carry a public one-hour cache policy.
+fn serve_metadata<T>(app: &mut App, path: &str, metadata: T)
+where
+    T: Serialize + Send + Sync + 'static,
+{
+    let cache_control = metadata_cache_control();
+    let metadata = Arc::new(metadata);
+    app.map_get(path, move || {
+        let metadata = Arc::clone(&metadata);
+        let cache_control = cache_control.clone();
+        async move { crate::ok!(metadata.as_ref(); [cache_control]) }
+    });
+}
+
+fn metadata_cache_control() -> Header<CacheControl> {
+    Header::try_from(CacheControl::default().with_public().with_max_age(3600))
+        .expect("valid cache control header")
+}

--- a/volga/src/auth/oauth/metadata.rs
+++ b/volga/src/auth/oauth/metadata.rs
@@ -160,6 +160,214 @@ impl AuthorizationServerMetadata {
             ..Default::default()
         }
     }
+
+    /// Sets the URL of the authorization endpoint
+    pub fn with_authorization_endpoint(mut self, url: impl Into<String>) -> Self {
+        self.authorization_endpoint = Some(url.into());
+        self
+    }
+
+    /// Sets the URL of the token endpoint
+    pub fn with_token_endpoint(mut self, url: impl Into<String>) -> Self {
+        self.token_endpoint = Some(url.into());
+        self
+    }
+
+    /// Sets the URL of the server's JWK Set document
+    pub fn with_jwks_uri(mut self, uri: impl Into<String>) -> Self {
+        self.jwks_uri = Some(uri.into());
+        self
+    }
+
+    /// Sets the URL of the dynamic client registration endpoint (RFC 7591)
+    pub fn with_registration_endpoint(mut self, url: impl Into<String>) -> Self {
+        self.registration_endpoint = Some(url.into());
+        self
+    }
+
+    /// Sets the scope values supported by this server
+    pub fn with_scopes<I, S>(mut self, scopes: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.scopes_supported = scopes.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Sets the `response_type` values supported by this server,
+    /// replacing the `["code"]` prefilled by [`new`](Self::new)
+    pub fn with_response_types<I, S>(mut self, types: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.response_types_supported = types.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Sets the `response_mode` values supported by this server
+    pub fn with_response_modes<I, S>(mut self, modes: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.response_modes_supported = modes.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Sets the grant type values supported by this server, replacing the
+    /// `["authorization_code"]` prefilled by [`new`](Self::new)
+    pub fn with_grant_types<I, S>(mut self, types: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.grant_types_supported = types.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Sets the client authentication methods supported by the token endpoint
+    pub fn with_token_endpoint_auth_methods<I, S>(mut self, methods: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.token_endpoint_auth_methods_supported = methods.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Sets the JWS signing algorithms supported by the token endpoint for
+    /// client authentication
+    pub fn with_token_endpoint_auth_signing_algs<I, S>(mut self, algs: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.token_endpoint_auth_signing_alg_values_supported =
+            algs.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Sets the URL of a page with human-readable developer documentation
+    pub fn with_service_documentation(mut self, url: impl Into<String>) -> Self {
+        self.service_documentation = Some(url.into());
+        self
+    }
+
+    /// Sets the languages supported for the user interface
+    pub fn with_ui_locales<I, S>(mut self, locales: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.ui_locales_supported = locales.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Sets the URL of the server's policy on client usage of registration data
+    pub fn with_op_policy_uri(mut self, url: impl Into<String>) -> Self {
+        self.op_policy_uri = Some(url.into());
+        self
+    }
+
+    /// Sets the URL of the server's terms of service
+    pub fn with_op_tos_uri(mut self, url: impl Into<String>) -> Self {
+        self.op_tos_uri = Some(url.into());
+        self
+    }
+
+    /// Sets the URL of the token revocation endpoint (RFC 7009)
+    pub fn with_revocation_endpoint(mut self, url: impl Into<String>) -> Self {
+        self.revocation_endpoint = Some(url.into());
+        self
+    }
+
+    /// Sets the client authentication methods supported by the revocation endpoint
+    pub fn with_revocation_endpoint_auth_methods<I, S>(mut self, methods: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.revocation_endpoint_auth_methods_supported =
+            methods.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Sets the JWS signing algorithms supported by the revocation endpoint
+    /// for client authentication
+    pub fn with_revocation_endpoint_auth_signing_algs<I, S>(mut self, algs: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.revocation_endpoint_auth_signing_alg_values_supported =
+            algs.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Sets the URL of the token introspection endpoint (RFC 7662)
+    pub fn with_introspection_endpoint(mut self, url: impl Into<String>) -> Self {
+        self.introspection_endpoint = Some(url.into());
+        self
+    }
+
+    /// Sets the client authentication methods supported by the introspection endpoint
+    pub fn with_introspection_endpoint_auth_methods<I, S>(mut self, methods: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.introspection_endpoint_auth_methods_supported =
+            methods.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Sets the JWS signing algorithms supported by the introspection
+    /// endpoint for client authentication
+    pub fn with_introspection_endpoint_auth_signing_algs<I, S>(mut self, algs: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.introspection_endpoint_auth_signing_alg_values_supported =
+            algs.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Sets the PKCE code challenge methods supported (e.g. `S256`)
+    pub fn with_code_challenge_methods<I, S>(mut self, methods: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.code_challenge_methods_supported = methods.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Adds an extension or OIDC-specific field not modeled by the typed fields
+    pub fn with_additional_field(
+        mut self,
+        name: impl Into<String>,
+        value: impl Into<serde_json::Value>,
+    ) -> Self {
+        self.additional_fields.insert(name.into(), value.into());
+        self
+    }
+}
+
+impl From<&str> for AuthorizationServerMetadata {
+    #[inline]
+    fn from(issuer: &str) -> Self {
+        Self::new(issuer)
+    }
+}
+
+impl From<String> for AuthorizationServerMetadata {
+    #[inline]
+    fn from(issuer: String) -> Self {
+        Self::new(issuer)
+    }
 }
 
 /// RFC 8414 §2 default for an omitted `response_modes_supported`
@@ -254,6 +462,145 @@ impl ProtectedResourceMetadata {
             resource: resource.into(),
             ..Default::default()
         }
+    }
+
+    /// Sets the issuer identifiers of authorization servers that can be
+    /// used with this resource
+    pub fn with_authorization_servers<I, S>(mut self, servers: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.authorization_servers = servers.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Sets the URL of the protected resource's JWK Set document
+    pub fn with_jwks_uri(mut self, uri: impl Into<String>) -> Self {
+        self.jwks_uri = Some(uri.into());
+        self
+    }
+
+    /// Sets the scope values used in authorization requests to access
+    /// this resource
+    pub fn with_scopes<I, S>(mut self, scopes: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.scopes_supported = scopes.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Sets the supported methods of sending a bearer token
+    /// (`header`, `body`, `query`)
+    pub fn with_bearer_methods<I, S>(mut self, methods: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.bearer_methods_supported = methods.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Sets the JWS signing algorithms supported for signed resource responses
+    pub fn with_resource_signing_algs<I, S>(mut self, algs: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.resource_signing_alg_values_supported = algs.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Sets the human-readable name of the protected resource
+    pub fn with_resource_name(mut self, name: impl Into<String>) -> Self {
+        self.resource_name = Some(name.into());
+        self
+    }
+
+    /// Sets the URL of a page with human-readable developer documentation
+    pub fn with_resource_documentation(mut self, url: impl Into<String>) -> Self {
+        self.resource_documentation = Some(url.into());
+        self
+    }
+
+    /// Sets the URL of the resource's policy on client usage of data
+    pub fn with_resource_policy_uri(mut self, url: impl Into<String>) -> Self {
+        self.resource_policy_uri = Some(url.into());
+        self
+    }
+
+    /// Sets the URL of the resource's terms of service
+    pub fn with_resource_tos_uri(mut self, url: impl Into<String>) -> Self {
+        self.resource_tos_uri = Some(url.into());
+        self
+    }
+
+    /// Sets whether the resource supports mutual-TLS certificate-bound
+    /// access tokens
+    #[inline]
+    pub fn with_tls_client_certificate_bound_access_tokens(mut self, enabled: bool) -> Self {
+        self.tls_client_certificate_bound_access_tokens = Some(enabled);
+        self
+    }
+
+    /// Sets the authorization details type values supported (RFC 9396)
+    pub fn with_authorization_details_types<I, S>(mut self, types: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.authorization_details_types_supported = types.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Sets the JWS algorithms supported for validating DPoP proof JWTs
+    /// (RFC 9449)
+    pub fn with_dpop_signing_algs<I, S>(mut self, algs: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.dpop_signing_alg_values_supported = algs.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Sets whether the resource always requires DPoP-bound access tokens
+    #[inline]
+    pub fn with_dpop_bound_access_tokens(mut self, required: bool) -> Self {
+        self.dpop_bound_access_tokens_required = Some(required);
+        self
+    }
+
+    /// Sets the signed JWT containing the metadata itself
+    pub fn with_signed_metadata(mut self, jwt: impl Into<String>) -> Self {
+        self.signed_metadata = Some(jwt.into());
+        self
+    }
+
+    /// Adds an extension field not modeled by the typed fields
+    pub fn with_additional_field(
+        mut self,
+        name: impl Into<String>,
+        value: impl Into<serde_json::Value>,
+    ) -> Self {
+        self.additional_fields.insert(name.into(), value.into());
+        self
+    }
+}
+
+impl From<&str> for ProtectedResourceMetadata {
+    #[inline]
+    fn from(resource: &str) -> Self {
+        Self::new(resource)
+    }
+}
+
+impl From<String> for ProtectedResourceMetadata {
+    #[inline]
+    fn from(resource: String) -> Self {
+        Self::new(resource)
     }
 }
 
@@ -416,6 +763,106 @@ mod tests {
 
         let back = serde_json::to_value(&metadata).unwrap();
         assert_eq!(back, doc);
+    }
+
+    #[test]
+    fn it_builds_server_metadata_with_builder_methods() {
+        let metadata = AuthorizationServerMetadata::new("https://auth.example.com")
+            .with_authorization_endpoint("https://auth.example.com/authorize")
+            .with_token_endpoint("https://auth.example.com/token")
+            .with_jwks_uri("https://auth.example.com/jwks")
+            .with_registration_endpoint("https://auth.example.com/register")
+            .with_scopes(["read", "write"])
+            .with_response_types(["code", "id_token"])
+            .with_response_modes(["query"])
+            .with_grant_types(["authorization_code", "refresh_token"])
+            .with_token_endpoint_auth_methods(["private_key_jwt"])
+            .with_token_endpoint_auth_signing_algs(["ES256"])
+            .with_service_documentation("https://auth.example.com/docs")
+            .with_ui_locales(["en", "de"])
+            .with_op_policy_uri("https://auth.example.com/policy")
+            .with_op_tos_uri("https://auth.example.com/tos")
+            .with_revocation_endpoint("https://auth.example.com/revoke")
+            .with_revocation_endpoint_auth_methods(["client_secret_basic"])
+            .with_revocation_endpoint_auth_signing_algs(["RS256"])
+            .with_introspection_endpoint("https://auth.example.com/introspect")
+            .with_introspection_endpoint_auth_methods(["client_secret_post"])
+            .with_introspection_endpoint_auth_signing_algs(["PS256"])
+            .with_code_challenge_methods(["S256"])
+            .with_additional_field("subject_types_supported", json!(["public"]));
+
+        let json = serde_json::to_value(&metadata).unwrap();
+        assert_eq!(
+            json,
+            json!({
+                "issuer": "https://auth.example.com",
+                "authorization_endpoint": "https://auth.example.com/authorize",
+                "token_endpoint": "https://auth.example.com/token",
+                "jwks_uri": "https://auth.example.com/jwks",
+                "registration_endpoint": "https://auth.example.com/register",
+                "scopes_supported": ["read", "write"],
+                "response_types_supported": ["code", "id_token"],
+                "response_modes_supported": ["query"],
+                "grant_types_supported": ["authorization_code", "refresh_token"],
+                "token_endpoint_auth_methods_supported": ["private_key_jwt"],
+                "token_endpoint_auth_signing_alg_values_supported": ["ES256"],
+                "service_documentation": "https://auth.example.com/docs",
+                "ui_locales_supported": ["en", "de"],
+                "op_policy_uri": "https://auth.example.com/policy",
+                "op_tos_uri": "https://auth.example.com/tos",
+                "revocation_endpoint": "https://auth.example.com/revoke",
+                "revocation_endpoint_auth_methods_supported": ["client_secret_basic"],
+                "revocation_endpoint_auth_signing_alg_values_supported": ["RS256"],
+                "introspection_endpoint": "https://auth.example.com/introspect",
+                "introspection_endpoint_auth_methods_supported": ["client_secret_post"],
+                "introspection_endpoint_auth_signing_alg_values_supported": ["PS256"],
+                "code_challenge_methods_supported": ["S256"],
+                "subject_types_supported": ["public"]
+            })
+        );
+    }
+
+    #[test]
+    fn it_builds_resource_metadata_with_builder_methods() {
+        let metadata = ProtectedResourceMetadata::new("https://api.example.com")
+            .with_authorization_servers(["https://auth.example.com"])
+            .with_jwks_uri("https://api.example.com/jwks")
+            .with_scopes(["read", "write"])
+            .with_bearer_methods(["header"])
+            .with_resource_signing_algs(["ES256"])
+            .with_resource_name("Example API")
+            .with_resource_documentation("https://api.example.com/docs")
+            .with_resource_policy_uri("https://api.example.com/policy")
+            .with_resource_tos_uri("https://api.example.com/tos")
+            .with_tls_client_certificate_bound_access_tokens(true)
+            .with_authorization_details_types(["payment_initiation"])
+            .with_dpop_signing_algs(["ES256"])
+            .with_dpop_bound_access_tokens(false)
+            .with_signed_metadata("header.payload.signature")
+            .with_additional_field("custom_extension", json!({ "nested": true }));
+
+        let json = serde_json::to_value(&metadata).unwrap();
+        assert_eq!(
+            json,
+            json!({
+                "resource": "https://api.example.com",
+                "authorization_servers": ["https://auth.example.com"],
+                "jwks_uri": "https://api.example.com/jwks",
+                "scopes_supported": ["read", "write"],
+                "bearer_methods_supported": ["header"],
+                "resource_signing_alg_values_supported": ["ES256"],
+                "resource_name": "Example API",
+                "resource_documentation": "https://api.example.com/docs",
+                "resource_policy_uri": "https://api.example.com/policy",
+                "resource_tos_uri": "https://api.example.com/tos",
+                "tls_client_certificate_bound_access_tokens": true,
+                "authorization_details_types_supported": ["payment_initiation"],
+                "dpop_signing_alg_values_supported": ["ES256"],
+                "dpop_bound_access_tokens_required": false,
+                "signed_metadata": "header.payload.signature",
+                "custom_extension": { "nested": true }
+            })
+        );
     }
 
     #[test]

--- a/volga/src/auth/oauth/utils.rs
+++ b/volga/src/auth/oauth/utils.rs
@@ -7,6 +7,9 @@
 //!   [RFC 8707 §2](https://www.rfc-editor.org/rfc/rfc8707#section-2)
 
 use super::error::{OAuthError, OAuthErrorCode};
+use super::metadata::{
+    WELL_KNOWN_AUTHORIZATION_SERVER, WELL_KNOWN_OPENID_CONFIGURATION, WELL_KNOWN_PROTECTED_RESOURCE,
+};
 use std::fmt::{self, Display, Formatter, Write};
 use std::net::Ipv6Addr;
 use std::str::FromStr;
@@ -529,6 +532,106 @@ pub fn canonicalize_resource_uri(uri: &str) -> Result<String, OAuthError> {
     Ok(result)
 }
 
+/// Derives the Protected Resource Metadata URL for a resource identifier
+/// per [RFC 9728 §3.1](https://www.rfc-editor.org/rfc/rfc9728#section-3.1):
+/// the well-known path is inserted between the host and the path components
+/// of the canonicalized resource identifier.
+///
+/// Returns an [`OAuthError`] with code `invalid_target` when the resource
+/// identifier is not a valid `http`/`https` URI or contains a query.
+///
+/// # Example
+/// ```
+/// use volga::auth::oauth::protected_resource_metadata_url;
+///
+/// let url = protected_resource_metadata_url("https://api.example.com").unwrap();
+/// assert_eq!(url, "https://api.example.com/.well-known/oauth-protected-resource");
+///
+/// let url = protected_resource_metadata_url("https://api.example.com/v1").unwrap();
+/// assert_eq!(url, "https://api.example.com/.well-known/oauth-protected-resource/v1");
+/// ```
+pub fn protected_resource_metadata_url(resource: &str) -> Result<String, OAuthError> {
+    insert_well_known_path(resource, WELL_KNOWN_PROTECTED_RESOURCE)
+}
+
+/// Derives the Authorization Server Metadata URL for an issuer identifier
+/// per [RFC 8414 §3.1](https://www.rfc-editor.org/rfc/rfc8414#section-3.1):
+/// the well-known path is inserted between the host and the path components
+/// of the canonicalized issuer identifier.
+///
+/// Returns an [`OAuthError`] with code `invalid_target` when the issuer
+/// identifier is not a valid `http`/`https` URI or contains a query
+/// (RFC 8414 §2 forbids query and fragment components in the issuer).
+///
+/// # Example
+/// ```
+/// use volga::auth::oauth::authorization_server_metadata_url;
+///
+/// let url = authorization_server_metadata_url("https://auth.example.com/tenant1").unwrap();
+/// assert_eq!(url, "https://auth.example.com/.well-known/oauth-authorization-server/tenant1");
+/// ```
+pub fn authorization_server_metadata_url(issuer: &str) -> Result<String, OAuthError> {
+    insert_well_known_path(issuer, WELL_KNOWN_AUTHORIZATION_SERVER)
+}
+
+/// Derives the OpenID Connect Discovery metadata URL for an issuer identifier
+/// per [OpenID Connect Discovery 1.0 §4](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig):
+/// unlike the RFC 8414 rule, the well-known path is appended **after** the
+/// issuer's path component (a trailing slash in the issuer is dropped first).
+///
+/// Returns an [`OAuthError`] with code `invalid_target` when the issuer
+/// identifier is not a valid `http`/`https` URI or contains a query.
+///
+/// # Example
+/// ```
+/// use volga::auth::oauth::openid_configuration_url;
+///
+/// let url = openid_configuration_url("https://auth.example.com").unwrap();
+/// assert_eq!(url, "https://auth.example.com/.well-known/openid-configuration");
+///
+/// let url = openid_configuration_url("https://auth.example.com/tenant1").unwrap();
+/// assert_eq!(url, "https://auth.example.com/tenant1/.well-known/openid-configuration");
+/// ```
+pub fn openid_configuration_url(issuer: &str) -> Result<String, OAuthError> {
+    let canonical = canonical_metadata_base(issuer)?;
+    let base = canonical.strip_suffix('/').unwrap_or(&canonical);
+    let mut url = String::with_capacity(base.len() + WELL_KNOWN_OPENID_CONFIGURATION.len());
+    url.push_str(base);
+    url.push_str(WELL_KNOWN_OPENID_CONFIGURATION);
+    Ok(url)
+}
+
+/// Canonicalizes a resource/issuer identifier and validates that a metadata
+/// URL can be derived from it: an `http`/`https` URI without a query.
+fn canonical_metadata_base(uri: &str) -> Result<String, OAuthError> {
+    let canonical = canonicalize_resource_uri(uri)?;
+    if !canonical.starts_with("https://") && !canonical.starts_with("http://") {
+        return Err(invalid_target(
+            "metadata URL can only be derived from an http(s) URI",
+        ));
+    }
+    if canonical.contains('?') {
+        return Err(invalid_target("metadata URL base must not contain a query"));
+    }
+    Ok(canonical)
+}
+
+/// Inserts a well-known path between the authority and the path of a
+/// canonicalized `http`/`https` URI (the insertion rule shared by
+/// RFC 8414 §3.1 and RFC 9728 §3.1).
+fn insert_well_known_path(uri: &str, well_known: &str) -> Result<String, OAuthError> {
+    let canonical = canonical_metadata_base(uri)?;
+    let after_scheme = canonical.find("://").expect("scheme checked above") + 3;
+    let path_start = canonical[after_scheme..]
+        .find('/')
+        .map_or(canonical.len(), |i| after_scheme + i);
+    let mut url = String::with_capacity(canonical.len() + well_known.len());
+    url.push_str(&canonical[..path_start]);
+    url.push_str(well_known);
+    url.push_str(&canonical[path_start..]);
+    Ok(url)
+}
+
 /// Splits a URI authority (without userinfo) into host and optional port,
 /// keeping IP literals (`[::1]`) intact and validating their content.
 fn split_host_port(authority: &str) -> Result<(&str, Option<&str>), OAuthError> {
@@ -945,6 +1048,64 @@ mod tests {
             canonicalize_resource_uri("foo://api.example.com:80/x").unwrap(),
             "foo://api.example.com:80/x"
         );
+    }
+
+    #[test]
+    fn it_derives_metadata_urls() {
+        assert_eq!(
+            protected_resource_metadata_url("HTTPS://API.Example.com:443").unwrap(),
+            "https://api.example.com/.well-known/oauth-protected-resource"
+        );
+        assert_eq!(
+            protected_resource_metadata_url("https://api.example.com/v1").unwrap(),
+            "https://api.example.com/.well-known/oauth-protected-resource/v1"
+        );
+        assert_eq!(
+            protected_resource_metadata_url("http://localhost:8080/api").unwrap(),
+            "http://localhost:8080/.well-known/oauth-protected-resource/api"
+        );
+        assert_eq!(
+            authorization_server_metadata_url("https://auth.example.com/").unwrap(),
+            "https://auth.example.com/.well-known/oauth-authorization-server"
+        );
+        assert_eq!(
+            authorization_server_metadata_url("https://auth.example.com/tenant1").unwrap(),
+            "https://auth.example.com/.well-known/oauth-authorization-server/tenant1"
+        );
+    }
+
+    #[test]
+    fn it_derives_openid_configuration_urls() {
+        assert_eq!(
+            openid_configuration_url("HTTPS://Auth.Example.com:443").unwrap(),
+            "https://auth.example.com/.well-known/openid-configuration"
+        );
+        // OIDC appends after the path, unlike the RFC 8414 insertion rule
+        assert_eq!(
+            openid_configuration_url("https://auth.example.com/tenant1").unwrap(),
+            "https://auth.example.com/tenant1/.well-known/openid-configuration"
+        );
+        assert_eq!(
+            openid_configuration_url("https://auth.example.com/tenant1/").unwrap(),
+            "https://auth.example.com/tenant1/.well-known/openid-configuration"
+        );
+    }
+
+    #[test]
+    fn it_rejects_underivable_metadata_urls() {
+        let cases = [
+            "urn:example:resource",           // no authority to insert after
+            "https://api.example.com?x=1",    // query in the base URI
+            "https://api.example.com/v1?x=1", // query in the base URI
+            "wss://api.example.com",          // not an http(s) scheme
+            "not a uri",
+        ];
+        for uri in cases {
+            let err = protected_resource_metadata_url(uri).unwrap_err();
+            assert_eq!(err.error, OAuthErrorCode::InvalidTarget, "case: {uri}");
+            let err = openid_configuration_url(uri).unwrap_err();
+            assert_eq!(err.error, OAuthErrorCode::InvalidTarget, "case: {uri}");
+        }
     }
 
     #[test]

--- a/volga/tests/auth_www_authenticate_tests.rs
+++ b/volga/tests/auth_www_authenticate_tests.rs
@@ -60,3 +60,74 @@ async fn it_includes_resource_metadata_in_challenge() {
     );
     server.shutdown().await;
 }
+
+#[tokio::test]
+async fn it_derives_resource_metadata_from_mounted_metadata_route() {
+    let server = TestServer::builder()
+        .configure(|app| {
+            app.with_bearer_auth(|auth| {
+                auth.set_decoding_key(DecodingKey::from_secret(b"wrong-secret"))
+            })
+        })
+        .setup(|app: &mut App| {
+            app.use_oauth_resource_metadata("https://api.example.com");
+            app.map_get("/x", || async { volga::ok!("x") })
+                .authorize::<Claims>(roles(["admin"]));
+        })
+        .build()
+        .await;
+
+    let res = server
+        .client()
+        .get(server.url("/x"))
+        .header("Authorization", "Bearer bad-token")
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 403);
+    let www_auth = res.headers().get("www-authenticate").unwrap();
+    let www_auth = www_auth.to_str().unwrap();
+    assert!(
+        www_auth.contains(
+            r#"resource_metadata="https://api.example.com/.well-known/oauth-protected-resource""#
+        ),
+        "header was: {www_auth}"
+    );
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn it_prefers_explicit_resource_metadata_url_over_derived() {
+    let server = TestServer::builder()
+        .configure(|app| {
+            app.with_bearer_auth(|auth| {
+                auth.set_decoding_key(DecodingKey::from_secret(b"wrong-secret"))
+                    .with_resource_metadata_url("https://api.example.com/custom-metadata")
+            })
+        })
+        .setup(|app: &mut App| {
+            app.use_oauth_resource_metadata("https://api.example.com");
+            app.map_get("/x", || async { volga::ok!("x") })
+                .authorize::<Claims>(roles(["admin"]));
+        })
+        .build()
+        .await;
+
+    let res = server
+        .client()
+        .get(server.url("/x"))
+        .header("Authorization", "Bearer bad-token")
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 403);
+    let www_auth = res.headers().get("www-authenticate").unwrap();
+    let www_auth = www_auth.to_str().unwrap();
+    assert!(
+        www_auth.contains(r#"resource_metadata="https://api.example.com/custom-metadata""#),
+        "header was: {www_auth}"
+    );
+    server.shutdown().await;
+}

--- a/volga/tests/oauth_metadata_tests.rs
+++ b/volga/tests/oauth_metadata_tests.rs
@@ -1,0 +1,215 @@
+//! Verifies the built-in OAuth metadata handlers (RFC 8414 §3, RFC 9728 §3,
+//! OIDC Discovery 1.0 §4).
+
+#![cfg(all(feature = "oauth", feature = "test"))]
+
+use volga::{
+    App,
+    auth::oauth::{AuthorizationServerMetadata, ProtectedResourceMetadata},
+    test::TestServer,
+};
+
+#[tokio::test]
+async fn it_serves_resource_metadata() {
+    let server = TestServer::builder()
+        .setup(|app: &mut App| {
+            let metadata = ProtectedResourceMetadata::new("https://api.example.com")
+                .with_authorization_servers(["https://auth.example.com"])
+                .with_scopes(["read", "write"]);
+            app.use_oauth_resource_metadata(metadata);
+        })
+        .build()
+        .await;
+
+    let res = server
+        .client()
+        .get(server.url("/.well-known/oauth-protected-resource"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let content_type = res.headers().get("content-type").unwrap().to_str().unwrap();
+    assert!(
+        content_type.starts_with("application/json"),
+        "content-type was: {content_type}"
+    );
+    let cache_control = res
+        .headers()
+        .get("cache-control")
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert!(
+        cache_control.contains("public"),
+        "cache-control was: {cache_control}"
+    );
+
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["resource"], "https://api.example.com");
+    assert_eq!(body["authorization_servers"][0], "https://auth.example.com");
+    assert_eq!(
+        body["scopes_supported"],
+        serde_json::json!(["read", "write"])
+    );
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn it_serves_resource_metadata_for_path_resources() {
+    let server = TestServer::builder()
+        .setup(|app: &mut App| {
+            // The well-known path is inserted between host and path (RFC 9728 §3.1)
+            app.use_oauth_resource_metadata("https://api.example.com/api/v1");
+        })
+        .build()
+        .await;
+
+    let res = server
+        .client()
+        .get(server.url("/.well-known/oauth-protected-resource/api/v1"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["resource"], "https://api.example.com/api/v1");
+
+    // The root well-known path is not mounted for a path-scoped resource
+    let res = server
+        .client()
+        .get(server.url("/.well-known/oauth-protected-resource"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 404);
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn it_serves_server_metadata() {
+    let server = TestServer::builder()
+        .setup(|app: &mut App| {
+            let metadata = AuthorizationServerMetadata::new("https://auth.example.com")
+                .with_token_endpoint("https://auth.example.com/token");
+            app.use_oauth_server_metadata(metadata);
+        })
+        .build()
+        .await;
+
+    let res = server
+        .client()
+        .get(server.url("/.well-known/oauth-authorization-server"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["issuer"], "https://auth.example.com");
+    assert_eq!(body["token_endpoint"], "https://auth.example.com/token");
+    assert_eq!(
+        body["response_types_supported"],
+        serde_json::json!(["code"])
+    );
+    assert_eq!(
+        body["grant_types_supported"],
+        serde_json::json!(["authorization_code"])
+    );
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn it_serves_openid_configuration() {
+    let server = TestServer::builder()
+        .setup(|app: &mut App| {
+            let metadata = AuthorizationServerMetadata::new("https://auth.example.com")
+                .with_jwks_uri("https://auth.example.com/jwks")
+                .with_additional_field("subject_types_supported", serde_json::json!(["public"]));
+            app.use_oauth_server_metadata(metadata.clone())
+                .use_oidc_metadata(metadata);
+        })
+        .build()
+        .await;
+
+    // The same document is available at both discovery paths
+    for path in [
+        "/.well-known/openid-configuration",
+        "/.well-known/oauth-authorization-server",
+    ] {
+        let res = server.client().get(server.url(path)).send().await.unwrap();
+        assert_eq!(res.status(), 200, "path: {path}");
+        let body: serde_json::Value = res.json().await.unwrap();
+        assert_eq!(body["issuer"], "https://auth.example.com");
+        assert_eq!(body["jwks_uri"], "https://auth.example.com/jwks");
+        assert_eq!(
+            body["subject_types_supported"],
+            serde_json::json!(["public"])
+        );
+    }
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn it_serves_openid_configuration_for_path_issuers() {
+    let server = TestServer::builder()
+        .setup(|app: &mut App| {
+            // OIDC appends the well-known path after the issuer's path,
+            // unlike the RFC 8414 insertion rule
+            app.use_oidc_metadata("https://auth.example.com/tenant1");
+        })
+        .build()
+        .await;
+
+    let res = server
+        .client()
+        .get(server.url("/tenant1/.well-known/openid-configuration"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["issuer"], "https://auth.example.com/tenant1");
+
+    let res = server
+        .client()
+        .get(server.url("/.well-known/openid-configuration"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 404);
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn it_serves_minimal_metadata_from_identifier_strings() {
+    let server = TestServer::builder()
+        .setup(|app: &mut App| {
+            app.use_oauth_resource_metadata("https://api.example.com")
+                .use_oauth_server_metadata("https://auth.example.com");
+        })
+        .build()
+        .await;
+
+    let res = server
+        .client()
+        .get(server.url("/.well-known/oauth-protected-resource"))
+        .send()
+        .await
+        .unwrap();
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(
+        body,
+        serde_json::json!({ "resource": "https://api.example.com" })
+    );
+
+    let res = server
+        .client()
+        .get(server.url("/.well-known/oauth-authorization-server"))
+        .send()
+        .await
+        .unwrap();
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["issuer"], "https://auth.example.com");
+    server.shutdown().await;
+}


### PR DESCRIPTION
## Summary
OAuth metadata serving handlers. Adds built-in handlers that serve OAuth discovery documents from a volga application: `App::use_oauth_resource_metadata` (RFC 9728 §3), `App::use_oauth_server_metadata` (RFC 8414 §3), and `App::use_oidc_metadata` (OpenID Connect Discovery 1.0 §4). Each mounts a `GET` route at the well-known path derived from the resource/issuer identifier, serving the document as `application/json` with a public one-hour cache policy. All three accept `impl Into<...Metadata>`, so a bare `&str/String` identifier serves the minimal document; both metadata types gained full `with_* builder` coverage (`IntoIterator` for list fields, `with_additional_field` for OIDC/extension fields).

RFC 9728 §5.1 wiring. When an app serves resource metadata and bearer auth has no explicit `with_resource_metadata_url`, the derived URL is now advertised automatically as `resource_metadata` in `WWW-Authenticate` challenges; an explicit URL always wins. The URL-derivation helpers (`protected_resource_metadata_url`, `authorization_server_metadata_url`, `openid_configuration_url`) are public — the upcoming discovery client reuses them.

## Type
- [ ] Bug fix
- [x] Feature
- [x] Enhancement
- [ ] Performance
- [ ] Documentation
- [ ] Refactor
- [ ] Security
- [ ] Breaking change

## Checklist
- [x] I added/updated tests where it makes sense
- [x] I updated docs/examples if needed
- [x] This change is backwards-compatible (or clearly marked as breaking)
- [x] I ran formatting/lints locally (if applicable)

## Notes for reviewers
- Two different well-known derivation rules: RFC 8414/9728 insert the well-known path between host and path (https://host/.well-known/oauth-authorization-server/tenant1), while OIDC Discovery appends it after the path (https://host/tenant1/.well-known/openid-configuration). Both are covered by unit and integration tests.
- `use_oauth_*`/`use_oidc_metadata` panic on an underivable identifier (non-http(s) URI or a query component) — startup misconfiguration, matching the use_open_api precedent.
- The `App::oauth_resource_metadata_url` field is gated behind `jwt-auth` (not `oauth`): its only consumer is the `WWW-Authenticate` challenge built by bearer auth, so under `oauth`-only builds the field would be dead code. `cargo check --features oauth` (without `jwt-auth`) passes clean.
- `BearerTokenService::from_config` gained a third parameter (`default_resource_metadata_url`) instead of a separate config-mutating method — explicit config wins over the derived default at service construction. The method is pub(crate), so no API impact.
- New example crate `examples/oauth_metadata` demonstrates all three handlers plus the automatic challenge advertising.
