### PR TITLE
[WIP] Fix fuzz nightly bump & OAuth perfromance improvements

### DIFF
--- a/.github/fuzz-nightly
+++ b/.github/fuzz-nightly
@@ -1,0 +1,15 @@
+# Pinned nightly toolchain for the Fuzz workflow (cargo-fuzz needs nightly for -Z sanitizer).
+#
+# Bump policy: bump deliberately, ~monthly, never float to plain `nightly`.
+# The `bump-fuzz-nightly` workflow opens a PR on the 1st of each month; merge only after
+# its Fuzz run is green. Do NOT regenerate fuzz/Cargo.lock from scratch on a bump -
+# a fresh resolve reintroduces the alloc-no-stdlib 2.0.4/3.0.0 split that breaks brotli;
+# keep the committed lock and just rebuild against it.
+#
+# This pin lives outside .github/workflows/ on purpose: GITHUB_TOKEN has no `workflows`
+# permission scope, so the bump bot cannot push edits to a workflow file. Keeping the
+# value here lets the monthly bump PR be opened with the default token.
+#
+# Format: comments (`#`) and blank lines are ignored; the first remaining line is the
+# toolchain name.
+nightly-2026-07-01

--- a/.github/fuzz-nightly
+++ b/.github/fuzz-nightly
@@ -12,4 +12,4 @@
 #
 # Format: comments (`#`) and blank lines are ignored; the first remaining line is the
 # toolchain name.
-nightly-2026-07-01
+nightly-2026-08-01

--- a/.github/workflows/bump-fuzz-nightly.yml
+++ b/.github/workflows/bump-fuzz-nightly.yml
@@ -6,6 +6,11 @@ name: Bump fuzz nightly
 # regenerated (a fresh resolve reintroduces the alloc-no-stdlib 2.0.4/3.0.0 split that
 # breaks brotli). If the new nightly can't build the locked graph, the job fails and no PR
 # is opened, leaving the current pin in place. Merge the PR only after its Fuzz run is green.
+#
+# The pin is read from and written to .github/fuzz-nightly, NOT fuzz.yml's `env:` block.
+# GITHUB_TOKEN has no `workflows` permission scope (it is not one of the scopes the
+# `permissions:` key accepts), so pushing a branch that touches .github/workflows/* is
+# rejected outright. Keeping the pin in a plain file avoids needing a PAT or App token.
 
 on:
   schedule:
@@ -36,18 +41,23 @@ jobs:
           echo "Latest nightly: $date"
 
       - name: Point pin at the new nightly
+        id: pin
         run: |
-          sed -i -E "s/(RUST_NIGHTLY: )nightly-[0-9-]+/\1nightly-${{ steps.nightly.outputs.date }}/" \
-            .github/workflows/fuzz.yml
-          git diff --exit-code .github/workflows/fuzz.yml && {
+          sed -i -E "s/^nightly-[0-9-]+$/nightly-${{ steps.nightly.outputs.date }}/" \
+            .github/fuzz-nightly
+          if git diff --quiet .github/fuzz-nightly; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
             echo "Pin already at nightly-${{ steps.nightly.outputs.date }}; nothing to do."
-            exit 0
-          } || true
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Install cargo-fuzz
+        if: steps.pin.outputs.changed == 'true'
         run: cargo install cargo-fuzz --locked
 
       - name: Verify the fuzz graph still resolves
+        if: steps.pin.outputs.changed == 'true'
         # NOT --locked: the fuzz crate is a separate workspace, so its Cargo.lock is not
         # auto-updated when a normal PR bumps a dependency version in the main manifests.
         # A strict --locked gate therefore breaks on every such drift (see fuzz.yml). Mirror
@@ -56,10 +66,12 @@ jobs:
         run: cargo +nightly metadata --manifest-path fuzz/Cargo.toml --format-version 1 > /dev/null
 
       - name: Build fuzz targets on the new nightly
+        if: steps.pin.outputs.changed == 'true'
         run: cargo +nightly fuzz build
 
       - name: Open bump PR
-        uses: peter-evans/create-pull-request@v6
+        if: steps.pin.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
         with:
           branch: chore/bump-fuzz-nightly
           commit-message: "chore(ci): bump fuzz nightly to nightly-${{ steps.nightly.outputs.date }}"
@@ -71,4 +83,4 @@ jobs:
             committed `fuzz/Cargo.lock` (lockfile intentionally not regenerated).
 
             Merge only after the Fuzz workflow on this PR is green.
-          add-paths: .github/workflows/fuzz.yml
+          add-paths: .github/fuzz-nightly

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -8,23 +8,40 @@ on:
   workflow_dispatch:
 
 env:
-  # Pinned nightly for reproducible fuzz builds (cargo-fuzz needs nightly for -Z sanitizer).
-  # Bump policy: bump deliberately, ~monthly, never float to `nightly`.
-  # The `bump-fuzz-nightly` workflow opens a PR on the 1st of each month; merge only after
-  # its fuzz build is green. Do NOT regenerate fuzz/Cargo.lock from scratch on a bump -
-  # a fresh resolve reintroduces the alloc-no-stdlib 2.0.4/3.0.0 split that breaks brotli;
-  # keep the committed lock and just rebuild against it.
-  RUST_NIGHTLY: nightly-2026-07-01
   CARGO_TERM_COLOR: always
   ASAN_OPTIONS: quarantine_size_mb=1:malloc_context_size=0
 
 jobs:
+  # The pinned nightly lives in .github/fuzz-nightly rather than in this file's `env:`
+  # block. GITHUB_TOKEN has no `workflows` permission scope, so the bump-fuzz-nightly bot
+  # cannot push an edit to a file under .github/workflows/; keeping the pin in a plain
+  # file lets the monthly bump PR be opened with the default token.
+  pin:
+    runs-on: ubuntu-latest
+    outputs:
+      toolchain: ${{ steps.read.outputs.toolchain }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Read the pinned nightly
+        id: read
+        run: |
+          toolchain="$(grep -vE '^[[:space:]]*(#|$)' .github/fuzz-nightly | head -n1 | tr -d '[:space:]')"
+          if [ -z "$toolchain" ]; then
+            echo "::error::.github/fuzz-nightly contains no toolchain line"
+            exit 1
+          fi
+          echo "toolchain=$toolchain" >> "$GITHUB_OUTPUT"
+          echo "Pinned nightly: $toolchain"
+
   fuzz_build:
     runs-on: ubuntu-latest
+    needs: pin
+    env:
+      RUST_NIGHTLY: ${{ needs.pin.outputs.toolchain }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
-        with: 
+        with:
           toolchain: ${{ env.RUST_NIGHTLY }}
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz --locked
@@ -42,7 +59,9 @@ jobs:
   fuzz_smoke:
     if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    needs: fuzz_build
+    needs: [pin, fuzz_build]
+    env:
+      RUST_NIGHTLY: ${{ needs.pin.outputs.toolchain }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
@@ -58,7 +77,9 @@ jobs:
   fuzz_nightly:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    needs: fuzz_build
+    needs: [pin, fuzz_build]
+    env:
+      RUST_NIGHTLY: ${{ needs.pin.outputs.toolchain }}
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+# Unreleased
+
+## Changed
+* Bearer authentication against an OAuth issuer (feature `oauth-client`) no longer rebuilds per-request state on every authenticated request. The JWKS key is handed out behind an `Arc` instead of copying (and zeroizing) its key material; the validation policy pinned to the resolved key's algorithm is memoized per algorithm instead of cloning the whole `Validation` (three `HashSet`s plus every audience and issuer string) each time; and the `authorize` middleware resolves the `BearerTokenService` once per request rather than twice. Behavior is unchanged.
+* OAuth metadata documents (`use_oauth_resource_metadata`, `use_oauth_server_metadata`, `use_oidc_metadata`) are serialized once when the route is mounted instead of on every request - the documents are immutable, so each response now shares the same buffer.
+
+## Fixed
+* The `bump-fuzz-nightly` workflow could never open its monthly PR: `GITHUB_TOKEN` has no `workflows` permission scope, so pushing a branch that edits `.github/workflows/fuzz.yml` was rejected. The pinned nightly moved to `.github/fuzz-nightly`, which the Fuzz workflow reads at run time.
+
 # 0.9.6
 
 ## Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,9 +144,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+checksum = "3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -220,9 +220,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bit-vec"
@@ -1101,9 +1101,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1688,7 +1688,7 @@ dependencies = [
 name = "oauth_flow"
 version = "0.1.0"
 dependencies = [
- "base64 0.23.0",
+ "base64 0.23.1",
  "jsonwebtoken",
  "serde",
  "serde_json",
@@ -3214,7 +3214,7 @@ dependencies = [
  "arc-swap",
  "async-compression",
  "async-stream",
- "base64 0.23.0",
+ "base64 0.23.1",
  "bytes",
  "cookie",
  "criterion",
@@ -3286,7 +3286,7 @@ name = "volga-oauth-client"
 version = "0.9.6"
 dependencies = [
  "aws-lc-rs",
- "base64 0.23.0",
+ "base64 0.23.1",
  "bytes",
  "form_urlencoded",
  "http",

--- a/volga-di/Cargo.toml
+++ b/volga-di/Cargo.toml
@@ -14,7 +14,7 @@ categories.workspace = true
 keywords = ["volga", "container", "dependency", "injection", "di"]
 
 [dependencies]
-http = "1.4.2"
+http = "1.5.0"
 
 [features]
 default = []

--- a/volga-oauth-client/Cargo.toml
+++ b/volga-oauth-client/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["volga", "oauth", "oidc", "client", "discovery"]
 
 [dependencies]
 aws-lc-rs = "1.17.3"
-base64 = "0.23.0"
+base64 = "0.23.1"
 bytes = "1.12.1"
 form_urlencoded = "1.2.2"
 http = "1.4.2"

--- a/volga-oauth-core/Cargo.toml
+++ b/volga-oauth-core/Cargo.toml
@@ -14,7 +14,7 @@ categories.workspace = true
 keywords = ["volga", "oauth", "oidc", "metadata", "discovery"]
 
 [dependencies]
-http = "1.4.2"
+http = "1.5.0"
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
 

--- a/volga-open-api/Cargo.toml
+++ b/volga-open-api/Cargo.toml
@@ -14,7 +14,7 @@ categories.workspace = true
 keywords = ["volga", "openapi", "documentation", "rest-api"]
 
 [dependencies]
-http = "1.4.2"
+http = "1.5.0"
 mime = "0.3.17"
 serde_json = "1.0.151"
 serde_urlencoded = "0.7.1"

--- a/volga/Cargo.toml
+++ b/volga/Cargo.toml
@@ -34,7 +34,7 @@ smallvec = "1.15.1"
 # optional
 arc-swap = { version = "1.9.2", optional = true }
 toml = { version = "1.1.2",   optional = true }
-async-compression = { version = "0.4.42", features = ["tokio"], optional = true }
+async-compression = { version = "0.4.43", features = ["tokio"], optional = true }
 base64 = { version = "0.23.0", optional = true }
 cookie = { version = "0.18.1", features = ["percent-encode"], optional = true }
 jsonwebtoken = { version = "11.0.0", features = ["aws_lc_rs"], optional = true }
@@ -63,7 +63,7 @@ volga-open-api     = { workspace = true, optional = true }
 volga-rate-limiter = { workspace = true, optional = true }
 
 [dev-dependencies]
-base64 = { version = "0.23.0" }
+base64 = { version = "0.23.1" }
 jsonwebtoken = { version = "11.0.0", features = ["aws_lc_rs"] }
 hyper = { version = "1.10.1", features = ["client"] }
 reqwest = { version = "0.13.4", features = ["rustls-no-provider"] }

--- a/volga/src/auth.rs
+++ b/volga/src/auth.rs
@@ -360,106 +360,103 @@ where
 }
 
 #[cfg(feature = "jwt-auth")]
-fn authorize_impl<C>(
+async fn authorize_impl<C>(
     authorizer: Arc<Authorizer<C>>,
     mut ctx: HttpContext,
     next: NextFn,
-) -> impl Future<Output = HttpResult>
+) -> HttpResult
 where
     C: AuthClaims + Send + Sync + 'static,
 {
-    let authorizer = authorizer.clone();
-    async move {
-        if should_reject_for_https(&ctx)? {
-            return status!(400; [
-                (WWW_AUTHENTICATE, r#"Bearer error="invalid_request", error_description="HTTPS required""#)
-            ]);
-        }
-        let bts: BearerTokenService = ctx.extract()?;
-        let resp = match resolve_bearer(&ctx) {
-            Err(_) => {
-                let mut challenge = oauth::BearerChallenge::new();
-                if let Some(url) = bts.resource_metadata_url.as_deref() {
-                    challenge = challenge.with_resource_metadata(url);
-                }
-                if ctx
-                    .request()
-                    .headers()
-                    .contains_key(crate::headers::AUTHORIZATION)
-                {
-                    // RFC 6750 Section 3.1: credentials were presented but are not
-                    // a well-formed Bearer value (wrong scheme, empty token)
-                    // - the client should fix the header, not start a flow
-                    let challenge = challenge
-                        .with_error(oauth::OAuthErrorCode::InvalidRequest)
-                        .with_description("Authorization header is not a valid Bearer credential");
-
-                    status!(400; [
-                        (WWW_AUTHENTICATE, challenge.to_string())
-                    ])
-                } else {
-                    // RFC 6750 Section 3: no credentials were presented - challenge
-                    // with a bare scheme (no error code) so clients can
-                    // discover the resource metadata and start an
-                    // authorization flow
-                    status!(401; [
-                        (WWW_AUTHENTICATE, challenge.to_string())
-                    ])
-                }
-            }
-            Ok(bearer) => {
-                #[cfg(feature = "oauth-client")]
-                let decoded = bts.decode_async(bearer.clone()).await;
-                #[cfg(not(feature = "oauth-client"))]
-                let decoded = bts.decode(bearer.clone());
-                match decoded {
-                    Ok(claims) if authorizer.validate(&claims) => {
-                        if bts.strip_token_from_request {
-                            stash_bearer(&mut ctx, bearer);
-                            ctx.request_mut()
-                                .headers_mut()
-                                .remove(crate::headers::AUTHORIZATION);
-                        }
-                        ctx.request_mut()
-                            .extensions_mut()
-                            .insert(Authenticated(claims));
-
-                        next(ctx).await
-                    }
-                    Ok(_) => {
-                        let metadata_url = bts.resource_metadata_url.as_deref();
-
-                        status!(403; [
-                            (WWW_AUTHENTICATE, authorizer::default_error_msg(metadata_url))
-                        ])
-                    }
-                    // a server-side failure (unreachable OAuth issuer,
-                    // missing security key) is not the client's token
-                    // being at fault - no invalid_token challenge
-                    Err(err) if err.status().is_server_error() => {
-                        status!(503, "Token validation is temporarily unavailable")
-                    }
-                    Err(err) => {
-                        let metadata_url = bts.resource_metadata_url.as_deref();
-                        let www_authenticate = err
-                            .into_inner()
-                            .downcast_ref::<JwtError>()
-                            .map(|e| build_www_authenticate(e.kind(), metadata_url))
-                            .unwrap_or_else(|| authorizer::default_error_msg(metadata_url));
-
-                        status!(403; [
-                            (WWW_AUTHENTICATE, www_authenticate)
-                        ])
-                    }
-                }
-            }
-        };
-        resp.map(|mut resp| {
-            resp.headers_mut()
-                .insert(CACHE_CONTROL, HeaderValue::from_static(NO_STORE));
-            resp
-        })
+    let bts: BearerTokenService = ctx.extract()?;
+    if should_reject_for_https(&ctx, &bts)? {
+        return status!(400; [
+            (WWW_AUTHENTICATE, r#"Bearer error="invalid_request", error_description="HTTPS required""#)
+        ]);
     }
+    let resp = match resolve_bearer(&ctx) {
+        Err(_) => {
+            let mut challenge = oauth::BearerChallenge::new();
+            if let Some(url) = bts.resource_metadata_url.as_deref() {
+                challenge = challenge.with_resource_metadata(url);
+            }
+            if ctx
+                .request()
+                .headers()
+                .contains_key(crate::headers::AUTHORIZATION)
+            {
+                // RFC 6750 Section 3.1: credentials were presented but are not
+                // a well-formed Bearer value (wrong scheme, empty token)
+                // - the client should fix the header, not start a flow
+                let challenge = challenge
+                    .with_error(oauth::OAuthErrorCode::InvalidRequest)
+                    .with_description("Authorization header is not a valid Bearer credential");
+
+                status!(400; [
+                    (WWW_AUTHENTICATE, challenge.to_string())
+                ])
+            } else {
+                // RFC 6750 Section 3: no credentials were presented - challenge
+                // with a bare scheme (no error code) so clients can
+                // discover the resource metadata and start an
+                // authorization flow
+                status!(401; [
+                    (WWW_AUTHENTICATE, challenge.to_string())
+                ])
+            }
+        }
+        Ok(bearer) => {
+            #[cfg(feature = "oauth-client")]
+            let decoded = bts.decode_async(bearer.clone()).await;
+            #[cfg(not(feature = "oauth-client"))]
+            let decoded = bts.decode(bearer.clone());
+            match decoded {
+                Ok(claims) if authorizer.validate(&claims) => {
+                    if bts.strip_token_from_request {
+                        stash_bearer(&mut ctx, bearer);
+                        ctx.request_mut()
+                            .headers_mut()
+                            .remove(crate::headers::AUTHORIZATION);
+                    }
+                    ctx.request_mut()
+                        .extensions_mut()
+                        .insert(Authenticated(claims));
+
+                    next(ctx).await
+                }
+                Ok(_) => {
+                    let metadata_url = bts.resource_metadata_url.as_deref();
+
+                    status!(403; [
+                        (WWW_AUTHENTICATE, authorizer::default_error_msg(metadata_url))
+                    ])
+                }
+                // a server-side failure (unreachable OAuth issuer,
+                // missing security key) is not the client's token
+                // being at fault - no invalid_token challenge
+                Err(err) if err.status().is_server_error() => {
+                    status!(503, "Token validation is temporarily unavailable")
+                }
+                Err(err) => {
+                    let metadata_url = bts.resource_metadata_url.as_deref();
+                    let www_authenticate = err
+                        .into_inner()
+                        .downcast_ref::<JwtError>()
+                        .map(|e| build_www_authenticate(e.kind(), metadata_url))
+                        .unwrap_or_else(|| authorizer::default_error_msg(metadata_url));
+
+                    status!(403; [
+                        (WWW_AUTHENTICATE, www_authenticate)
+                    ])
+                }
+            }
+        }
+    };
+    resp.map(|mut resp| {
+        resp.headers_mut()
+            .insert(CACHE_CONTROL, HeaderValue::from_static(NO_STORE));
+        resp
+    })
 }
 
 /// Returns the bearer token for this request, preferring the value stashed
@@ -498,8 +495,7 @@ fn stash_bearer(ctx: &mut HttpContext, bearer: Bearer) {
 /// `require_https` is enabled, the server isn't accepting TLS, and the
 /// peer is not a loopback address.
 #[cfg(feature = "jwt-auth")]
-fn should_reject_for_https(ctx: &HttpContext) -> Result<bool, Error> {
-    let bts: BearerTokenService = ctx.extract()?;
+fn should_reject_for_https(ctx: &HttpContext, bts: &BearerTokenService) -> Result<bool, Error> {
     if !bts.require_https || bts.tls_enabled {
         return Ok(false);
     }

--- a/volga/src/auth/bearer.rs
+++ b/volga/src/auth/bearer.rs
@@ -15,6 +15,8 @@ use futures_util::future::{Ready, ready};
 use hyper::http::request::Parts;
 use jsonwebtoken::{Header as JwtHeader, Validation};
 use serde::{Serialize, de::DeserializeOwned};
+#[cfg(feature = "oauth-client")]
+use std::{collections::HashMap, sync::RwLock};
 use std::{
     collections::HashSet,
     fmt::{Display, Formatter},
@@ -382,6 +384,10 @@ pub struct BearerTokenService {
     decoding: Option<Arc<DecodingKey>>,
     #[cfg(feature = "oauth-client")]
     jwks: Option<Arc<crate::auth::oauth_client::JwksStore>>,
+    /// Memoized copies of `validation` pinned to a single algorithm, keyed
+    /// by it. See [`validation_for`](Self::validation_for).
+    #[cfg(feature = "oauth-client")]
+    validation_by_alg: Arc<RwLock<HashMap<jsonwebtoken::Algorithm, Arc<Validation>>>>,
     pub(crate) strip_token_from_request: bool,
     pub(crate) resource_metadata_url: Option<Arc<str>>,
     pub(crate) require_https: bool,
@@ -434,6 +440,8 @@ impl BearerTokenService {
             decoding: cfg.decoding.map(Arc::new),
             #[cfg(feature = "oauth-client")]
             jwks: None,
+            #[cfg(feature = "oauth-client")]
+            validation_by_alg: Arc::new(RwLock::new(HashMap::new())),
             strip_token_from_request: cfg.strip_token_from_request,
             resource_metadata_url: cfg
                 .resource_metadata_url
@@ -511,12 +519,46 @@ impl BearerTokenService {
 
         // pin the algorithm to the resolved key: a token must not talk the
         // key into a different scheme than the JWKS advertises for it
-        let mut validation = (*self.validation).clone();
-        validation.algorithms = vec![entry.alg];
+        let validation = self.validation_for(entry.alg);
 
         jsonwebtoken::decode(&*bearer.0, &entry.key, &validation)
             .map_err(Error::from_jwt_error)
             .map(|t| t.claims)
+    }
+
+    /// Returns the configured validation policy pinned to `alg`, building it
+    /// on first use and memoizing it afterwards.
+    ///
+    /// The pinned policy differs from the configured one only in
+    /// `algorithms`, but building it means cloning a [`Validation`] - three
+    /// `HashSet`s plus every audience and issuer string in them. A JWKS
+    /// advertises a handful of algorithms at most, so the cache is filled
+    /// within the first few requests and stays that size; every later
+    /// request just clones an [`Arc`].
+    #[cfg(feature = "oauth-client")]
+    fn validation_for(&self, alg: jsonwebtoken::Algorithm) -> Arc<Validation> {
+        let cached = self
+            .validation_by_alg
+            .read()
+            .expect("validation cache lock poisoned")
+            .get(&alg)
+            .cloned();
+        if let Some(validation) = cached {
+            return validation;
+        }
+
+        let mut validation = (*self.validation).clone();
+        validation.algorithms = vec![alg];
+        let validation = Arc::new(validation);
+
+        // a concurrent builder for the same alg produces an equal value, so
+        // whichever insert lands last is fine
+        self.validation_by_alg
+            .write()
+            .expect("validation cache lock poisoned")
+            .insert(alg, Arc::clone(&validation));
+
+        validation
     }
 }
 
@@ -805,6 +847,53 @@ mod tests {
 
         assert!(service.encoding_key().is_some());
         assert!(service.decoding_key().is_some());
+    }
+
+    #[cfg(feature = "oauth-client")]
+    #[test]
+    fn it_pins_the_algorithm_and_memoizes_the_validation() {
+        let service: BearerTokenService = BearerAuthConfig::default()
+            .with_aud(["https://api.example.com"])
+            .with_iss(["https://auth.example.com"])
+            .into();
+
+        let rs256 = service.validation_for(jsonwebtoken::Algorithm::RS256);
+        // only `algorithms` is pinned - the rest of the policy carries over
+        assert_eq!(rs256.algorithms, vec![jsonwebtoken::Algorithm::RS256]);
+        assert!(
+            rs256
+                .aud
+                .as_ref()
+                .unwrap()
+                .contains("https://api.example.com")
+        );
+        assert!(
+            rs256
+                .iss
+                .as_ref()
+                .unwrap()
+                .contains("https://auth.example.com")
+        );
+        assert!(rs256.required_spec_claims.contains("aud"));
+
+        // a second lookup for the same alg reuses the cached value instead
+        // of cloning the policy again
+        assert!(Arc::ptr_eq(
+            &rs256,
+            &service.validation_for(jsonwebtoken::Algorithm::RS256)
+        ));
+
+        let es256 = service.validation_for(jsonwebtoken::Algorithm::ES256);
+        assert_eq!(es256.algorithms, vec![jsonwebtoken::Algorithm::ES256]);
+        assert!(!Arc::ptr_eq(&rs256, &es256));
+
+        // clones share the cache - the service is cloned per request
+        assert!(Arc::ptr_eq(
+            &rs256,
+            &service
+                .clone()
+                .validation_for(jsonwebtoken::Algorithm::RS256)
+        ));
     }
 
     #[tokio::test]

--- a/volga/src/auth/oauth/handlers.rs
+++ b/volga/src/auth/oauth/handlers.rs
@@ -15,8 +15,8 @@
 //! `[oauth.resource]` and `[oauth.server]` sections of the configuration
 //! file; the file overrides prior builder calls.
 
+use bytes::Bytes;
 use serde::Serialize;
-use std::sync::Arc;
 
 use crate::{
     App,
@@ -316,16 +316,29 @@ fn well_known_route(metadata_url: &str) -> &str {
 
 /// Mounts a `GET` route serving the document as JSON; metadata documents
 /// are immutable, so responses carry a public one-hour cache policy.
+///
+/// The document is serialized once at mount time rather than on every
+/// request: it cannot change afterwards, and `Bytes` hands each response a
+/// refcounted view of the same buffer.
 fn serve_metadata<T>(app: &mut App, path: &str, metadata: T)
 where
     T: Serialize + Send + Sync + 'static,
 {
     let cache_control = metadata_cache_control();
-    let metadata = Arc::new(metadata);
+    let body = Bytes::from(
+        serde_json::to_vec(&metadata).expect("OAuth metadata document is serializable"),
+    );
+
     app.map_get(path, move || {
-        let metadata = Arc::clone(&metadata);
+        let body = body.clone();
         let cache_control = cache_control.clone();
-        async move { crate::ok!(metadata.as_ref(); [cache_control]) }
+        async move {
+            crate::response!(
+                crate::http::StatusCode::OK,
+                crate::HttpBody::full(body);
+                [crate::headers::ContentType::json(), cache_control]
+            )
+        }
     });
 }
 

--- a/volga/src/auth/oauth_client.rs
+++ b/volga/src/auth/oauth_client.rs
@@ -193,9 +193,15 @@ impl OAuthConfig {
 }
 
 /// A verification key resolved from the issuer's JWKS
+///
+/// The key is behind an [`Arc`]: `lookup` hands out a clone on every
+/// authenticated request, and `jsonwebtoken::DecodingKey` owns its key
+/// material in `Vec<u8>`s that are additionally zeroized on drop - copying
+/// and wiping them per request is pure overhead for a value that never
+/// changes between JWKS refreshes.
 #[derive(Clone)]
 pub(crate) struct KeyEntry {
-    pub(crate) key: jsonwebtoken::DecodingKey,
+    pub(crate) key: Arc<jsonwebtoken::DecodingKey>,
     pub(crate) alg: Algorithm,
 }
 
@@ -277,7 +283,7 @@ fn entry_from_jwk(jwk: &Jwk) -> Option<KeyEntry> {
         Some(alg) => signing_algorithm(alg)?,
         None => default_alg(&jwk.algorithm)?,
     };
-    let key = jsonwebtoken::DecodingKey::from_jwk(jwk).ok()?;
+    let key = Arc::new(jsonwebtoken::DecodingKey::from_jwk(jwk).ok()?);
     Some(KeyEntry { key, alg })
 }
 


### PR DESCRIPTION
## Summary

**CI.** The monthly `bump-fuzz-nightly` job could never open its PR: `GITHUB_TOKEN` has no `workflows` permission scope, so pushing a branch that edits `.github/workflows/fuzz.yml` is rejected outright. The pinned nightly moved to `.github/fuzz-nightly`; `fuzz.yml` reads it in a `pin` job and passes it to the other jobs via `needs.outputs`. Also bumps the pin to `nightly-2026-08-01` and `peter-evans/create-pull-request` to v7.

**Performance.** The per-request bearer path against an OAuth issuer rebuilt state on every authenticated request: the JWKS `DecodingKey` was cloned (copying and later zeroizing its key material), and the whole `Validation` was cloned just to pin `algorithms` to the resolved key - three `HashSet`s plus every audience and issuer string. The key is now behind an `Arc` and the pinned policy is memoized per algorithm. `authorize` also resolved `BearerTokenService` twice per
request; now once. OAuth metadata documents are serialized at mount time rather than per request. No API or behavior changes.

**Dependencies.** `http` 1.4.2 -> 1.5.0, `base64` 0.23.0 -> 0.23.1, `async-compression` 0.4.42 -> 0.4.43.

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Enhancement
- [x] Performance
- [ ] Documentation
- [ ] Refactor
- [ ] Security
- [ ] Breaking change

## Checklist
- [x] I added/updated tests where it makes sense
- [x] I updated docs/examples if needed
- [x] This change is backwards-compatible (or clearly marked as breaking)
- [x] I ran formatting/lints locally (if applicable)