### PR TITLE
Send token-endpoint futures; feat: application_type, RFC 9207 iss validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+# 0.9.6
+
+## Added
+* `ClientMetadata::application_type` (`volga-oauth-core`, RFC 7591 / OIDC Dynamic Client Registration §2) with the `with_application_type` builder — first-class instead of an `additional_fields` entry. Desktop and CLI clients register as `"native"`, which is what makes loopback redirect URIs (`http://127.0.0.1:{port}/…`) acceptable to authorization servers.
+* `AuthorizationServerMetadata::authorization_response_iss_parameter_supported` (`volga-oauth-core`, RFC 9207 §3) with the `with_authorization_response_iss_parameter` builder — likewise typed; it is also accepted in the `[oauth.server]` config file section.
+* `AuthorizationRequest::validate_callback` (`volga-oauth-client`) — validates the authorization callback before the code is exchanged: the `state` (CSRF) plus the RFC 9207 `iss`, which must match the issuer whenever present and is required once the server advertises it. Without the `iss` check a callback can be replayed from a different authorization server (mix-up attack); `matches_state` remains for the `state`-only check.
+
+## Fixed
+* `OAuthClient::exchange_code`, `refresh` and `token` returned `!Send` futures: the non-`Sync` form serializer was held across the token-endpoint `await`, so the calls could not be spawned onto a multi-thread runtime (callers had to bridge them through a current-thread runtime). The serializer is now dropped before the request; the futures are `Send`, which a test now pins down.
+
 # 0.9.5
 
 ## Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,7 +127,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -139,7 +139,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -173,7 +173,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -190,9 +190,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -201,14 +201,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -279,9 +280,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cast"
@@ -735,7 +736,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -861,9 +862,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
@@ -878,38 +879,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -1114,9 +1115,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1156,9 +1157,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1395,7 +1396,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1414,7 +1415,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1544,9 +1545,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "middleware"
@@ -1881,7 +1882,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1906,9 +1907,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -1980,9 +1981,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -2426,9 +2427,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -2436,29 +2437,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.2",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -2510,18 +2511,7 @@ checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2693,6 +2683,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2709,7 +2710,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2763,7 +2764,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2852,9 +2853,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -2874,7 +2875,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2889,9 +2890,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+checksum = "17a073bfed563fa236697a068031408a93cd9522e08abf9933ead3e73411bd71"
 dependencies = [
  "futures-util",
  "log",
@@ -3029,7 +3030,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3089,27 +3090,27 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+checksum = "e48ac77174b19c110a50ab2128b24215ac9cb40e0e12e093fb602d175c569d22"
 dependencies = [
  "bytes",
  "data-encoding",
  "http",
  "httparse",
  "log",
- "rand 0.9.4",
- "sha1 0.10.6",
+ "rand 0.10.2",
+ "sha1",
  "thiserror",
 ]
 
 [[package]]
 name = "twox-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
 dependencies = [
- "rand 0.9.4",
+ "rand 0.10.2",
 ]
 
 [[package]]
@@ -3178,9 +3179,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.4"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -3201,7 +3202,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "volga"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "arc-swap",
  "async-compression",
@@ -3227,7 +3228,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sha1 0.11.0",
+ "sha1",
  "smallvec",
  "subtle",
  "tempfile",
@@ -3251,7 +3252,7 @@ dependencies = [
 
 [[package]]
 name = "volga-dev-cert"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "rcgen",
  "serial_test",
@@ -3259,23 +3260,23 @@ dependencies = [
 
 [[package]]
 name = "volga-di"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "http",
 ]
 
 [[package]]
 name = "volga-macros"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.2",
 ]
 
 [[package]]
 name = "volga-oauth-client"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -3295,7 +3296,7 @@ dependencies = [
 
 [[package]]
 name = "volga-oauth-core"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "http",
  "serde",
@@ -3304,7 +3305,7 @@ dependencies = [
 
 [[package]]
 name = "volga-open-api"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "http",
  "mime",
@@ -3315,7 +3316,7 @@ dependencies = [
 
 [[package]]
 name = "volga-rate-limiter"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "dashmap",
 ]
@@ -3405,7 +3406,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -3778,7 +3779,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.118",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3794,7 +3795,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -3889,7 +3890,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -3910,7 +3911,7 @@ checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3930,7 +3931,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -3951,7 +3952,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3984,7 +3985,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.9.5"
+version = "0.9.6"
 license = "MIT"
 edition = "2024"
 rust-version = "1.90.0"
@@ -21,13 +21,13 @@ categories = [
 ]
 
 [workspace.dependencies]
-volga-dev-cert    = { path = "volga-dev-cert",    version = "0.9.5" }
-volga-di          = { path = "volga-di",          version = "0.9.5" }
-volga-macros      = { path = "volga-macros",      version = "0.9.5" }
-volga-oauth-client = { path = "volga-oauth-client", version = "0.9.5", default-features = false }
-volga-oauth-core  = { path = "volga-oauth-core",  version = "0.9.5" }
-volga-open-api    = { path = "volga-open-api",    version = "0.9.5" }
-volga-rate-limiter = { path = "volga-rate-limiter", version = "0.9.5" }
+volga-dev-cert    = { path = "volga-dev-cert",    version = "0.9.6" }
+volga-di          = { path = "volga-di",          version = "0.9.6" }
+volga-macros      = { path = "volga-macros",      version = "0.9.6" }
+volga-oauth-client = { path = "volga-oauth-client", version = "0.9.6", default-features = false }
+volga-oauth-core  = { path = "volga-oauth-core",  version = "0.9.6" }
+volga-open-api    = { path = "volga-open-api",    version = "0.9.6" }
+volga-rate-limiter = { path = "volga-rate-limiter", version = "0.9.6" }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Fast, simple, and high-performance web framework for Rust, built on top of
 Volga is designed to make building HTTP services straightforward and explicit,
 while keeping performance predictable and overhead minimal.
 
-[![latest](https://img.shields.io/badge/latest-0.9.5-blue)](https://crates.io/crates/volga)
+[![latest](https://img.shields.io/badge/latest-0.9.6-blue)](https://crates.io/crates/volga)
 [![latest](https://img.shields.io/badge/rustc-1.90+-964B00)](https://releases.rs/docs/1.90.0/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-violet.svg)](https://github.com/RomanEmreis/volga/blob/main/LICENSE)
 [![Build](https://github.com/RomanEmreis/volga/actions/workflows/rust.yml/badge.svg)](https://github.com/RomanEmreis/volga/actions/workflows/rust.yml)
@@ -47,7 +47,7 @@ Volga is a good fit if you:
 ### Dependencies
 ```toml
 [dependencies]
-volga = "0.9.5"
+volga = "0.9.6"
 tokio = { version = "1", features = ["full"] }
 ```
 ### Simple request handler

--- a/README.md
+++ b/README.md
@@ -75,23 +75,30 @@ More advanced examples (middleware, DI, auth, rate limiting) can be found in the
 [documentation](https://romanemreis.github.io/volga-docs/) and [here](https://github.com/RomanEmreis/volga/tree/main/examples).
 
 ## Performance
-Tested on a single instance with 4 threads and 500 concurrent connections:
+Volga is benchmarked using a minimal plaintext endpoint to measure raw request handling to measure baseline HTTP throughput.
 
+The benchmark harness is available here:
+https://github.com/RomanEmreis/volga-benchmark
+
+### Benchmark environment
+
+Tested on a single machine:
 ```
-OS: Arch Linux
-CPU: Intel i7-8665U (8) @ 4.800GHz
-RAM: 31686MiB
+Platform: Apple Silicon MacBook Pro
+Runtime: Linux containers (Colima)
 ```
+
 ### Results
 ```
-Running 10s test @ http://0.0.0.0:7878/plaintext
-  4 threads and 500 connections
+Running 30s test @ http://volga:7878/plaintext
+  8 threads and 512 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency     1.30ms    1.06ms  16.75ms   84.52%
-    Req/Sec    97.79k    18.43k  133.87k    61.50%
-  3902819 requests in 10.07s, 483.86MB read
-Requests/sec: 387433.91
-Transfer/sec:     48.03MB
+    Latency   539.89us    3.00ms 213.60ms   99.94%
+    Req/Sec   131.04k    14.14k 296.06k    95.76%
+  31080913 requests in 29.83s, 3.76GB read
+  Socket errors: connect 0, read 0, write 0, timeout 987
+Requests/sec: 1,041,952.40
+Transfer/sec: 129.18MB
 ```
 
 > ⚠️ Benchmark results are provided for reference only.

--- a/volga-macros/Cargo.toml
+++ b/volga-macros/Cargo.toml
@@ -17,9 +17,9 @@ keywords = ["volga", "http", "web", "framework"]
 proc-macro = true
 
 [dependencies]
-quote = "1.0.46"
-syn = { version = "2.0.118", features = ["full"] }
-proc-macro2 = "1.0.106"
+quote = "1.0.47"
+syn = { version = "3.0.2", features = ["full"] }
+proc-macro2 = "1.0.107"
 
 [features]
 default = []

--- a/volga-oauth-client/Cargo.toml
+++ b/volga-oauth-client/Cargo.toml
@@ -14,22 +14,22 @@ categories.workspace = true
 keywords = ["volga", "oauth", "oidc", "client", "discovery"]
 
 [dependencies]
-aws-lc-rs = "1.17.0"
+aws-lc-rs = "1.17.3"
 base64 = "0.22.1"
-bytes = "1.12.0"
+bytes = "1.12.1"
 form_urlencoded = "1.2.2"
 http = "1.4.2"
-http-body-util = "0.1.3"
+http-body-util = "0.1.4"
 hyper = { version = "1.10.1", features = ["client"] }
-hyper-rustls = { version = "0.27.7", default-features = false, features = ["tls12", "webpki-tokio", "aws-lc-rs"] }
+hyper-rustls = { version = "0.27.9", default-features = false, features = ["tls12", "webpki-tokio", "aws-lc-rs"] }
 hyper-util = { version = "0.1.20", features = ["client", "client-legacy", "tokio"] }
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.150"
-tokio = { version = "1.52.3", features = ["time"] }
+serde = { version = "1.0.229", features = ["derive"] }
+serde_json = "1.0.151"
+tokio = { version = "1.53.1", features = ["time"] }
 volga-oauth-core = { workspace = true }
 
 [dev-dependencies]
-tokio = { version = "1.52.3", features = ["macros", "net", "rt-multi-thread"] }
+tokio = { version = "1.53.1", features = ["macros", "net", "rt-multi-thread"] }
 volga = { path = "../volga", features = ["http1", "oauth"] }
 
 [features]

--- a/volga-oauth-client/src/client.rs
+++ b/volga-oauth-client/src/client.rs
@@ -217,23 +217,28 @@ impl OAuthClient {
         request: &AuthorizationRequest,
     ) -> Result<TokenSet, ClientError> {
         let endpoint = token_endpoint(metadata)?;
-        let mut form = form_urlencoded::Serializer::new(String::new());
+        // the serializer is not `Sync`: scoping it keeps it out of the
+        // future's state, so this future stays `Send` (see `refresh`)
+        let (body, authorization) = {
+            let mut form = form_urlencoded::Serializer::new(String::new());
 
-        form.append_pair("grant_type", "authorization_code")
-            .append_pair("code", code)
-            .append_pair("code_verifier", request.pkce.verifier());
+            form.append_pair("grant_type", "authorization_code")
+                .append_pair("code", code)
+                .append_pair("code_verifier", request.pkce.verifier());
 
-        if let Some(redirect_uri) = &self.redirect_uri {
-            form.append_pair("redirect_uri", redirect_uri);
-        }
+            if let Some(redirect_uri) = &self.redirect_uri {
+                form.append_pair("redirect_uri", redirect_uri);
+            }
 
-        for resource in &request.resources {
-            form.append_pair("resource", resource);
-        }
+            for resource in &request.resources {
+                form.append_pair("resource", resource);
+            }
 
-        let authorization = self.apply_client_auth(&mut form);
-        self.request_tokens(endpoint, form.finish(), authorization)
-            .await
+            let authorization = self.apply_client_auth(&mut form);
+            (form.finish(), authorization)
+        };
+
+        self.request_tokens(endpoint, body, authorization).await
     }
 
     /// Obtains fresh tokens with a refresh token (RFC 6749 §6)
@@ -247,14 +252,19 @@ impl OAuthClient {
         refresh_token: &str,
     ) -> Result<TokenSet, ClientError> {
         let endpoint = token_endpoint(metadata)?;
-        let mut form = form_urlencoded::Serializer::new(String::new());
+        // scoped so the non-`Sync` serializer is dropped before the await:
+        // a future holding it would be `!Send` and could not be spawned
+        let (body, authorization) = {
+            let mut form = form_urlencoded::Serializer::new(String::new());
 
-        form.append_pair("grant_type", "refresh_token")
-            .append_pair("refresh_token", refresh_token);
+            form.append_pair("grant_type", "refresh_token")
+                .append_pair("refresh_token", refresh_token);
 
-        let authorization = self.apply_client_auth(&mut form);
-        self.request_tokens(endpoint, form.finish(), authorization)
-            .await
+            let authorization = self.apply_client_auth(&mut form);
+            (form.finish(), authorization)
+        };
+
+        self.request_tokens(endpoint, body, authorization).await
     }
 
     /// Returns valid tokens stored under `key`, refreshing a stale access
@@ -519,6 +529,57 @@ impl AuthorizationRequest {
     pub fn matches_state(&self, state: &str) -> bool {
         self.state == state
     }
+
+    /// Validates the parameters of the authorization callback before the
+    /// code is exchanged: the `state` (CSRF) and the RFC 9207 `iss`
+    /// (authorization server mix-up).
+    ///
+    /// `iss` is the callback's `iss` query parameter, `None` when the
+    /// response carried none. It must match the issuer whenever it is
+    /// present, and it is *required* when the metadata advertises
+    /// [`authorization_response_iss_parameter_supported`] — a response
+    /// missing it there may come from a different, possibly malicious,
+    /// authorization server.
+    ///
+    /// ```no_run
+    /// # use volga_oauth_client::{
+    /// #     AuthorizationRequest, AuthorizationServerMetadata, ClientError,
+    /// # };
+    /// # fn check(
+    /// #     request: &AuthorizationRequest,
+    /// #     metadata: &AuthorizationServerMetadata,
+    /// #     state: &str,
+    /// #     iss: Option<&str>,
+    /// # ) -> Result<(), ClientError> {
+    /// request.validate_callback(metadata, state, iss)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// [`authorization_response_iss_parameter_supported`]: AuthorizationServerMetadata::authorization_response_iss_parameter_supported
+    pub fn validate_callback(
+        &self,
+        metadata: &AuthorizationServerMetadata,
+        state: &str,
+        iss: Option<&str>,
+    ) -> Result<(), ClientError> {
+        if !self.matches_state(state) {
+            return Err(ClientError::validation(
+                "authorization response `state` does not match the request",
+            ));
+        }
+
+        match (iss, metadata.authorization_response_iss_parameter_supported) {
+            (Some(iss), _) if iss != metadata.issuer => Err(ClientError::validation(format!(
+                "authorization response `iss` mismatch: expected {}, got {iss}",
+                metadata.issuer
+            ))),
+            (None, true) => Err(ClientError::validation(
+                "authorization server advertises RFC 9207 but the response carries no `iss`",
+            )),
+            _ => Ok(()),
+        }
+    }
 }
 
 /// Builds an RFC 6749 §2.3.1 HTTP Basic authorization header: identifier
@@ -715,6 +776,63 @@ mod tests {
             err,
             ClientError::Validation(reason) if reason.contains("client_secret_jwt")
         ));
+    }
+
+    #[test]
+    fn it_returns_send_token_endpoint_futures() {
+        // the token-endpoint futures must be spawnable onto a multi-thread
+        // runtime: nothing non-`Sync` (the form serializer) may be held
+        // across their awaits
+        fn assert_send(_: impl Send) {}
+
+        let client = OAuthClient::new("my-client")
+            .with_token_store(Arc::new(crate::InMemoryTokenStore::default()));
+        let metadata = metadata();
+        let request = client.authorization_request(&metadata).build().unwrap();
+
+        assert_send(client.exchange_code(&metadata, "the-code", &request));
+        assert_send(client.refresh(&metadata, "the-refresh-token"));
+        assert_send(client.token("alice", &metadata));
+    }
+
+    #[test]
+    fn it_validates_the_authorization_callback() {
+        let client = OAuthClient::new("my-client");
+        let metadata = metadata();
+        let request = client.authorization_request(&metadata).build().unwrap();
+        let state = request.state.clone();
+
+        // no `iss` and no advertisement — nothing more to check
+        assert!(request.validate_callback(&metadata, &state, None).is_ok());
+        assert!(
+            request
+                .validate_callback(&metadata, &state, Some(&metadata.issuer))
+                .is_ok()
+        );
+
+        // CSRF: a foreign `state` never reaches the token endpoint
+        let err = request
+            .validate_callback(&metadata, "forged", None)
+            .unwrap_err();
+        assert!(matches!(err, ClientError::Validation(reason) if reason.contains("state")));
+
+        // mix-up: a present `iss` must match the issuer, advertised or not
+        let err = request
+            .validate_callback(&metadata, &state, Some("https://evil.example.com"))
+            .unwrap_err();
+        assert!(matches!(err, ClientError::Validation(reason) if reason.contains("`iss` mismatch")));
+
+        // ...and it is mandatory once the server advertises RFC 9207
+        let advertised = metadata.with_authorization_response_iss_parameter(true);
+        assert!(
+            request
+                .validate_callback(&advertised, &state, Some(&advertised.issuer))
+                .is_ok()
+        );
+        let err = request
+            .validate_callback(&advertised, &state, None)
+            .unwrap_err();
+        assert!(matches!(err, ClientError::Validation(reason) if reason.contains("RFC 9207")));
     }
 
     #[test]

--- a/volga-oauth-client/src/client.rs
+++ b/volga-oauth-client/src/client.rs
@@ -820,7 +820,9 @@ mod tests {
         let err = request
             .validate_callback(&metadata, &state, Some("https://evil.example.com"))
             .unwrap_err();
-        assert!(matches!(err, ClientError::Validation(reason) if reason.contains("`iss` mismatch")));
+        assert!(
+            matches!(err, ClientError::Validation(reason) if reason.contains("`iss` mismatch"))
+        );
 
         // ...and it is mandatory once the server advertises RFC 9207
         let advertised = metadata.with_authorization_response_iss_parameter(true);

--- a/volga-oauth-core/Cargo.toml
+++ b/volga-oauth-core/Cargo.toml
@@ -15,8 +15,8 @@ keywords = ["volga", "oauth", "oidc", "metadata", "discovery"]
 
 [dependencies]
 http = "1.4.2"
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.150"
+serde = { version = "1.0.229", features = ["derive"] }
+serde_json = "1.0.151"
 
 [features]
 default = []

--- a/volga-oauth-core/src/metadata.rs
+++ b/volga-oauth-core/src/metadata.rs
@@ -136,6 +136,16 @@ pub struct AuthorizationServerMetadata {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub code_challenge_methods_supported: Vec<String>,
 
+    /// Whether the authorization response carries the `iss` parameter
+    /// ([RFC 9207](https://www.rfc-editor.org/rfc/rfc9207) §3)
+    ///
+    /// Defaults to `false` — the RFC 9207 §3 default — and is then omitted
+    /// from the serialized document. When `true`, clients must reject a
+    /// callback that carries no `iss` (see
+    /// `AuthorizationRequest::validate_callback` in `volga-oauth-client`).
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub authorization_response_iss_parameter_supported: bool,
+
     /// Extension and OIDC-specific fields not modeled above
     #[serde(flatten)]
     pub additional_fields: HashMap<String, serde_json::Value>,
@@ -351,6 +361,16 @@ impl AuthorizationServerMetadata {
         self
     }
 
+    /// Advertises that authorization responses carry the `iss` parameter
+    /// (RFC 9207 §3)
+    ///
+    /// Clients then treat a callback without `iss` as an error, which is
+    /// what closes the mix-up attack the parameter exists to prevent.
+    pub fn with_authorization_response_iss_parameter(mut self, supported: bool) -> Self {
+        self.authorization_response_iss_parameter_supported = supported;
+        self
+    }
+
     /// Adds an extension or OIDC-specific field not modeled by the typed fields
     pub fn with_additional_field(
         mut self,
@@ -392,6 +412,13 @@ fn default_grant_types() -> Vec<String> {
 #[inline]
 fn default_client_auth_methods() -> Vec<String> {
     vec!["client_secret_basic".into()]
+}
+
+/// Keeps `false` — the spec default for the boolean metadata fields —
+/// out of the serialized document
+#[inline]
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 /// OAuth 2.0 Protected Resource Metadata per RFC 9728 §2
@@ -667,6 +694,32 @@ mod tests {
                 "grant_types_supported": ["authorization_code"],
                 "code_challenge_methods_supported": ["S256"]
             })
+        );
+    }
+
+    #[test]
+    fn it_round_trips_the_iss_parameter_flag() {
+        let metadata = AuthorizationServerMetadata::new("https://auth.example.com")
+            .with_authorization_response_iss_parameter(true);
+        let json = serde_json::to_value(&metadata).unwrap();
+        assert_eq!(json["authorization_response_iss_parameter_supported"], true);
+
+        let parsed: AuthorizationServerMetadata = serde_json::from_value(json).unwrap();
+        assert!(parsed.authorization_response_iss_parameter_supported);
+        // typed, not swept into the extension bag
+        assert!(
+            !parsed
+                .additional_fields
+                .contains_key("authorization_response_iss_parameter_supported")
+        );
+
+        // the RFC 9207 §3 default is `false`, and stays off the wire
+        let metadata = AuthorizationServerMetadata::new("https://auth.example.com");
+        assert!(!metadata.authorization_response_iss_parameter_supported);
+        let json = serde_json::to_value(&metadata).unwrap();
+        assert!(
+            json.get("authorization_response_iss_parameter_supported")
+                .is_none()
         );
     }
 

--- a/volga-oauth-core/src/registration.rs
+++ b/volga-oauth-core/src/registration.rs
@@ -25,6 +25,17 @@ pub struct ClientMetadata {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub redirect_uris: Vec<String>,
 
+    /// Kind of application the client is: `web` (the default when absent)
+    /// or `native`
+    ///
+    /// Defined by OpenID Connect Dynamic Client Registration §2 and widely
+    /// honored by OAuth 2.0 registration endpoints: a `native` client is
+    /// what allows the loopback redirect URIs (`http://127.0.0.1:{port}/…`)
+    /// desktop and CLI applications rely on — servers reject those for
+    /// `web` clients.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub application_type: Option<String>,
+
     /// Requested token endpoint authentication method
     /// (e.g. `client_secret_basic`, `client_secret_post`, `none`)
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -113,6 +124,13 @@ impl ClientMetadata {
         S: Into<String>,
     {
         self.redirect_uris = uris.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Sets the application type — `web` (the server-side default) or
+    /// `native` for a desktop/CLI client with a loopback redirect URI
+    pub fn with_application_type(mut self, application_type: impl Into<String>) -> Self {
+        self.application_type = Some(application_type.into());
         self
     }
 
@@ -371,16 +389,39 @@ mod tests {
             "redirect_uris": ["https://app.example.com/callback"],
             "client_name": "My App",
             "client_name#ja-JP": "マイアプリ",
-            "application_type": "web"
+            "backchannel_logout_uri": "https://app.example.com/logout"
         });
         let metadata: ClientMetadata = serde_json::from_value(document.clone()).unwrap();
         assert_eq!(
             metadata.additional_fields["client_name#ja-JP"],
             json!("マイアプリ")
         );
-        assert_eq!(metadata.additional_fields["application_type"], json!("web"));
+        assert_eq!(
+            metadata.additional_fields["backchannel_logout_uri"],
+            json!("https://app.example.com/logout")
+        );
         // lossless round-trip
         assert_eq!(serde_json::to_value(&metadata).unwrap(), document);
+    }
+
+    #[test]
+    fn it_round_trips_the_application_type() {
+        let metadata = ClientMetadata::new()
+            .with_redirect_uris(["http://127.0.0.1:8080/callback"])
+            .with_application_type("native");
+        assert_eq!(metadata.application_type.as_deref(), Some("native"));
+
+        let json = serde_json::to_value(&metadata).unwrap();
+        assert_eq!(json["application_type"], json!("native"));
+        // typed, not swept into the extension bag
+        assert!(!metadata.additional_fields.contains_key("application_type"));
+
+        let parsed: ClientMetadata = serde_json::from_value(json).unwrap();
+        assert_eq!(parsed, metadata);
+
+        // absent by default — servers assume `web`
+        let json = serde_json::to_value(ClientMetadata::new()).unwrap();
+        assert!(json.get("application_type").is_none());
     }
 
     #[test]

--- a/volga-open-api/Cargo.toml
+++ b/volga-open-api/Cargo.toml
@@ -16,9 +16,9 @@ keywords = ["volga", "openapi", "documentation", "rest-api"]
 [dependencies]
 http = "1.4.2"
 mime = "0.3.17"
-serde_json = "1.0.150"
+serde_json = "1.0.151"
 serde_urlencoded = "0.7.1"
-serde = { version = "1.0.228", features = ["derive"] }
+serde = { version = "1.0.229", features = ["derive"] }
 
 [features]
 problem-details = []

--- a/volga/Cargo.toml
+++ b/volga/Cargo.toml
@@ -16,18 +16,18 @@ keywords = ["async", "server", "http", "web", "framework"]
 [dependencies]
 # required
 async-stream = "0.3.6"
-bytes = "1.12.0"
-futures-util = { version = "0.3.32", default-features = false, features = ["alloc"] }
-http-body-util = "0.1.3"
+bytes = "1.12.1"
+futures-util = { version = "0.3.33", default-features = false, features = ["alloc"] }
+http-body-util = "0.1.4"
 itoa = "1.0.18"
-memchr = "2.8.2"
+memchr = "2.8.3"
 mime = "0.3.17"
 mime_guess = "2.0.5"
 pin-project-lite = "0.2.17"
-tokio = { version = "1.52.3", features = ["fs", "io-util", "macros", "net", "rt", "rt-multi-thread", "signal", "sync", "time"] }
+tokio = { version = "1.53.1", features = ["fs", "io-util", "macros", "net", "rt", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-util = "0.7.18"
-serde = "1.0.228"
-serde_json = "1.0.150"
+serde = "1.0.229"
+serde_json = "1.0.151"
 serde_urlencoded = "0.7.1"
 smallvec = "1.15.1"
 
@@ -39,7 +39,7 @@ base64 = { version = "0.22.1", optional = true }
 cookie = { version = "0.18.1", features = ["percent-encode"], optional = true }
 jsonwebtoken = { version = "10.4.0", features = ["aws_lc_rs"], optional = true }
 httpdate = { version = "1.0.3", optional = true }
-hyper = { version = "1.10.1", features = ["server"], optional = true }
+hyper = { version = "1.11.0", features = ["server"], optional = true }
 hyper-util = { version = "0.1.20", features = ["server", "server-auto", "server-graceful", "service", "tokio"], optional = true }
 multer = { version = "3.1.0", optional = true }
 rand = { version = "0.10.2", optional = true }
@@ -48,10 +48,10 @@ sha1 = { version = "0.11.0", optional = true }
 subtle = { version = "2.6.1", default-features = false, optional = true }
 tempfile = { version = "3.27.0", optional = true }
 tokio-rustls = { version = "0.26.4", default-features = false, features = ["tls12", "aws-lc-rs"], optional = true }
-tokio-tungstenite = { version = "0.29.0", optional = true }
+tokio-tungstenite = { version = "0.30.0", optional = true }
 tracing = { version = "0.1.44", default-features = false, optional = true }
-twox-hash = { version = "2.1.2", optional = true }
-uuid = { version = "1.23.3", features = ["v4"], optional = true }
+twox-hash = { version = "2.1.3", optional = true }
+uuid = { version = "1.24.0", features = ["v4"], optional = true }
 
 # volga
 volga-dev-cert     = { workspace = true, optional = true }


### PR DESCRIPTION
## Summary
Upstreams three OAuth items found while wiring `volga-oauth-client` into a downstream MCP client (neva), where each one needed a local workaround.

**Fix.** `OAuthClient::exchange_code`, `refresh` and (transitively) `token` returned `!Send` futures: the `form_urlencoded::Serializer` — which holds an `Option<&dyn Fn(..)>` and is therefore not `Sync` — stayed alive across the `.await` on the token endpoint, so the calls could not be spawned onto a multi-thread runtime. The serializer now lives in a scope that ends before the request, so it is dropped rather than captured in the future's state. Assigning `form.finish()` to a local is *not* enough: `form` still gets a `StorageDead` past the await point and lands in the generator.

**Additions.** `ClientMetadata::application_type` (OIDC Dynamic Client Registration §2) and `AuthorizationServerMetadata::authorization_response_iss_parameter_supported` (RFC 9207 §3) become typed fields instead of `additional_fields` entries — the first is what lets desktop/CLI clients register as `native` and keep loopback redirect URIs, the second is what a client needs to know whether `iss` is mandatory. On top of it, `AuthorizationRequest::validate_callback(&metadata, state, iss)` validates the authorization callback before the code is exchanged: `state` for CSRF, plus `iss`, which must match the issuer whenever present and is required once the server advertises support. Without that check a callback can be replayed from a different authorization server (mix-up attack).

## Type
- [x] Bug fix
- [x] Feature
- [ ] Enhancement
- [ ] Performance
- [ ] Documentation
- [ ] Refactor
- [x] Security
- [ ] Breaking change

## Checklist
- [x] I added/updated tests where it makes sense
- [x] I updated docs/examples if needed
- [x] This change is backwards-compatible (or clearly marked as breaking)
- [x] I ran formatting/lints locally (if applicable)

## Notes for reviewers
* `it_returns_send_token_endpoint_futures` is the regression test for the `Send` fix — worth checking it actually bites: reverting either scope makes it fail to compile with `future cannot be sent between threads safely`. It covers `token` too, since that one awaits `refresh`.
* The two new public fields are source-breaking only for exhaustive struct literals / destructuring of `ClientMetadata` and `AuthorizationServerMetadata`. Both derive `Default` and are normally built through the builder DSLs or serde, so nothing in the workspace or the examples needed a change — but it is the one spot where a downstream could notice.
* `authorization_response_iss_parameter_supported` is automatically accepted in the `[oauth.server]` config-file section (it deserializes straight into the metadata type) — intentional, no separate wiring.
* `validate_callback` takes `state` and `iss` as plain arguments rather than a callback-params struct: the crate has no type for a parsed redirect callback, and inventing one would force callers to convert into it. `matches_state` stays for the `state`-only case.
* Deliberately left out: constants or an enum for `application_type` values, mirroring how `token_endpoint_auth_method` is a plain `Option<String>`.
* `cargo clippy --all-targets --all-features -- -D warnings` is clean; `cargo test --all-features` passes across all 48 test binaries.