### PR TITLE
OAuth metadata DSL Improvements + file configuration

### DIFF
--- a/examples/oauth_metadata/src/main.rs
+++ b/examples/oauth_metadata/src/main.rs
@@ -18,7 +18,7 @@
 use serde::Deserialize;
 use volga::{
     App,
-    auth::{AuthClaims, DecodingKey, oauth::ProtectedResourceMetadata, roles},
+    auth::{AuthClaims, DecodingKey, roles},
     ok,
 };
 
@@ -40,23 +40,29 @@ fn main() {
         .with_bearer_auth(|auth| {
             auth.set_decoding_key(DecodingKey::from_secret(b"secret"))
                 .require_https(false)
-        });
+        })
+        // Protected Resource Metadata (RFC 9728)
+        .with_oauth_resource_metadata(|metadata| {
+            metadata
+                .with_resource("http://127.0.0.1:7878")
+                .with_authorization_servers(["https://auth.example.com"])
+                .with_scopes(["read", "write"])
+                .with_bearer_methods(["header"])
+        })
+        // Authorization Server Metadata (RFC 8414) — only when the
+        // application is also an authorization server; the identifier
+        // string alone configures the minimal document. Both documents can
+        // also come from the `[oauth.resource]`/`[oauth.server]` sections
+        // of the config file (`config` feature).
+        .set_oauth_server_metadata("http://127.0.0.1:7878");
 
-    // Protected Resource Metadata (RFC 9728),
-    // served at /.well-known/oauth-protected-resource
-    let resource = ProtectedResourceMetadata::new("http://127.0.0.1:7878")
-        .with_authorization_servers(["https://auth.example.com"])
-        .with_scopes(["read", "write"])
-        .with_bearer_methods(["header"]);
-    app.use_oauth_resource_metadata(resource);
+    // GET /.well-known/oauth-protected-resource
+    app.use_oauth_resource_metadata();
 
-    // Authorization Server Metadata (RFC 8414) — only when the application
-    // is also an authorization server; the identifier string alone serves
-    // the minimal document at /.well-known/oauth-authorization-server.
-    // The same document is commonly published at the OpenID Connect
-    // Discovery path too (/.well-known/openid-configuration)
-    app.use_oauth_server_metadata("http://127.0.0.1:7878")
-        .use_oidc_metadata("http://127.0.0.1:7878");
+    // The same server document is commonly published at both discovery paths:
+    // GET /.well-known/oauth-authorization-server
+    // GET /.well-known/openid-configuration
+    app.use_oauth_server_metadata().use_oidc_metadata();
 
     app.map_get("/protected", || async { ok!("protected") })
         .authorize::<Claims>(roles(["admin"]));

--- a/volga/src/app.rs
+++ b/volga/src/app.rs
@@ -141,6 +141,16 @@ pub struct App {
     #[cfg(feature = "jwt-auth")]
     pub(super) oauth_resource_metadata_url: Option<String>,
 
+    /// OAuth 2.0 Protected Resource Metadata (RFC 9728) configuration options,
+    /// served by [`App::use_oauth_resource_metadata`]
+    #[cfg(feature = "oauth")]
+    pub(super) oauth_resource_metadata: Option<crate::auth::oauth::ProtectedResourceMetadata>,
+
+    /// OAuth 2.0 Authorization Server Metadata (RFC 8414) configuration options,
+    /// served by [`App::use_oauth_server_metadata`] and [`App::use_oidc_metadata`]
+    #[cfg(feature = "oauth")]
+    pub(super) oauth_server_metadata: Option<crate::auth::oauth::AuthorizationServerMetadata>,
+
     /// Global rate limiter
     #[cfg(feature = "rate-limiting")]
     pub(super) rate_limiter: Option<GlobalRateLimiter>,
@@ -264,6 +274,10 @@ impl App {
             auth_config: None,
             #[cfg(feature = "jwt-auth")]
             oauth_resource_metadata_url: None,
+            #[cfg(feature = "oauth")]
+            oauth_resource_metadata: None,
+            #[cfg(feature = "oauth")]
+            oauth_server_metadata: None,
             #[cfg(feature = "rate-limiting")]
             rate_limiter: None,
             #[cfg(feature = "rate-limiting")]

--- a/volga/src/auth/oauth.rs
+++ b/volga/src/auth/oauth.rs
@@ -9,9 +9,14 @@
 //!   resource URI canonicalization per [RFC 8707](https://www.rfc-editor.org/rfc/rfc8707)
 //!   and well-known metadata URL derivation
 //! * Built-in handlers serving the metadata documents from a volga
-//!   application ([`App::use_oauth_resource_metadata`](crate::App::use_oauth_resource_metadata),
-//!   [`App::use_oauth_server_metadata`](crate::App::use_oauth_server_metadata),
-//!   [`App::use_oidc_metadata`](crate::App::use_oidc_metadata))
+//!   application: configure with
+//!   [`App::with_oauth_resource_metadata`](crate::App::with_oauth_resource_metadata) /
+//!   [`App::with_oauth_server_metadata`](crate::App::with_oauth_server_metadata)
+//!   (or the `set_*` counterparts, or the `[oauth.resource]`/`[oauth.server]`
+//!   config file sections), then serve via
+//!   [`App::use_oauth_resource_metadata`](crate::App::use_oauth_resource_metadata),
+//!   [`App::use_oauth_server_metadata`](crate::App::use_oauth_server_metadata) and
+//!   [`App::use_oidc_metadata`](crate::App::use_oidc_metadata)
 //!
 //! This module intentionally contains no client flows yet — the discovery
 //! client is built on top of these types separately.

--- a/volga/src/auth/oauth/handlers.rs
+++ b/volga/src/auth/oauth/handlers.rs
@@ -1,4 +1,8 @@
-//! Built-in handlers serving OAuth metadata documents
+//! Configuration and built-in handlers serving OAuth metadata documents
+//!
+//! Metadata is configured on [`App`] with `with_*` (closure) / `set_*`
+//! (whole value, including the `&str` identifier shorthand) and served by
+//! the parameterless `use_*` methods:
 //!
 //! * [`App::use_oauth_resource_metadata`] — Protected Resource Metadata
 //!   per [RFC 9728 §3](https://www.rfc-editor.org/rfc/rfc9728#section-3)
@@ -6,6 +10,10 @@
 //!   per [RFC 8414 §3](https://www.rfc-editor.org/rfc/rfc8414#section-3)
 //! * [`App::use_oidc_metadata`] — the same document at the OpenID Connect
 //!   Discovery path per [OIDC Discovery 1.0 §4](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig)
+//!
+//! With the `config` feature, both documents can also be provided by the
+//! `[oauth.resource]` and `[oauth.server]` sections of the configuration
+//! file; the file overrides prior builder calls.
 
 use serde::Serialize;
 use std::sync::Arc;
@@ -20,8 +28,133 @@ use super::{
     openid_configuration_url, protected_resource_metadata_url,
 };
 
+const RESOURCE_METADATA_NOT_CONFIGURED: &str = "OAuth protected resource metadata is not configured. \
+    Use `App::with_oauth_resource_metadata` or `App::set_oauth_resource_metadata` to configure it.";
+
+const SERVER_METADATA_NOT_CONFIGURED: &str = "OAuth authorization server metadata is not configured. \
+    Use `App::with_oauth_server_metadata` or `App::set_oauth_server_metadata` to configure it.";
+
 impl App {
-    /// Serves OAuth 2.0 Protected Resource Metadata (RFC 9728 §3)
+    /// Configures OAuth 2.0 Protected Resource Metadata (RFC 9728) via a
+    /// builder closure
+    ///
+    /// The closure receives the currently configured document (e.g. from the
+    /// `[oauth.resource]` config file section or an earlier builder call) or
+    /// a default one. Call [`use_oauth_resource_metadata`] to serve it.
+    ///
+    /// [`use_oauth_resource_metadata`]: App::use_oauth_resource_metadata
+    ///
+    /// # Example
+    /// ```no_run
+    /// use volga::App;
+    ///
+    /// let mut app = App::new().with_oauth_resource_metadata(|metadata| metadata
+    ///     .with_resource("https://api.example.com")
+    ///     .with_authorization_servers(["https://auth.example.com"])
+    ///     .with_scopes(["read", "write"]));
+    ///
+    /// app.use_oauth_resource_metadata();
+    /// ```
+    pub fn with_oauth_resource_metadata<F>(mut self, config: F) -> Self
+    where
+        F: FnOnce(ProtectedResourceMetadata) -> ProtectedResourceMetadata,
+    {
+        let metadata = self.oauth_resource_metadata.take().unwrap_or_default();
+        self.oauth_resource_metadata = Some(config(metadata));
+        self
+    }
+
+    /// Sets the OAuth 2.0 Protected Resource Metadata (RFC 9728)
+    ///
+    /// Accepts anything convertible into [`ProtectedResourceMetadata`],
+    /// including the resource identifier itself (`&str` / `String`) for the
+    /// minimal document. Call [`use_oauth_resource_metadata`] to serve it.
+    ///
+    /// [`use_oauth_resource_metadata`]: App::use_oauth_resource_metadata
+    ///
+    /// # Example
+    /// ```no_run
+    /// use volga::App;
+    ///
+    /// let mut app = App::new()
+    ///     .set_oauth_resource_metadata("https://api.example.com");
+    ///
+    /// app.use_oauth_resource_metadata();
+    /// ```
+    pub fn set_oauth_resource_metadata<M>(mut self, metadata: M) -> Self
+    where
+        M: Into<ProtectedResourceMetadata>,
+    {
+        self.oauth_resource_metadata = Some(metadata.into());
+        self
+    }
+
+    /// Configures OAuth 2.0 Authorization Server Metadata (RFC 8414) via a
+    /// builder closure
+    ///
+    /// The closure receives the currently configured document (e.g. from the
+    /// `[oauth.server]` config file section or an earlier builder call) or a
+    /// default one carrying the [`AuthorizationServerMetadata::new`]
+    /// prefills (`response_types_supported = ["code"]`,
+    /// `grant_types_supported = ["authorization_code"]`). Call
+    /// [`use_oauth_server_metadata`] and/or [`use_oidc_metadata`] to serve it.
+    ///
+    /// [`use_oauth_server_metadata`]: App::use_oauth_server_metadata
+    /// [`use_oidc_metadata`]: App::use_oidc_metadata
+    ///
+    /// # Example
+    /// ```no_run
+    /// use volga::App;
+    ///
+    /// let mut app = App::new().with_oauth_server_metadata(|metadata| metadata
+    ///     .with_issuer("https://auth.example.com")
+    ///     .with_authorization_endpoint("https://auth.example.com/authorize")
+    ///     .with_token_endpoint("https://auth.example.com/token"));
+    ///
+    /// app.use_oauth_server_metadata();
+    /// ```
+    pub fn with_oauth_server_metadata<F>(mut self, config: F) -> Self
+    where
+        F: FnOnce(AuthorizationServerMetadata) -> AuthorizationServerMetadata,
+    {
+        let metadata = self
+            .oauth_server_metadata
+            .take()
+            // seed with `new()` rather than `Default` to keep the OAuth 2.1
+            // response/grant type prefills when the closure builds from scratch
+            .unwrap_or_else(|| AuthorizationServerMetadata::new(""));
+        self.oauth_server_metadata = Some(config(metadata));
+        self
+    }
+
+    /// Sets the OAuth 2.0 Authorization Server Metadata (RFC 8414)
+    ///
+    /// Accepts anything convertible into [`AuthorizationServerMetadata`],
+    /// including the issuer identifier itself (`&str` / `String`) for the
+    /// minimal document. Call [`use_oauth_server_metadata`] and/or
+    /// [`use_oidc_metadata`] to serve it.
+    ///
+    /// [`use_oauth_server_metadata`]: App::use_oauth_server_metadata
+    /// [`use_oidc_metadata`]: App::use_oidc_metadata
+    ///
+    /// # Example
+    /// ```no_run
+    /// use volga::App;
+    ///
+    /// let mut app = App::new()
+    ///     .set_oauth_server_metadata("https://auth.example.com");
+    ///
+    /// app.use_oauth_server_metadata();
+    /// ```
+    pub fn set_oauth_server_metadata<M>(mut self, metadata: M) -> Self
+    where
+        M: Into<AuthorizationServerMetadata>,
+    {
+        self.oauth_server_metadata = Some(metadata.into());
+        self
+    }
+
+    /// Serves the configured OAuth 2.0 Protected Resource Metadata (RFC 9728 §3)
     ///
     /// Mounts a `GET` route returning the document as `application/json` at
     /// the well-known path derived from the `resource` identifier per
@@ -29,36 +162,38 @@ impl App {
     /// resource's path appended (e.g. `/.well-known/oauth-protected-resource/v1`
     /// for `https://api.example.com/v1`).
     ///
-    /// Accepts anything convertible into [`ProtectedResourceMetadata`],
-    /// including the resource identifier itself (`&str` / `String`) for the
-    /// minimal document. When bearer authentication is configured and no
-    /// explicit [`with_resource_metadata_url`] is set, the derived metadata
-    /// URL is advertised automatically in `WWW-Authenticate` challenges
+    /// When bearer authentication is configured and no explicit
+    /// [`with_resource_metadata_url`] is set, the derived metadata URL is
+    /// advertised automatically in `WWW-Authenticate` challenges
     /// (RFC 9728 §5.1).
     ///
-    /// Panics when the `resource` identifier is not a valid `http`/`https`
-    /// URI or contains a query — this is a startup misconfiguration.
+    /// Panics when no document is configured (via
+    /// [`with_oauth_resource_metadata`], [`set_oauth_resource_metadata`] or
+    /// the `[oauth.resource]` config file section), or when the `resource`
+    /// identifier is not a valid `http`/`https` URI or contains a query —
+    /// these are startup misconfigurations.
     ///
     /// [`with_resource_metadata_url`]: crate::auth::BearerAuthConfig::with_resource_metadata_url
+    /// [`with_oauth_resource_metadata`]: App::with_oauth_resource_metadata
+    /// [`set_oauth_resource_metadata`]: App::set_oauth_resource_metadata
     ///
     /// # Example
     /// ```no_run
-    /// use volga::{App, auth::oauth::ProtectedResourceMetadata};
+    /// use volga::App;
     ///
-    /// let mut app = App::new();
-    ///
-    /// let metadata = ProtectedResourceMetadata::new("https://api.example.com")
+    /// let mut app = App::new().with_oauth_resource_metadata(|metadata| metadata
+    ///     .with_resource("https://api.example.com")
     ///     .with_authorization_servers(["https://auth.example.com"])
-    ///     .with_scopes(["read", "write"]);
+    ///     .with_scopes(["read", "write"]));
     ///
-    /// app.use_oauth_resource_metadata(metadata);
+    /// app.use_oauth_resource_metadata();
     /// // GET /.well-known/oauth-protected-resource
     /// ```
-    pub fn use_oauth_resource_metadata<M>(&mut self, metadata: M) -> &mut Self
-    where
-        M: Into<ProtectedResourceMetadata>,
-    {
-        let metadata = metadata.into();
+    pub fn use_oauth_resource_metadata(&mut self) -> &mut Self {
+        let metadata = self
+            .oauth_resource_metadata
+            .clone()
+            .expect(RESOURCE_METADATA_NOT_CONFIGURED);
         let metadata_url = protected_resource_metadata_url(&metadata.resource)
             .unwrap_or_else(|err| panic!("OAuth protected resource metadata: {err}"));
 
@@ -73,7 +208,7 @@ impl App {
         self
     }
 
-    /// Serves OAuth 2.0 Authorization Server Metadata (RFC 8414 §3)
+    /// Serves the configured OAuth 2.0 Authorization Server Metadata (RFC 8414 §3)
     ///
     /// Mounts a `GET` route returning the document as `application/json` at
     /// the well-known path derived from the `issuer` identifier per
@@ -82,31 +217,32 @@ impl App {
     /// `/.well-known/oauth-authorization-server/tenant1` for
     /// `https://auth.example.com/tenant1`).
     ///
-    /// Accepts anything convertible into [`AuthorizationServerMetadata`],
-    /// including the issuer identifier itself (`&str` / `String`) for the
-    /// minimal document.
+    /// Panics when no document is configured (via
+    /// [`with_oauth_server_metadata`], [`set_oauth_server_metadata`] or the
+    /// `[oauth.server]` config file section), or when the `issuer`
+    /// identifier is not a valid `http`/`https` URI or contains a query —
+    /// these are startup misconfigurations.
     ///
-    /// Panics when the `issuer` identifier is not a valid `http`/`https`
-    /// URI or contains a query — this is a startup misconfiguration.
+    /// [`with_oauth_server_metadata`]: App::with_oauth_server_metadata
+    /// [`set_oauth_server_metadata`]: App::set_oauth_server_metadata
     ///
     /// # Example
     /// ```no_run
-    /// use volga::{App, auth::oauth::AuthorizationServerMetadata};
+    /// use volga::App;
     ///
-    /// let mut app = App::new();
-    ///
-    /// let metadata = AuthorizationServerMetadata::new("https://auth.example.com")
+    /// let mut app = App::new().with_oauth_server_metadata(|metadata| metadata
+    ///     .with_issuer("https://auth.example.com")
     ///     .with_authorization_endpoint("https://auth.example.com/authorize")
-    ///     .with_token_endpoint("https://auth.example.com/token");
+    ///     .with_token_endpoint("https://auth.example.com/token"));
     ///
-    /// app.use_oauth_server_metadata(metadata);
+    /// app.use_oauth_server_metadata();
     /// // GET /.well-known/oauth-authorization-server
     /// ```
-    pub fn use_oauth_server_metadata<M>(&mut self, metadata: M) -> &mut Self
-    where
-        M: Into<AuthorizationServerMetadata>,
-    {
-        let metadata = metadata.into();
+    pub fn use_oauth_server_metadata(&mut self) -> &mut Self {
+        let metadata = self
+            .oauth_server_metadata
+            .clone()
+            .expect(SERVER_METADATA_NOT_CONFIGURED);
         let metadata_url = authorization_server_metadata_url(&metadata.issuer)
             .unwrap_or_else(|err| panic!("OAuth authorization server metadata: {err}"));
 
@@ -114,18 +250,18 @@ impl App {
         self
     }
 
-    /// Serves the metadata document at the OpenID Connect Discovery path
+    /// Serves the configured metadata document at the OpenID Connect
+    /// Discovery path
     ///
-    /// Mounts a `GET` route returning the document as `application/json` at
-    /// the path derived from the `issuer` identifier per
+    /// Mounts a `GET` route returning the same document configured for
+    /// [`use_oauth_server_metadata`] as `application/json` at the path
+    /// derived from the `issuer` identifier per
     /// [OIDC Discovery 1.0 §4](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig):
     /// unlike RFC 8414, `/.well-known/openid-configuration` is appended
     /// **after** the issuer's path (e.g.
     /// `/tenant1/.well-known/openid-configuration` for
     /// `https://auth.example.com/tenant1`).
     ///
-    /// Accepts anything convertible into [`AuthorizationServerMetadata`],
-    /// including the issuer identifier itself (`&str` / `String`).
     /// OIDC-specific fields required by a compliant provider document
     /// (`subject_types_supported`, `id_token_signing_alg_values_supported`,
     /// `userinfo_endpoint`, …) can be supplied through
@@ -135,28 +271,31 @@ impl App {
     ///
     /// [`use_oauth_server_metadata`]: App::use_oauth_server_metadata
     ///
-    /// Panics when the `issuer` identifier is not a valid `http`/`https`
-    /// URI or contains a query — this is a startup misconfiguration.
+    /// Panics when no document is configured (via
+    /// [`with_oauth_server_metadata`](App::with_oauth_server_metadata),
+    /// [`set_oauth_server_metadata`](App::set_oauth_server_metadata) or the
+    /// `[oauth.server]` config file section), or when the `issuer`
+    /// identifier is not a valid `http`/`https` URI or contains a query —
+    /// these are startup misconfigurations.
     ///
     /// # Example
     /// ```no_run
-    /// use volga::{App, auth::oauth::AuthorizationServerMetadata};
+    /// use volga::App;
     ///
-    /// let mut app = App::new();
+    /// let mut app = App::new().with_oauth_server_metadata(|metadata| metadata
+    ///     .with_issuer("https://auth.example.com")
+    ///     .with_token_endpoint("https://auth.example.com/token"));
     ///
-    /// let metadata = AuthorizationServerMetadata::new("https://auth.example.com")
-    ///     .with_token_endpoint("https://auth.example.com/token");
-    ///
-    /// app.use_oauth_server_metadata(metadata.clone())
-    ///     .use_oidc_metadata(metadata);
+    /// app.use_oauth_server_metadata()
+    ///     .use_oidc_metadata();
     /// // GET /.well-known/oauth-authorization-server
     /// // GET /.well-known/openid-configuration
     /// ```
-    pub fn use_oidc_metadata<M>(&mut self, metadata: M) -> &mut Self
-    where
-        M: Into<AuthorizationServerMetadata>,
-    {
-        let metadata = metadata.into();
+    pub fn use_oidc_metadata(&mut self) -> &mut Self {
+        let metadata = self
+            .oauth_server_metadata
+            .clone()
+            .expect(SERVER_METADATA_NOT_CONFIGURED);
         let metadata_url = openid_configuration_url(&metadata.issuer)
             .unwrap_or_else(|err| panic!("OpenID Connect discovery metadata: {err}"));
 
@@ -193,4 +332,63 @@ where
 fn metadata_cache_control() -> Header<CacheControl> {
     Header::try_from(CacheControl::default().with_public().with_max_age(3600))
         .expect("valid cache control header")
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::App;
+
+    #[test]
+    fn it_composes_oauth_metadata_builder_calls() {
+        let app = App::new()
+            .set_oauth_resource_metadata("https://api.example.com")
+            .with_oauth_resource_metadata(|metadata| metadata.with_scopes(["read"]))
+            .set_oauth_server_metadata("https://auth.example.com")
+            .with_oauth_server_metadata(|metadata| {
+                metadata.with_token_endpoint("https://auth.example.com/token")
+            });
+
+        let resource = app.oauth_resource_metadata.as_ref().unwrap();
+        assert_eq!(resource.resource, "https://api.example.com");
+        assert_eq!(resource.scopes_supported, ["read"]);
+
+        let server = app.oauth_server_metadata.as_ref().unwrap();
+        assert_eq!(server.issuer, "https://auth.example.com");
+        assert_eq!(
+            server.token_endpoint.as_deref(),
+            Some("https://auth.example.com/token")
+        );
+        // the `new()` prefills survive the closure composition
+        assert_eq!(server.response_types_supported, ["code"]);
+        assert_eq!(server.grant_types_supported, ["authorization_code"]);
+    }
+
+    #[test]
+    fn it_seeds_server_metadata_closure_with_oauth21_prefills() {
+        let app = App::new().with_oauth_server_metadata(|metadata| {
+            metadata.with_issuer("https://auth.example.com")
+        });
+
+        let server = app.oauth_server_metadata.as_ref().unwrap();
+        assert_eq!(server.response_types_supported, ["code"]);
+        assert_eq!(server.grant_types_supported, ["authorization_code"]);
+    }
+
+    #[test]
+    #[should_panic(expected = "OAuth protected resource metadata is not configured")]
+    fn it_panics_when_resource_metadata_is_not_configured() {
+        App::new().use_oauth_resource_metadata();
+    }
+
+    #[test]
+    #[should_panic(expected = "OAuth authorization server metadata is not configured")]
+    fn it_panics_when_server_metadata_is_not_configured() {
+        App::new().use_oauth_server_metadata();
+    }
+
+    #[test]
+    #[should_panic(expected = "OAuth authorization server metadata is not configured")]
+    fn it_panics_when_oidc_metadata_is_not_configured() {
+        App::new().use_oidc_metadata();
+    }
 }

--- a/volga/src/auth/oauth/metadata.rs
+++ b/volga/src/auth/oauth/metadata.rs
@@ -161,6 +161,12 @@ impl AuthorizationServerMetadata {
         }
     }
 
+    /// Sets the authorization server's issuer identifier URL
+    pub fn with_issuer(mut self, issuer: impl Into<String>) -> Self {
+        self.issuer = issuer.into();
+        self
+    }
+
     /// Sets the URL of the authorization endpoint
     pub fn with_authorization_endpoint(mut self, url: impl Into<String>) -> Self {
         self.authorization_endpoint = Some(url.into());
@@ -462,6 +468,12 @@ impl ProtectedResourceMetadata {
             resource: resource.into(),
             ..Default::default()
         }
+    }
+
+    /// Sets the protected resource's resource identifier URL
+    pub fn with_resource(mut self, resource: impl Into<String>) -> Self {
+        self.resource = resource.into();
+        self
     }
 
     /// Sets the issuer identifiers of authorization servers that can be
@@ -767,7 +779,8 @@ mod tests {
 
     #[test]
     fn it_builds_server_metadata_with_builder_methods() {
-        let metadata = AuthorizationServerMetadata::new("https://auth.example.com")
+        let metadata = AuthorizationServerMetadata::new("https://old.example.com")
+            .with_issuer("https://auth.example.com")
             .with_authorization_endpoint("https://auth.example.com/authorize")
             .with_token_endpoint("https://auth.example.com/token")
             .with_jwks_uri("https://auth.example.com/jwks")
@@ -824,7 +837,8 @@ mod tests {
 
     #[test]
     fn it_builds_resource_metadata_with_builder_methods() {
-        let metadata = ProtectedResourceMetadata::new("https://api.example.com")
+        let metadata = ProtectedResourceMetadata::new("https://old.example.com")
+            .with_resource("https://api.example.com")
             .with_authorization_servers(["https://auth.example.com"])
             .with_jwks_uri("https://api.example.com/jwks")
             .with_scopes(["read", "write"])

--- a/volga/src/config/processing.rs
+++ b/volga/src/config/processing.rs
@@ -48,6 +48,10 @@ impl App {
         {
             self = self.apply_cors_section(&full_value)?;
         }
+        #[cfg(feature = "oauth")]
+        {
+            self = self.apply_oauth_section(&full_value)?;
+        }
 
         let store = builder
             .build_from_value(&full_value)
@@ -151,6 +155,54 @@ impl App {
         }
         Ok(self)
     }
+
+    /// Applies the `[oauth.resource]` and `[oauth.server]` sections from the
+    /// parsed config value.
+    #[cfg(feature = "oauth")]
+    fn apply_oauth_section(mut self, value: &Value) -> Result<Self, io::Error> {
+        use crate::auth::oauth::{AuthorizationServerMetadata, ProtectedResourceMetadata};
+
+        let Some(section) = value.get("oauth") else {
+            return Ok(self);
+        };
+
+        if let Some(resource) = section.get("resource") {
+            let metadata: ProtectedResourceMetadata = parse_subsection(resource, "oauth.resource")?;
+            self = self.set_oauth_resource_metadata(metadata);
+        }
+        if let Some(server) = section.get("server") {
+            let mut server = server.clone();
+            // Mirror the `AuthorizationServerMetadata::new()` prefills so a
+            // minimal `[oauth.server]` section behaves like the builder DSL:
+            // `response_types_supported` is REQUIRED per RFC 8414 §2, and
+            // leaving `grant_types_supported` absent would make clients
+            // assume the implicit grant is supported
+            if let Some(obj) = server.as_object_mut() {
+                obj.entry("response_types_supported")
+                    .or_insert_with(|| serde_json::json!(["code"]));
+                obj.entry("grant_types_supported")
+                    .or_insert_with(|| serde_json::json!(["authorization_code"]));
+            }
+            let metadata: AuthorizationServerMetadata = parse_subsection(&server, "oauth.server")?;
+            self = self.set_oauth_server_metadata(metadata);
+        }
+        Ok(self)
+    }
+}
+
+/// Deserializes a nested built-in section (e.g. `[oauth.server]`), reporting
+/// the full dotted key in the startup error.
+#[cfg(feature = "oauth")]
+fn parse_subsection<T: serde::de::DeserializeOwned>(
+    value: &Value,
+    key: &str,
+) -> Result<T, io::Error> {
+    serde_json::from_value(value.clone()).map_err(|e| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("config: [{key}] section is invalid: {e}"),
+        )
+    })
 }
 
 /// Spawns a background task that periodically reloads config from file.
@@ -378,6 +430,64 @@ mod tests {
     #[test]
     fn cors_section_applied_from_config() {
         let file = write_toml("[cors]\n");
+        let path = file.path().to_str().unwrap().to_owned();
+        App::new().with_config(|cfg| cfg.with_file(&path));
+    }
+
+    #[cfg(feature = "oauth")]
+    #[test]
+    fn oauth_section_applied_from_config() {
+        let file = write_toml(
+            "[oauth.resource]\n\
+             resource = \"https://api.example.com\"\n\
+             authorization_servers = [\"https://auth.example.com\"]\n\
+             scopes_supported = [\"read\"]\n\
+             \n\
+             [oauth.server]\n\
+             issuer = \"https://auth.example.com\"\n\
+             subject_types_supported = [\"public\"]\n",
+        );
+        let path = file.path().to_str().unwrap().to_owned();
+
+        let app = App::new().with_config(|cfg| cfg.with_file(&path));
+
+        let resource = app.oauth_resource_metadata.as_ref().unwrap();
+        assert_eq!(resource.resource, "https://api.example.com");
+        assert_eq!(resource.authorization_servers, ["https://auth.example.com"]);
+        assert_eq!(resource.scopes_supported, ["read"]);
+
+        let server = app.oauth_server_metadata.as_ref().unwrap();
+        assert_eq!(server.issuer, "https://auth.example.com");
+        // a minimal section gets the `new()` prefills
+        assert_eq!(server.response_types_supported, ["code"]);
+        assert_eq!(server.grant_types_supported, ["authorization_code"]);
+        // unknown keys land in `additional_fields` (flatten)
+        assert_eq!(
+            server.additional_fields["subject_types_supported"],
+            serde_json::json!(["public"])
+        );
+    }
+
+    #[cfg(feature = "oauth")]
+    #[test]
+    fn oauth_section_overrides_builder_calls() {
+        let file = write_toml("[oauth.server]\nissuer = \"https://file.example.com\"\n");
+        let path = file.path().to_str().unwrap().to_owned();
+
+        let app = App::new()
+            .set_oauth_server_metadata("https://builder.example.com")
+            .with_config(|cfg| cfg.with_file(&path));
+
+        let server = app.oauth_server_metadata.as_ref().unwrap();
+        assert_eq!(server.issuer, "https://file.example.com");
+    }
+
+    #[cfg(feature = "oauth")]
+    #[test]
+    #[should_panic(expected = "config: [oauth.resource] section is invalid")]
+    fn invalid_oauth_section_panics_at_startup() {
+        // `resource` is required for the resource metadata document
+        let file = write_toml("[oauth.resource]\nscopes_supported = [\"read\"]\n");
         let path = file.path().to_str().unwrap().to_owned();
         App::new().with_config(|cfg| cfg.with_file(&path));
     }

--- a/volga/tests/auth_www_authenticate_tests.rs
+++ b/volga/tests/auth_www_authenticate_tests.rs
@@ -68,9 +68,10 @@ async fn it_derives_resource_metadata_from_mounted_metadata_route() {
             app.with_bearer_auth(|auth| {
                 auth.set_decoding_key(DecodingKey::from_secret(b"wrong-secret"))
             })
+            .set_oauth_resource_metadata("https://api.example.com")
         })
         .setup(|app: &mut App| {
-            app.use_oauth_resource_metadata("https://api.example.com");
+            app.use_oauth_resource_metadata();
             app.map_get("/x", || async { volga::ok!("x") })
                 .authorize::<Claims>(roles(["admin"]));
         })
@@ -105,9 +106,10 @@ async fn it_prefers_explicit_resource_metadata_url_over_derived() {
                 auth.set_decoding_key(DecodingKey::from_secret(b"wrong-secret"))
                     .with_resource_metadata_url("https://api.example.com/custom-metadata")
             })
+            .set_oauth_resource_metadata("https://api.example.com")
         })
         .setup(|app: &mut App| {
-            app.use_oauth_resource_metadata("https://api.example.com");
+            app.use_oauth_resource_metadata();
             app.map_get("/x", || async { volga::ok!("x") })
                 .authorize::<Claims>(roles(["admin"]));
         })

--- a/volga/tests/oauth_metadata_tests.rs
+++ b/volga/tests/oauth_metadata_tests.rs
@@ -3,20 +3,21 @@
 
 #![cfg(all(feature = "oauth", feature = "test"))]
 
-use volga::{
-    App,
-    auth::oauth::{AuthorizationServerMetadata, ProtectedResourceMetadata},
-    test::TestServer,
-};
+use volga::{App, test::TestServer};
 
 #[tokio::test]
 async fn it_serves_resource_metadata() {
     let server = TestServer::builder()
+        .configure(|app: App| {
+            app.with_oauth_resource_metadata(|metadata| {
+                metadata
+                    .with_resource("https://api.example.com")
+                    .with_authorization_servers(["https://auth.example.com"])
+                    .with_scopes(["read", "write"])
+            })
+        })
         .setup(|app: &mut App| {
-            let metadata = ProtectedResourceMetadata::new("https://api.example.com")
-                .with_authorization_servers(["https://auth.example.com"])
-                .with_scopes(["read", "write"]);
-            app.use_oauth_resource_metadata(metadata);
+            app.use_oauth_resource_metadata();
         })
         .build()
         .await;
@@ -58,9 +59,12 @@ async fn it_serves_resource_metadata() {
 #[tokio::test]
 async fn it_serves_resource_metadata_for_path_resources() {
     let server = TestServer::builder()
-        .setup(|app: &mut App| {
+        .configure(|app: App| {
             // The well-known path is inserted between host and path (RFC 9728 §3.1)
-            app.use_oauth_resource_metadata("https://api.example.com/api/v1");
+            app.set_oauth_resource_metadata("https://api.example.com/api/v1")
+        })
+        .setup(|app: &mut App| {
+            app.use_oauth_resource_metadata();
         })
         .build()
         .await;
@@ -89,10 +93,15 @@ async fn it_serves_resource_metadata_for_path_resources() {
 #[tokio::test]
 async fn it_serves_server_metadata() {
     let server = TestServer::builder()
+        .configure(|app: App| {
+            app.with_oauth_server_metadata(|metadata| {
+                metadata
+                    .with_issuer("https://auth.example.com")
+                    .with_token_endpoint("https://auth.example.com/token")
+            })
+        })
         .setup(|app: &mut App| {
-            let metadata = AuthorizationServerMetadata::new("https://auth.example.com")
-                .with_token_endpoint("https://auth.example.com/token");
-            app.use_oauth_server_metadata(metadata);
+            app.use_oauth_server_metadata();
         })
         .build()
         .await;
@@ -122,17 +131,21 @@ async fn it_serves_server_metadata() {
 #[tokio::test]
 async fn it_serves_openid_configuration() {
     let server = TestServer::builder()
+        .configure(|app: App| {
+            app.with_oauth_server_metadata(|metadata| {
+                metadata
+                    .with_issuer("https://auth.example.com")
+                    .with_jwks_uri("https://auth.example.com/jwks")
+                    .with_additional_field("subject_types_supported", serde_json::json!(["public"]))
+            })
+        })
         .setup(|app: &mut App| {
-            let metadata = AuthorizationServerMetadata::new("https://auth.example.com")
-                .with_jwks_uri("https://auth.example.com/jwks")
-                .with_additional_field("subject_types_supported", serde_json::json!(["public"]));
-            app.use_oauth_server_metadata(metadata.clone())
-                .use_oidc_metadata(metadata);
+            // Both discovery paths serve the same configured document
+            app.use_oauth_server_metadata().use_oidc_metadata();
         })
         .build()
         .await;
 
-    // The same document is available at both discovery paths
     for path in [
         "/.well-known/openid-configuration",
         "/.well-known/oauth-authorization-server",
@@ -153,10 +166,11 @@ async fn it_serves_openid_configuration() {
 #[tokio::test]
 async fn it_serves_openid_configuration_for_path_issuers() {
     let server = TestServer::builder()
+        .configure(|app: App| app.set_oauth_server_metadata("https://auth.example.com/tenant1"))
         .setup(|app: &mut App| {
             // OIDC appends the well-known path after the issuer's path,
             // unlike the RFC 8414 insertion rule
-            app.use_oidc_metadata("https://auth.example.com/tenant1");
+            app.use_oidc_metadata();
         })
         .build()
         .await;
@@ -184,9 +198,13 @@ async fn it_serves_openid_configuration_for_path_issuers() {
 #[tokio::test]
 async fn it_serves_minimal_metadata_from_identifier_strings() {
     let server = TestServer::builder()
+        .configure(|app: App| {
+            app.set_oauth_resource_metadata("https://api.example.com")
+                .set_oauth_server_metadata("https://auth.example.com")
+        })
         .setup(|app: &mut App| {
-            app.use_oauth_resource_metadata("https://api.example.com")
-                .use_oauth_server_metadata("https://auth.example.com");
+            app.use_oauth_resource_metadata()
+                .use_oauth_server_metadata();
         })
         .build()
         .await;
@@ -211,5 +229,58 @@ async fn it_serves_minimal_metadata_from_identifier_strings() {
         .unwrap();
     let body: serde_json::Value = res.json().await.unwrap();
     assert_eq!(body["issuer"], "https://auth.example.com");
+    server.shutdown().await;
+}
+
+#[cfg(feature = "config")]
+#[tokio::test]
+async fn it_serves_metadata_from_config_file() {
+    use std::io::Write;
+
+    let mut file = tempfile::NamedTempFile::with_suffix(".toml").unwrap();
+    file.write_all(
+        b"[oauth.resource]\n\
+          resource = \"https://api.example.com\"\n\
+          authorization_servers = [\"https://auth.example.com\"]\n\
+          \n\
+          [oauth.server]\n\
+          issuer = \"https://auth.example.com\"\n",
+    )
+    .unwrap();
+    let path = file.path().to_str().unwrap().to_owned();
+
+    let server = TestServer::builder()
+        .configure(move |app: App| app.with_config(|cfg| cfg.with_file(&path)))
+        .setup(|app: &mut App| {
+            app.use_oauth_resource_metadata()
+                .use_oauth_server_metadata()
+                .use_oidc_metadata();
+        })
+        .build()
+        .await;
+
+    let res = server
+        .client()
+        .get(server.url("/.well-known/oauth-protected-resource"))
+        .send()
+        .await
+        .unwrap();
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["resource"], "https://api.example.com");
+    assert_eq!(body["authorization_servers"][0], "https://auth.example.com");
+
+    for path in [
+        "/.well-known/oauth-authorization-server",
+        "/.well-known/openid-configuration",
+    ] {
+        let res = server.client().get(server.url(path)).send().await.unwrap();
+        assert_eq!(res.status(), 200, "path: {path}");
+        let body: serde_json::Value = res.json().await.unwrap();
+        assert_eq!(body["issuer"], "https://auth.example.com");
+        assert_eq!(
+            body["response_types_supported"],
+            serde_json::json!(["code"])
+        );
+    }
     server.shutdown().await;
 }


### PR DESCRIPTION
## Summary
Split OAuth metadata configuration from serving. `ProtectedResourceMetadata` / `AuthorizationServerMetadata` are now stored on `App` and configured through the framework-wide builder convention — `with_oauth_resource_metadata` / `with_oauth_server_metadata` (closure over the current document) and `set_oauth_resource_metadata` / `set_oauth_server_metadata` (whole value, keeping the `&str` identifier shorthand) — mirroring the `with_tls`/`set_tls` and `with_open_api`/`set_open_api` pairs. The `use_*` handlers became parameterless: they serve whatever is configured and panic at startup when nothing is (matching `use_open_api`). Since `use_oauth_server_metadata()` and `use_oidc_metadata()` now share one stored document, publishing at both discovery paths no longer requires cloning the metadata.

File-based configuration. With the config feature, both documents can be provided by the new `[oauth.resource]` and `[oauth.server]` sections of the config file, applied like the other built-in sections (file overrides prior builder calls). A minimal `[oauth.server]` section receives the same OAuth 2.1 prefills as `AuthorizationServerMetadata::new` (`response_types_supported = ["code"]`, `grant_types_supported = ["authorization_code"]`); unknown keys flow into additional_fields, so OIDC-specific fields work from the file too.

## Type
- [ ] Bug fix
- [x] Feature
- [x] Enhancement
- [ ] Performance
- [ ] Documentation
- [ ] Refactor
- [x] Security
- [ ] Breaking change

## Checklist
- [x] I added/updated tests where it makes sense
- [x] I updated docs/examples if needed
- [x] This change is backwards-compatible (or clearly marked as breaking)
- [x] I ran formatting/lints locally (if applicable)

## Notes for reviewers
- Breaking only against `main`, not against any release: the parameterized `use_*` methods this replaces were merged in the previous PR but never shipped (latest tag is 0.9.4, workspace is at 0.9.5), so no released API changes.
- The `with_oauth_server_metadata` closure is seeded with `AuthorizationServerMetadata::new("")` rather than `Default::default()` — otherwise a closure-built document would silently lose the OAuth 2.1 response/grant-type prefills. Covered by a dedicated unit test.
- The `[oauth.server]` file section injects the same prefills when the keys are absent: `response_types_supported` is REQUIRED per RFC 8414 §2, and an absent `grant_types_supported` would make clients assume the implicit grant is supported. Explicit keys in the file are never touched.
- Fields deserialized from the file pick up the RFC 8414 serde defaults (`response_modes_supported = ["query", "fragment"]`, `token_endpoint_auth_methods_supported = ["client_secret_basic"]`), so a file-sourced document serves these explicitly while a builder-built one omits them — semantically identical per spec, called out here to avoid surprise when diffing responses.
- `use_*` panic messages and behavior follow the `use_open_api` precedent; the derived `resource_metadata` URL for `WWW-Authenticate` challenges is still set inside `use_oauth_resource_metadata()`, so only an actually-served document is advertised.
- New `with_issuer` / `with_resource` builder methods exist mainly to make the closure form usable; they're included in the all-methods builder coverage tests.
